### PR TITLE
feat: enhance firewall rule modal with additional source/destination

### DIFF
--- a/backend/vyos_builders/firewall/ipv4.py
+++ b/backend/vyos_builders/firewall/ipv4.py
@@ -229,6 +229,16 @@ class FirewallIPv4BatchBuilder:
         path = self.mappers[self.mapper_key].get_rule_source_geoip_inverse_path(chain, rule_number, is_custom)
         return self.add_delete(path)
 
+    def delete_rule_source_geoip(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv4BatchBuilder":
+        """Delete the entire source GeoIP node (used when removing the last country)."""
+        path = self.mappers[self.mapper_key].get_rule_source_geoip_path(chain, rule_number, is_custom)
+        return self.add_delete(path)
+
+    def delete_rule_source(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv4BatchBuilder":
+        """Delete the entire source node (used when switching to 'any')."""
+        path = self.mappers[self.mapper_key].get_rule_source_path(chain, rule_number, is_custom)
+        return self.add_delete(path)
+
     def set_rule_source_group_address(self, chain: str, rule_number: int, group_name: str, is_custom: bool = False) -> "FirewallIPv4BatchBuilder":
         """Set source address group."""
         path = self.mappers[self.mapper_key].get_rule_source_group_address(chain, rule_number, group_name, is_custom)
@@ -331,6 +341,16 @@ class FirewallIPv4BatchBuilder:
     def delete_rule_destination_geoip_inverse(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv4BatchBuilder":
         """Delete destination GeoIP inverse match."""
         path = self.mappers[self.mapper_key].get_rule_destination_geoip_inverse_path(chain, rule_number, is_custom)
+        return self.add_delete(path)
+
+    def delete_rule_destination_geoip(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv4BatchBuilder":
+        """Delete the entire destination GeoIP node (used when removing the last country)."""
+        path = self.mappers[self.mapper_key].get_rule_destination_geoip_path(chain, rule_number, is_custom)
+        return self.add_delete(path)
+
+    def delete_rule_destination(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv4BatchBuilder":
+        """Delete the entire destination node (used when switching to 'any')."""
+        path = self.mappers[self.mapper_key].get_rule_destination_path(chain, rule_number, is_custom)
         return self.add_delete(path)
 
     def set_rule_destination_group_address(self, chain: str, rule_number: int, group_name: str, is_custom: bool = False) -> "FirewallIPv4BatchBuilder":

--- a/backend/vyos_builders/firewall/ipv6.py
+++ b/backend/vyos_builders/firewall/ipv6.py
@@ -229,6 +229,16 @@ class FirewallIPv6BatchBuilder:
         path = self.mappers[self.mapper_key].get_rule_source_geoip_inverse_path(chain, rule_number, is_custom)
         return self.add_delete(path)
 
+    def delete_rule_source_geoip(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv6BatchBuilder":
+        """Delete the entire source GeoIP node (used when removing the last country)."""
+        path = self.mappers[self.mapper_key].get_rule_source_geoip_path(chain, rule_number, is_custom)
+        return self.add_delete(path)
+
+    def delete_rule_source(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv6BatchBuilder":
+        """Delete the entire source node (used when switching to 'any')."""
+        path = self.mappers[self.mapper_key].get_rule_source_path(chain, rule_number, is_custom)
+        return self.add_delete(path)
+
     def set_rule_source_group_address(self, chain: str, rule_number: int, group_name: str, is_custom: bool = False) -> "FirewallIPv6BatchBuilder":
         """Set source address group."""
         path = self.mappers[self.mapper_key].get_rule_source_group_address(chain, rule_number, group_name, is_custom)
@@ -311,6 +321,16 @@ class FirewallIPv6BatchBuilder:
     def delete_rule_destination_geoip_inverse(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv6BatchBuilder":
         """Delete destination GeoIP inverse match."""
         path = self.mappers[self.mapper_key].get_rule_destination_geoip_inverse_path(chain, rule_number, is_custom)
+        return self.add_delete(path)
+
+    def delete_rule_destination_geoip(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv6BatchBuilder":
+        """Delete the entire destination GeoIP node (used when removing the last country)."""
+        path = self.mappers[self.mapper_key].get_rule_destination_geoip_path(chain, rule_number, is_custom)
+        return self.add_delete(path)
+
+    def delete_rule_destination(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv6BatchBuilder":
+        """Delete the entire destination node (used when switching to 'any')."""
+        path = self.mappers[self.mapper_key].get_rule_destination_path(chain, rule_number, is_custom)
         return self.add_delete(path)
 
     def set_rule_destination_group_address(self, chain: str, rule_number: int, group_name: str, is_custom: bool = False) -> "FirewallIPv6BatchBuilder":

--- a/backend/vyos_mappers/firewall/ipv4.py
+++ b/backend/vyos_mappers/firewall/ipv4.py
@@ -200,6 +200,18 @@ class FirewallIPv4Mapper(BaseFeatureMapper):
             return ["firewall", "ipv4", "name", chain, "rule", str(rule_number), "source", "geoip", "inverse-match"]
         return ["firewall", "ipv4", chain, "filter", "rule", str(rule_number), "source", "geoip", "inverse-match"]
 
+    def get_rule_source_geoip_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
+        """Get command path for source GeoIP node (for deletion of entire geoip section)."""
+        if is_custom:
+            return ["firewall", "ipv4", "name", chain, "rule", str(rule_number), "source", "geoip"]
+        return ["firewall", "ipv4", chain, "filter", "rule", str(rule_number), "source", "geoip"]
+
+    def get_rule_source_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
+        """Get command path for entire source node (for deletion when switching to 'any')."""
+        if is_custom:
+            return ["firewall", "ipv4", "name", chain, "rule", str(rule_number), "source"]
+        return ["firewall", "ipv4", chain, "filter", "rule", str(rule_number), "source"]
+
     def get_rule_source_group_address(self, chain: str, rule_number: int, group_name: str, is_custom: bool = False) -> List[str]:
         """Get command path for setting source address group."""
         if is_custom:
@@ -323,6 +335,18 @@ class FirewallIPv4Mapper(BaseFeatureMapper):
         if is_custom:
             return ["firewall", "ipv4", "name", chain, "rule", str(rule_number), "destination", "geoip", "inverse-match"]
         return ["firewall", "ipv4", chain, "filter", "rule", str(rule_number), "destination", "geoip", "inverse-match"]
+
+    def get_rule_destination_geoip_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
+        """Get command path for destination GeoIP node (for deletion of entire geoip section)."""
+        if is_custom:
+            return ["firewall", "ipv4", "name", chain, "rule", str(rule_number), "destination", "geoip"]
+        return ["firewall", "ipv4", chain, "filter", "rule", str(rule_number), "destination", "geoip"]
+
+    def get_rule_destination_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
+        """Get command path for entire destination node (for deletion when switching to 'any')."""
+        if is_custom:
+            return ["firewall", "ipv4", "name", chain, "rule", str(rule_number), "destination"]
+        return ["firewall", "ipv4", chain, "filter", "rule", str(rule_number), "destination"]
 
     def get_rule_destination_group_address(self, chain: str, rule_number: int, group_name: str, is_custom: bool = False) -> List[str]:
         """Get command path for setting destination address group."""

--- a/backend/vyos_mappers/firewall/ipv6.py
+++ b/backend/vyos_mappers/firewall/ipv6.py
@@ -200,6 +200,18 @@ class FirewallIPv6Mapper(BaseFeatureMapper):
             return ["firewall", "ipv6", "name", chain, "rule", str(rule_number), "source", "geoip", "inverse-match"]
         return ["firewall", "ipv6", chain, "filter", "rule", str(rule_number), "source", "geoip", "inverse-match"]
 
+    def get_rule_source_geoip_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
+        """Get command path for source GeoIP node (for deletion of entire geoip section)."""
+        if is_custom:
+            return ["firewall", "ipv6", "name", chain, "rule", str(rule_number), "source", "geoip"]
+        return ["firewall", "ipv6", chain, "filter", "rule", str(rule_number), "source", "geoip"]
+
+    def get_rule_source_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
+        """Get command path for entire source node (for deletion when switching to 'any')."""
+        if is_custom:
+            return ["firewall", "ipv6", "name", chain, "rule", str(rule_number), "source"]
+        return ["firewall", "ipv6", chain, "filter", "rule", str(rule_number), "source"]
+
     def get_rule_source_group_address(self, chain: str, rule_number: int, group_name: str, is_custom: bool = False) -> List[str]:
         """Get command path for setting source address group."""
         if is_custom:
@@ -299,6 +311,18 @@ class FirewallIPv6Mapper(BaseFeatureMapper):
         if is_custom:
             return ["firewall", "ipv6", "name", chain, "rule", str(rule_number), "destination", "geoip", "inverse-match"]
         return ["firewall", "ipv6", chain, "filter", "rule", str(rule_number), "destination", "geoip", "inverse-match"]
+
+    def get_rule_destination_geoip_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
+        """Get command path for destination GeoIP node (for deletion of entire geoip section)."""
+        if is_custom:
+            return ["firewall", "ipv6", "name", chain, "rule", str(rule_number), "destination", "geoip"]
+        return ["firewall", "ipv6", chain, "filter", "rule", str(rule_number), "destination", "geoip"]
+
+    def get_rule_destination_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
+        """Get command path for entire destination node (for deletion when switching to 'any')."""
+        if is_custom:
+            return ["firewall", "ipv6", "name", chain, "rule", str(rule_number), "destination"]
+        return ["firewall", "ipv6", chain, "filter", "rule", str(rule_number), "destination"]
 
     def get_rule_destination_group_address(self, chain: str, rule_number: int, group_name: str, is_custom: bool = False) -> List[str]:
         """Get command path for setting destination address group."""

--- a/frontend/prisma/migrations/20251127213255_init/migration.sql
+++ b/frontend/prisma/migrations/20251127213255_init/migration.sql
@@ -1,0 +1,118 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('SUPER_ADMIN', 'ADMIN', 'NETWORK_ADMIN', 'OPERATOR', 'VIEWER');
+
+-- CreateEnum
+CREATE TYPE "Action" AS ENUM ('READ', 'CREATE', 'UPDATE', 'DELETE', 'MANAGE');
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL,
+    "name" TEXT,
+    "email" TEXT NOT NULL,
+    "emailVerified" BOOLEAN NOT NULL DEFAULT false,
+    "image" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "role" "Role" NOT NULL DEFAULT 'VIEWER',
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sessions" (
+    "id" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "token" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "accounts" (
+    "id" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "providerId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "accessToken" TEXT,
+    "refreshToken" TEXT,
+    "idToken" TEXT,
+    "accessTokenExpiresAt" TIMESTAMP(3),
+    "refreshTokenExpiresAt" TIMESTAMP(3),
+    "scope" TEXT,
+    "password" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "verifications" (
+    "id" TEXT NOT NULL,
+    "identifier" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "verifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "role_permissions" (
+    "id" TEXT NOT NULL,
+    "role" "Role" NOT NULL,
+    "resource" TEXT NOT NULL,
+    "action" "Action" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "role_permissions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "audit_logs" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "userEmail" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "resource" TEXT NOT NULL,
+    "details" JSONB,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sessions_token_key" ON "sessions"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "accounts_providerId_accountId_key" ON "accounts"("providerId", "accountId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "verifications_identifier_value_key" ON "verifications"("identifier", "value");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "role_permissions_role_resource_action_key" ON "role_permissions"("role", "resource", "action");
+
+-- CreateIndex
+CREATE INDEX "audit_logs_userId_idx" ON "audit_logs"("userId");
+
+-- CreateIndex
+CREATE INDEX "audit_logs_createdAt_idx" ON "audit_logs"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/frontend/src/lib/api/firewall-ipv4.ts
+++ b/frontend/src/lib/api/firewall-ipv4.ts
@@ -454,42 +454,46 @@ class FirewallIPv4Service {
 
     // Update source (simplified - delete old, set new if changed)
     if (hasChanged(config.source, currentRule.source)) {
-      // Delete old source settings
-      if (currentRule.source?.address) {
-        operations.push({ op: "delete_rule_source_address" });
-      }
-      if (currentRule.source?.port) {
-        operations.push({ op: "delete_rule_source_port" });
-      }
-      if (currentRule.source?.mac_address) {
-        operations.push({ op: "delete_rule_source_mac_address" });
-      }
-      if (currentRule.source?.geoip) {
-        if (currentRule.source.geoip.country_code) {
-          operations.push({ op: "delete_rule_source_geoip_country" });
+      // Check if we're clearing to "any" (empty object)
+      const isAny = config.source && Object.keys(config.source).length === 0;
+
+      if (isAny) {
+        // When switching to "any", delete the entire source node
+        operations.push({ op: "delete_rule_source" });
+      } else {
+        // Delete old source settings individually
+        if (currentRule.source?.address) {
+          operations.push({ op: "delete_rule_source_address" });
         }
-        if (currentRule.source.geoip.inverse_match) {
-          operations.push({ op: "delete_rule_source_geoip_inverse" });
+        if (currentRule.source?.port) {
+          operations.push({ op: "delete_rule_source_port" });
         }
-      }
-      if (currentRule.source?.group) {
-        // Delete ALL existing groups (address, network, port, etc.)
-        for (const [groupType] of Object.entries(currentRule.source.group)) {
-          if (groupType.includes("address")) {
-            operations.push({ op: "delete_rule_source_group_address" });
-          } else if (groupType.includes("network")) {
-            operations.push({ op: "delete_rule_source_group_network" });
-          } else if (groupType.includes("port")) {
-            operations.push({ op: "delete_rule_source_group_port" });
-          } else if (groupType.includes("mac")) {
-            operations.push({ op: "delete_rule_source_group_mac" });
-          } else if (groupType.includes("domain")) {
-            operations.push({ op: "delete_rule_source_group_domain" });
+        if (currentRule.source?.mac_address) {
+          operations.push({ op: "delete_rule_source_mac_address" });
+        }
+        if (currentRule.source?.geoip) {
+          // When removing all GeoIP settings, delete the entire geoip node
+          operations.push({ op: "delete_rule_source_geoip" });
+        }
+        if (currentRule.source?.group) {
+          // Delete ALL existing groups (address, network, port, etc.)
+          for (const [groupType] of Object.entries(currentRule.source.group)) {
+            if (groupType.includes("address")) {
+              operations.push({ op: "delete_rule_source_group_address" });
+            } else if (groupType.includes("network")) {
+              operations.push({ op: "delete_rule_source_group_network" });
+            } else if (groupType.includes("port")) {
+              operations.push({ op: "delete_rule_source_group_port" });
+            } else if (groupType.includes("mac")) {
+              operations.push({ op: "delete_rule_source_group_mac" });
+            } else if (groupType.includes("domain")) {
+              operations.push({ op: "delete_rule_source_group_domain" });
+            }
           }
         }
       }
 
-      // Set new source settings
+      // Set new source settings (only if not "any")
       if (config.source) {
         if (config.source.address) {
           operations.push({ op: "set_rule_source_address", value: config.source.address });
@@ -532,39 +536,43 @@ class FirewallIPv4Service {
 
     // Update destination (similar to source)
     if (hasChanged(config.destination, currentRule.destination)) {
-      // Delete old destination settings
-      if (currentRule.destination?.address) {
-        operations.push({ op: "delete_rule_destination_address" });
-      }
-      if (currentRule.destination?.port) {
-        operations.push({ op: "delete_rule_destination_port" });
-      }
-      if (currentRule.destination?.geoip) {
-        if (currentRule.destination.geoip.country_code) {
-          operations.push({ op: "delete_rule_destination_geoip_country" });
+      // Check if we're clearing to "any" (empty object)
+      const isAny = config.destination && Object.keys(config.destination).length === 0;
+
+      if (isAny) {
+        // When switching to "any", delete the entire destination node
+        operations.push({ op: "delete_rule_destination" });
+      } else {
+        // Delete old destination settings individually
+        if (currentRule.destination?.address) {
+          operations.push({ op: "delete_rule_destination_address" });
         }
-        if (currentRule.destination.geoip.inverse_match) {
-          operations.push({ op: "delete_rule_destination_geoip_inverse" });
+        if (currentRule.destination?.port) {
+          operations.push({ op: "delete_rule_destination_port" });
         }
-      }
-      if (currentRule.destination?.group) {
-        // Delete ALL existing groups (address, network, port, etc.)
-        for (const [groupType] of Object.entries(currentRule.destination.group)) {
-          if (groupType.includes("address")) {
-            operations.push({ op: "delete_rule_destination_group_address" });
-          } else if (groupType.includes("network")) {
-            operations.push({ op: "delete_rule_destination_group_network" });
-          } else if (groupType.includes("port")) {
-            operations.push({ op: "delete_rule_destination_group_port" });
-          } else if (groupType.includes("mac")) {
-            operations.push({ op: "delete_rule_destination_group_mac" });
-          } else if (groupType.includes("domain")) {
-            operations.push({ op: "delete_rule_destination_group_domain" });
+        if (currentRule.destination?.geoip) {
+          // When removing all GeoIP settings, delete the entire geoip node
+          operations.push({ op: "delete_rule_destination_geoip" });
+        }
+        if (currentRule.destination?.group) {
+          // Delete ALL existing groups (address, network, port, etc.)
+          for (const [groupType] of Object.entries(currentRule.destination.group)) {
+            if (groupType.includes("address")) {
+              operations.push({ op: "delete_rule_destination_group_address" });
+            } else if (groupType.includes("network")) {
+              operations.push({ op: "delete_rule_destination_group_network" });
+            } else if (groupType.includes("port")) {
+              operations.push({ op: "delete_rule_destination_group_port" });
+            } else if (groupType.includes("mac")) {
+              operations.push({ op: "delete_rule_destination_group_mac" });
+            } else if (groupType.includes("domain")) {
+              operations.push({ op: "delete_rule_destination_group_domain" });
+            }
           }
         }
       }
 
-      // Set new destination settings
+      // Set new destination settings (only if not "any")
       if (config.destination) {
         if (config.destination.address) {
           operations.push({ op: "set_rule_destination_address", value: config.destination.address });

--- a/frontend/src/lib/api/firewall-ipv6.ts
+++ b/frontend/src/lib/api/firewall-ipv6.ts
@@ -454,42 +454,46 @@ class FirewallIPv6Service {
 
     // Update source (simplified - delete old, set new if changed)
     if (hasChanged(config.source, currentRule.source)) {
-      // Delete old source settings
-      if (currentRule.source?.address) {
-        operations.push({ op: "delete_rule_source_address" });
-      }
-      if (currentRule.source?.port) {
-        operations.push({ op: "delete_rule_source_port" });
-      }
-      if (currentRule.source?.mac_address) {
-        operations.push({ op: "delete_rule_source_mac_address" });
-      }
-      if (currentRule.source?.geoip) {
-        if (currentRule.source.geoip.country_code) {
-          operations.push({ op: "delete_rule_source_geoip_country" });
+      // Check if we're clearing to "any" (empty object)
+      const isAny = config.source && Object.keys(config.source).length === 0;
+
+      if (isAny) {
+        // When switching to "any", delete the entire source node
+        operations.push({ op: "delete_rule_source" });
+      } else {
+        // Delete old source settings individually
+        if (currentRule.source?.address) {
+          operations.push({ op: "delete_rule_source_address" });
         }
-        if (currentRule.source.geoip.inverse_match) {
-          operations.push({ op: "delete_rule_source_geoip_inverse" });
+        if (currentRule.source?.port) {
+          operations.push({ op: "delete_rule_source_port" });
         }
-      }
-      if (currentRule.source?.group) {
-        // Delete ALL existing groups (address, network, port, etc.)
-        for (const [groupType] of Object.entries(currentRule.source.group)) {
-          if (groupType.includes("address")) {
-            operations.push({ op: "delete_rule_source_group_address" });
-          } else if (groupType.includes("network")) {
-            operations.push({ op: "delete_rule_source_group_network" });
-          } else if (groupType.includes("port")) {
-            operations.push({ op: "delete_rule_source_group_port" });
-          } else if (groupType.includes("mac")) {
-            operations.push({ op: "delete_rule_source_group_mac" });
-          } else if (groupType.includes("domain")) {
-            operations.push({ op: "delete_rule_source_group_domain" });
+        if (currentRule.source?.mac_address) {
+          operations.push({ op: "delete_rule_source_mac_address" });
+        }
+        if (currentRule.source?.geoip) {
+          // When removing all GeoIP settings, delete the entire geoip node
+          operations.push({ op: "delete_rule_source_geoip" });
+        }
+        if (currentRule.source?.group) {
+          // Delete ALL existing groups (address, network, port, etc.)
+          for (const [groupType] of Object.entries(currentRule.source.group)) {
+            if (groupType.includes("address")) {
+              operations.push({ op: "delete_rule_source_group_address" });
+            } else if (groupType.includes("network")) {
+              operations.push({ op: "delete_rule_source_group_network" });
+            } else if (groupType.includes("port")) {
+              operations.push({ op: "delete_rule_source_group_port" });
+            } else if (groupType.includes("mac")) {
+              operations.push({ op: "delete_rule_source_group_mac" });
+            } else if (groupType.includes("domain")) {
+              operations.push({ op: "delete_rule_source_group_domain" });
+            }
           }
         }
       }
 
-      // Set new source settings
+      // Set new source settings (only if not "any")
       if (config.source) {
         if (config.source.address) {
           operations.push({ op: "set_rule_source_address", value: config.source.address });
@@ -532,39 +536,43 @@ class FirewallIPv6Service {
 
     // Update destination (similar to source)
     if (hasChanged(config.destination, currentRule.destination)) {
-      // Delete old destination settings
-      if (currentRule.destination?.address) {
-        operations.push({ op: "delete_rule_destination_address" });
-      }
-      if (currentRule.destination?.port) {
-        operations.push({ op: "delete_rule_destination_port" });
-      }
-      if (currentRule.destination?.geoip) {
-        if (currentRule.destination.geoip.country_code) {
-          operations.push({ op: "delete_rule_destination_geoip_country" });
+      // Check if we're clearing to "any" (empty object)
+      const isAny = config.destination && Object.keys(config.destination).length === 0;
+
+      if (isAny) {
+        // When switching to "any", delete the entire destination node
+        operations.push({ op: "delete_rule_destination" });
+      } else {
+        // Delete old destination settings individually
+        if (currentRule.destination?.address) {
+          operations.push({ op: "delete_rule_destination_address" });
         }
-        if (currentRule.destination.geoip.inverse_match) {
-          operations.push({ op: "delete_rule_destination_geoip_inverse" });
+        if (currentRule.destination?.port) {
+          operations.push({ op: "delete_rule_destination_port" });
         }
-      }
-      if (currentRule.destination?.group) {
-        // Delete ALL existing groups (address, network, port, etc.)
-        for (const [groupType] of Object.entries(currentRule.destination.group)) {
-          if (groupType.includes("address")) {
-            operations.push({ op: "delete_rule_destination_group_address" });
-          } else if (groupType.includes("network")) {
-            operations.push({ op: "delete_rule_destination_group_network" });
-          } else if (groupType.includes("port")) {
-            operations.push({ op: "delete_rule_destination_group_port" });
-          } else if (groupType.includes("mac")) {
-            operations.push({ op: "delete_rule_destination_group_mac" });
-          } else if (groupType.includes("domain")) {
-            operations.push({ op: "delete_rule_destination_group_domain" });
+        if (currentRule.destination?.geoip) {
+          // When removing all GeoIP settings, delete the entire geoip node
+          operations.push({ op: "delete_rule_destination_geoip" });
+        }
+        if (currentRule.destination?.group) {
+          // Delete ALL existing groups (address, network, port, etc.)
+          for (const [groupType] of Object.entries(currentRule.destination.group)) {
+            if (groupType.includes("address")) {
+              operations.push({ op: "delete_rule_destination_group_address" });
+            } else if (groupType.includes("network")) {
+              operations.push({ op: "delete_rule_destination_group_network" });
+            } else if (groupType.includes("port")) {
+              operations.push({ op: "delete_rule_destination_group_port" });
+            } else if (groupType.includes("mac")) {
+              operations.push({ op: "delete_rule_destination_group_mac" });
+            } else if (groupType.includes("domain")) {
+              operations.push({ op: "delete_rule_destination_group_domain" });
+            }
           }
         }
       }
 
-      // Set new destination settings
+      // Set new destination settings (only if not "any")
       if (config.destination) {
         if (config.destination.address) {
           operations.push({ op: "set_rule_destination_address", value: config.destination.address });


### PR DESCRIPTION


- Updated source and destination modes to include "any", "geoip", and "mac" options.
- Refactored state management for source and destination fields to accommodate new modes.
- Improved handling of source and destination configurations, ensuring proper deletion of old settings when switching modes.
- Added UI elements for selecting GeoIP countries and MAC addresses in the firewall rule modal.
- Adjusted API calls to handle new configurations for both IPv4 and IPv6 services.