### PR TITLE
feat: add modals for managing prefix lists and rules

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -19,6 +19,7 @@ from routers.dhcp import dhcp
 from routers.static_routes import static_routes
 from routers.route_map import route_map
 from routers.access_list import access_list
+from routers.prefix_list import prefix_list
 from routers import system
 from routers.config import config as config_router
 
@@ -62,6 +63,7 @@ async def lifespan(app: FastAPI):
             static_routes.set_configured_device_name(name)
             route_map.set_configured_device_name(name)
             access_list.set_configured_device_name(name)
+            prefix_list.set_configured_device_name(name)
             system.set_configured_device_name(name)
             config_router.set_configured_device_name(name)
 
@@ -109,6 +111,7 @@ async def lifespan(app: FastAPI):
     static_routes.set_configured_device_name(None)
     route_map.set_configured_device_name(None)
     access_list.set_configured_device_name(None)
+    prefix_list.set_configured_device_name(None)
     system.set_configured_device_name(None)
     config_router.set_configured_device_name(None)
     print("✓ Cleanup complete\n")
@@ -162,6 +165,7 @@ dhcp.set_device_registry(device_registry)
 static_routes.set_device_registry(device_registry)
 route_map.set_device_registry(device_registry)
 access_list.set_device_registry(device_registry)
+prefix_list.set_device_registry(device_registry)
 system.set_device_registry(device_registry)
 config_router.set_device_registry(device_registry)
 
@@ -176,6 +180,7 @@ app.include_router(dhcp.router)
 app.include_router(static_routes.router)
 app.include_router(route_map.router)
 app.include_router(access_list.router)
+app.include_router(prefix_list.router)
 app.include_router(system.router)
 app.include_router(config_router.router)
 

--- a/backend/routers/prefix_list/__init__.py
+++ b/backend/routers/prefix_list/__init__.py
@@ -1,0 +1,8 @@
+"""Prefix List router module."""
+from .prefix_list import (
+    router,
+    set_device_registry,
+    set_configured_device_name,
+)
+
+__all__ = ["router", "set_device_registry", "set_configured_device_name"]

--- a/backend/routers/prefix_list/prefix_list.py
+++ b/backend/routers/prefix_list/prefix_list.py
@@ -1,0 +1,429 @@
+"""
+Prefix List Router
+
+API endpoints for managing VyOS prefix-list configuration.
+Supports both IPv4 (prefix-list) and IPv6 (prefix-list6) with version-aware configuration.
+"""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from typing import List, Dict, Optional, Any
+from vyos_service import VyOSDeviceRegistry
+from vyos_builders import PrefixListBatchBuilder
+import inspect
+
+router = APIRouter(prefix="/vyos/prefix-list", tags=["prefix-list"])
+
+# Module-level variables for device registry
+device_registry: VyOSDeviceRegistry = None
+CONFIGURED_DEVICE_NAME: Optional[str] = None
+
+
+def set_device_registry(registry: VyOSDeviceRegistry):
+    """Set the device registry for this router."""
+    global device_registry
+    device_registry = registry
+
+
+def set_configured_device_name(name: str):
+    """Set the configured device name for this router."""
+    global CONFIGURED_DEVICE_NAME
+    CONFIGURED_DEVICE_NAME = name
+
+
+# ============================================================================
+# Pydantic Models
+# ============================================================================
+
+
+class PrefixListRule(BaseModel):
+    """Model for a prefix-list rule."""
+    rule_number: int
+    action: str  # permit or deny
+    description: Optional[str] = None
+    prefix: Optional[str] = None  # CIDR notation (e.g., 10.0.0.0/8)
+    ge: Optional[int] = None  # Greater-than-or-equal prefix length
+    le: Optional[int] = None  # Less-than-or-equal prefix length
+
+
+class PrefixList(BaseModel):
+    """Model for a prefix-list."""
+    name: str
+    description: Optional[str] = None
+    rules: List[PrefixListRule] = []
+    list_type: str  # ipv4 or ipv6
+
+
+class PrefixListConfigResponse(BaseModel):
+    """Response containing all prefix-list configuration."""
+    ipv4_lists: List[PrefixList] = []
+    ipv6_lists: List[PrefixList] = []
+    total_ipv4: int = 0
+    total_ipv6: int = 0
+
+
+class PrefixListBatchOperation(BaseModel):
+    """Single operation in a batch request."""
+    op: str = Field(..., description="Operation name")
+    value: Optional[str] = Field(None, description="Operation value")
+
+
+class PrefixListBatchRequest(BaseModel):
+    """Model for batch configuration."""
+    name: str = Field(..., description="Prefix list name")
+    list_type: str = Field(..., description="ipv4 or ipv6")
+    rule_number: Optional[int] = Field(None, description="Rule number for rule operations")
+    operations: List[PrefixListBatchOperation]
+
+
+class ReorderRuleItem(BaseModel):
+    """Model for a single rule in reorder request."""
+    old_number: int
+    new_number: int
+    rule_data: PrefixListRule
+
+
+class ReorderPrefixListRequest(BaseModel):
+    """Model for reordering rules in a prefix-list."""
+    name: str = Field(..., description="Prefix list name")
+    list_type: str = Field(..., description="ipv4 or ipv6")
+    rules: List[ReorderRuleItem]
+
+
+class VyOSResponse(BaseModel):
+    """Standard response from VyOS operations."""
+    success: bool
+    data: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+
+# ============================================================================
+# Endpoint 1: Capabilities
+# ============================================================================
+
+
+@router.get("/capabilities")
+async def get_prefix_list_capabilities():
+    """
+    Get feature capabilities based on device VyOS version.
+
+    Returns feature flags indicating which operations are supported.
+    Allows frontends to conditionally enable/disable features.
+    """
+    if CONFIGURED_DEVICE_NAME is None:
+        raise HTTPException(
+            status_code=503, detail="No device configured. Check .env file."
+        )
+
+    try:
+        service = device_registry.get(CONFIGURED_DEVICE_NAME)
+        version = service.get_version()
+        builder = PrefixListBatchBuilder(version=version)
+        capabilities = builder.get_capabilities()
+
+        capabilities["device_name"] = CONFIGURED_DEVICE_NAME
+        return capabilities
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ============================================================================
+# Endpoint 2: Config (Generalized Data)
+# ============================================================================
+
+
+@router.get("/config", response_model=PrefixListConfigResponse)
+async def get_prefix_list_config(refresh: bool = False):
+    """
+    Get all prefix-list configurations from VyOS in a generalized format.
+
+    Args:
+        refresh: If True, force refresh from VyOS. If False, use cache.
+
+    Returns:
+        Generalized configuration data optimized for frontend consumption
+    """
+    if CONFIGURED_DEVICE_NAME is None:
+        raise HTTPException(
+            status_code=503, detail="No device configured."
+        )
+
+    try:
+        service = device_registry.get(CONFIGURED_DEVICE_NAME)
+        full_config = service.get_full_config(refresh=refresh)
+
+        ipv4_lists = []
+        ipv6_lists = []
+
+        # Parse IPv4 prefix-lists
+        policy_config = full_config.get("policy", {})
+        prefix_lists = policy_config.get("prefix-list", {})
+
+        for name, list_config in prefix_lists.items():
+            rules = []
+            rules_config = list_config.get("rule", {})
+
+            for rule_num, rule_config in rules_config.items():
+                # Parse rule data
+                action = rule_config.get("action", "permit")
+                description = rule_config.get("description")
+                prefix = rule_config.get("prefix")
+
+                # Parse ge (greater-than-or-equal)
+                ge = None
+                ge_value = rule_config.get("ge")
+                if ge_value is not None:
+                    try:
+                        ge = int(ge_value)
+                    except (ValueError, TypeError):
+                        pass
+
+                # Parse le (less-than-or-equal)
+                le = None
+                le_value = rule_config.get("le")
+                if le_value is not None:
+                    try:
+                        le = int(le_value)
+                    except (ValueError, TypeError):
+                        pass
+
+                rule = PrefixListRule(
+                    rule_number=int(rule_num),
+                    action=action,
+                    description=description,
+                    prefix=prefix,
+                    ge=ge,
+                    le=le,
+                )
+                rules.append(rule)
+
+            # Sort rules by rule number
+            rules.sort(key=lambda r: r.rule_number)
+
+            prefix_list = PrefixList(
+                name=name,
+                description=list_config.get("description"),
+                rules=rules,
+                list_type="ipv4",
+            )
+            ipv4_lists.append(prefix_list)
+
+        # Parse IPv6 prefix-lists
+        prefix_lists6 = policy_config.get("prefix-list6", {})
+
+        for name, list_config in prefix_lists6.items():
+            rules = []
+            rules_config = list_config.get("rule", {})
+
+            for rule_num, rule_config in rules_config.items():
+                # Parse rule data
+                action = rule_config.get("action", "permit")
+                description = rule_config.get("description")
+                prefix = rule_config.get("prefix")
+
+                # Parse ge (greater-than-or-equal)
+                ge = None
+                ge_value = rule_config.get("ge")
+                if ge_value is not None:
+                    try:
+                        ge = int(ge_value)
+                    except (ValueError, TypeError):
+                        pass
+
+                # Parse le (less-than-or-equal)
+                le = None
+                le_value = rule_config.get("le")
+                if le_value is not None:
+                    try:
+                        le = int(le_value)
+                    except (ValueError, TypeError):
+                        pass
+
+                rule = PrefixListRule(
+                    rule_number=int(rule_num),
+                    action=action,
+                    description=description,
+                    prefix=prefix,
+                    ge=ge,
+                    le=le,
+                )
+                rules.append(rule)
+
+            # Sort rules by rule number
+            rules.sort(key=lambda r: r.rule_number)
+
+            prefix_list = PrefixList(
+                name=name,
+                description=list_config.get("description"),
+                rules=rules,
+                list_type="ipv6",
+            )
+            ipv6_lists.append(prefix_list)
+
+        # Sort prefix lists by name
+        ipv4_lists.sort(key=lambda pl: pl.name)
+        ipv6_lists.sort(key=lambda pl: pl.name)
+
+        return PrefixListConfigResponse(
+            ipv4_lists=ipv4_lists,
+            ipv6_lists=ipv6_lists,
+            total_ipv4=len(ipv4_lists),
+            total_ipv6=len(ipv6_lists),
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ============================================================================
+# Endpoint 3: Batch Operations
+# ============================================================================
+
+
+@router.post("/batch")
+async def prefix_list_batch_configure(request: PrefixListBatchRequest):
+    """
+    Execute a batch of configuration operations.
+
+    Allows multiple changes in a single VyOS commit for efficiency.
+    """
+    if CONFIGURED_DEVICE_NAME is None:
+        raise HTTPException(status_code=503, detail="No device configured.")
+
+    try:
+        service = device_registry.get(CONFIGURED_DEVICE_NAME)
+        version = service.get_version()
+        builder = PrefixListBatchBuilder(version=version)
+
+        # Process operations using inspect for dynamic method calls
+        for operation in request.operations:
+            method = getattr(builder, operation.op)
+            sig = inspect.signature(method)
+            params = list(sig.parameters.keys())
+
+            # Build arguments dynamically
+            args = []
+
+            # Add name
+            if "name" in params:
+                args.append(request.name)
+
+            # Add rule number if present in method signature
+            if "rule" in params and request.rule_number is not None:
+                args.append(str(request.rule_number))
+
+            # Add operation value
+            if operation.value and len(params) > len(args):
+                args.append(operation.value)
+
+            method(*args)
+
+        # Execute batch
+        response = service.execute_batch(builder)
+
+        return VyOSResponse(
+            success=response.status == 200,
+            data={"message": "Configuration updated"},
+            error=response.error if response.error else None
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ============================================================================
+# Reorder Endpoint
+# ============================================================================
+
+
+@router.post("/reorder")
+async def reorder_prefix_list_rules(request: ReorderPrefixListRequest):
+    """
+    Reorder rules in a prefix-list.
+
+    This endpoint deletes all existing rules and recreates them with new numbers
+    in a single VyOS commit for atomicity.
+    """
+    if CONFIGURED_DEVICE_NAME is None:
+        raise HTTPException(status_code=503, detail="No device configured.")
+
+    try:
+        service = device_registry.get(CONFIGURED_DEVICE_NAME)
+        version = service.get_version()
+        builder = PrefixListBatchBuilder(version=version)
+
+        # Step 1: Delete all rules in reverse order
+        rules_to_delete = sorted(
+            [item.old_number for item in request.rules],
+            reverse=True
+        )
+
+        for old_number in rules_to_delete:
+            if request.list_type == "ipv4":
+                builder.delete_rule(request.name, str(old_number))
+            else:  # ipv6
+                builder.delete_rule6(request.name, str(old_number))
+
+        # Step 2: Recreate rules with new numbers
+        for item in request.rules:
+            rule = item.rule_data
+            rule_str = str(item.new_number)
+
+            if request.list_type == "ipv4":
+                # Create rule
+                builder.set_rule(request.name, rule_str)
+
+                # Set action
+                builder.set_rule_action(request.name, rule_str, rule.action)
+
+                # Set description
+                if rule.description:
+                    builder.set_rule_description(
+                        request.name, rule_str, rule.description
+                    )
+
+                # Set prefix
+                if rule.prefix:
+                    builder.set_rule_prefix(request.name, rule_str, rule.prefix)
+
+                # Set ge
+                if rule.ge is not None:
+                    builder.set_rule_ge(request.name, rule_str, str(rule.ge))
+
+                # Set le
+                if rule.le is not None:
+                    builder.set_rule_le(request.name, rule_str, str(rule.le))
+
+            else:  # ipv6
+                # Create rule
+                builder.set_rule6(request.name, rule_str)
+
+                # Set action
+                builder.set_rule6_action(request.name, rule_str, rule.action)
+
+                # Set description
+                if rule.description:
+                    builder.set_rule6_description(
+                        request.name, rule_str, rule.description
+                    )
+
+                # Set prefix
+                if rule.prefix:
+                    builder.set_rule6_prefix(request.name, rule_str, rule.prefix)
+
+                # Set ge
+                if rule.ge is not None:
+                    builder.set_rule6_ge(request.name, rule_str, str(rule.ge))
+
+                # Set le
+                if rule.le is not None:
+                    builder.set_rule6_le(request.name, rule_str, str(rule.le))
+
+        # Execute batch
+        response = service.execute_batch(builder)
+
+        return VyOSResponse(
+            success=response.status == 200,
+            data={"message": f"Rules reordered in prefix-list {request.name}"},
+            error=response.error if response.error else None
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/vyos_builders/__init__.py
+++ b/backend/vyos_builders/__init__.py
@@ -12,6 +12,7 @@ from .dhcp import DHCPBatchBuilder
 from .static_routes import StaticRoutesBatchBuilder
 from .route_map import RouteMapBatchBuilder
 from .access_list import AccessListBatchBuilder
+from .prefix_list import PrefixListBatchBuilder
 
 # Directly use the self-contained builders
 EthernetBatchBuilder = EthernetInterfaceBuilderMixin
@@ -28,4 +29,5 @@ __all__ = [
     "StaticRoutesBatchBuilder",
     "RouteMapBatchBuilder",
     "AccessListBatchBuilder",
+    "PrefixListBatchBuilder",
 ]

--- a/backend/vyos_builders/prefix_list/__init__.py
+++ b/backend/vyos_builders/prefix_list/__init__.py
@@ -1,0 +1,4 @@
+"""Prefix List builder module."""
+from .prefix_list import PrefixListBatchBuilder
+
+__all__ = ["PrefixListBatchBuilder"]

--- a/backend/vyos_builders/prefix_list/prefix_list.py
+++ b/backend/vyos_builders/prefix_list/prefix_list.py
@@ -1,0 +1,279 @@
+"""
+Prefix List Batch Builder
+
+Provides all batch operations following the standard pattern.
+Handles version-specific differences through the mapper layer.
+"""
+
+from typing import List, Dict, Any
+from vyos_mappers import CommandMapperRegistry
+
+
+class PrefixListBatchBuilder:
+    """Complete batch builder for prefix-list operations"""
+
+    def __init__(self, version: str):
+        """Initialize builder with VyOS version."""
+        self.version = version
+        self._operations: List[Dict[str, Any]] = []
+
+        # Get mapper for this version
+        self.mappers = CommandMapperRegistry.get_all_mappers(version)
+        self.mapper_key = "prefix_list"
+
+    # ========================================================================
+    # Core Batch Operations
+    # ========================================================================
+
+    def add_set(self, path: List[str]) -> "PrefixListBatchBuilder":
+        """Add a 'set' operation to the batch."""
+        if path:  # Only add if path is not empty
+            self._operations.append({"op": "set", "path": path})
+        return self
+
+    def add_delete(self, path: List[str]) -> "PrefixListBatchBuilder":
+        """Add a 'delete' operation to the batch."""
+        if path:
+            self._operations.append({"op": "delete", "path": path})
+        return self
+
+    def clear(self) -> None:
+        """Clear all operations from the batch."""
+        self._operations = []
+
+    def get_operations(self) -> List[Dict[str, Any]]:
+        """Get the list of operations."""
+        return self._operations.copy()
+
+    def operation_count(self) -> int:
+        """Get the number of operations in the batch."""
+        return len(self._operations)
+
+    def is_empty(self) -> bool:
+        """Check if the batch is empty."""
+        return len(self._operations) == 0
+
+    # ========================================================================
+    # IPv4 Prefix List Operations
+    # ========================================================================
+
+    def set_prefix_list(self, name: str) -> "PrefixListBatchBuilder":
+        """Create prefix-list."""
+        path = self.mappers[self.mapper_key].get_prefix_list_path(name)
+        return self.add_set(path)
+
+    def delete_prefix_list(self, name: str) -> "PrefixListBatchBuilder":
+        """Delete prefix-list."""
+        path = self.mappers[self.mapper_key].get_prefix_list_path(name)
+        return self.add_delete(path)
+
+    def set_prefix_list_description(
+        self, name: str, description: str
+    ) -> "PrefixListBatchBuilder":
+        """Set prefix-list description."""
+        path = self.mappers[self.mapper_key].get_prefix_list_description(
+            name, description
+        )
+        return self.add_set(path)
+
+    def delete_prefix_list_description(self, name: str) -> "PrefixListBatchBuilder":
+        """Delete prefix-list description."""
+        path = self.mappers[self.mapper_key].get_prefix_list_description(name, "")
+        # For description deletion, we need just the path without value
+        path = path[:-1]  # Remove the empty description value
+        return self.add_delete(path)
+
+    # ========================================================================
+    # IPv4 Rule Operations
+    # ========================================================================
+
+    def set_rule(self, name: str, rule: str) -> "PrefixListBatchBuilder":
+        """Create rule."""
+        path = self.mappers[self.mapper_key].get_rule_path(name, rule)
+        return self.add_set(path)
+
+    def delete_rule(self, name: str, rule: str) -> "PrefixListBatchBuilder":
+        """Delete rule."""
+        path = self.mappers[self.mapper_key].get_rule_path(name, rule)
+        return self.add_delete(path)
+
+    def set_rule_action(
+        self, name: str, rule: str, action: str
+    ) -> "PrefixListBatchBuilder":
+        """Set rule action (permit/deny)."""
+        path = self.mappers[self.mapper_key].get_rule_action(name, rule, action)
+        return self.add_set(path)
+
+    def set_rule_description(
+        self, name: str, rule: str, description: str
+    ) -> "PrefixListBatchBuilder":
+        """Set rule description."""
+        path = self.mappers[self.mapper_key].get_rule_description(
+            name, rule, description
+        )
+        return self.add_set(path)
+
+    def delete_rule_description(
+        self, name: str, rule: str
+    ) -> "PrefixListBatchBuilder":
+        """Delete rule description."""
+        path = self.mappers[self.mapper_key].get_rule_description_path(name, rule)
+        return self.add_delete(path)
+
+    def set_rule_prefix(
+        self, name: str, rule: str, prefix: str
+    ) -> "PrefixListBatchBuilder":
+        """Set rule prefix."""
+        path = self.mappers[self.mapper_key].get_rule_prefix(name, rule, prefix)
+        return self.add_set(path)
+
+    def set_rule_ge(
+        self, name: str, rule: str, ge: str
+    ) -> "PrefixListBatchBuilder":
+        """Set rule ge (greater-than-or-equal)."""
+        path = self.mappers[self.mapper_key].get_rule_ge(name, rule, ge)
+        return self.add_set(path)
+
+    def delete_rule_ge(self, name: str, rule: str) -> "PrefixListBatchBuilder":
+        """Delete rule ge."""
+        path = self.mappers[self.mapper_key].get_rule_ge_path(name, rule)
+        return self.add_delete(path)
+
+    def set_rule_le(
+        self, name: str, rule: str, le: str
+    ) -> "PrefixListBatchBuilder":
+        """Set rule le (less-than-or-equal)."""
+        path = self.mappers[self.mapper_key].get_rule_le(name, rule, le)
+        return self.add_set(path)
+
+    def delete_rule_le(self, name: str, rule: str) -> "PrefixListBatchBuilder":
+        """Delete rule le."""
+        path = self.mappers[self.mapper_key].get_rule_le_path(name, rule)
+        return self.add_delete(path)
+
+    # ========================================================================
+    # IPv6 Prefix List Operations
+    # ========================================================================
+
+    def set_prefix_list6(self, name: str) -> "PrefixListBatchBuilder":
+        """Create prefix-list6."""
+        path = self.mappers[self.mapper_key].get_prefix_list6_path(name)
+        return self.add_set(path)
+
+    def delete_prefix_list6(self, name: str) -> "PrefixListBatchBuilder":
+        """Delete prefix-list6."""
+        path = self.mappers[self.mapper_key].get_prefix_list6_path(name)
+        return self.add_delete(path)
+
+    def set_prefix_list6_description(
+        self, name: str, description: str
+    ) -> "PrefixListBatchBuilder":
+        """Set prefix-list6 description."""
+        path = self.mappers[self.mapper_key].get_prefix_list6_description(
+            name, description
+        )
+        return self.add_set(path)
+
+    def delete_prefix_list6_description(self, name: str) -> "PrefixListBatchBuilder":
+        """Delete prefix-list6 description."""
+        path = self.mappers[self.mapper_key].get_prefix_list6_description(name, "")
+        # For description deletion, we need just the path without value
+        path = path[:-1]  # Remove the empty description value
+        return self.add_delete(path)
+
+    # ========================================================================
+    # IPv6 Rule Operations
+    # ========================================================================
+
+    def set_rule6(self, name: str, rule: str) -> "PrefixListBatchBuilder":
+        """Create IPv6 rule."""
+        path = self.mappers[self.mapper_key].get_rule6_path(name, rule)
+        return self.add_set(path)
+
+    def delete_rule6(self, name: str, rule: str) -> "PrefixListBatchBuilder":
+        """Delete IPv6 rule."""
+        path = self.mappers[self.mapper_key].get_rule6_path(name, rule)
+        return self.add_delete(path)
+
+    def set_rule6_action(
+        self, name: str, rule: str, action: str
+    ) -> "PrefixListBatchBuilder":
+        """Set IPv6 rule action (permit/deny)."""
+        path = self.mappers[self.mapper_key].get_rule6_action(name, rule, action)
+        return self.add_set(path)
+
+    def set_rule6_description(
+        self, name: str, rule: str, description: str
+    ) -> "PrefixListBatchBuilder":
+        """Set IPv6 rule description."""
+        path = self.mappers[self.mapper_key].get_rule6_description(
+            name, rule, description
+        )
+        return self.add_set(path)
+
+    def delete_rule6_description(
+        self, name: str, rule: str
+    ) -> "PrefixListBatchBuilder":
+        """Delete IPv6 rule description."""
+        path = self.mappers[self.mapper_key].get_rule6_description_path(name, rule)
+        return self.add_delete(path)
+
+    def set_rule6_prefix(
+        self, name: str, rule: str, prefix: str
+    ) -> "PrefixListBatchBuilder":
+        """Set IPv6 rule prefix."""
+        path = self.mappers[self.mapper_key].get_rule6_prefix(name, rule, prefix)
+        return self.add_set(path)
+
+    def set_rule6_ge(
+        self, name: str, rule: str, ge: str
+    ) -> "PrefixListBatchBuilder":
+        """Set IPv6 rule ge (greater-than-or-equal)."""
+        path = self.mappers[self.mapper_key].get_rule6_ge(name, rule, ge)
+        return self.add_set(path)
+
+    def delete_rule6_ge(self, name: str, rule: str) -> "PrefixListBatchBuilder":
+        """Delete IPv6 rule ge."""
+        path = self.mappers[self.mapper_key].get_rule6_ge_path(name, rule)
+        return self.add_delete(path)
+
+    def set_rule6_le(
+        self, name: str, rule: str, le: str
+    ) -> "PrefixListBatchBuilder":
+        """Set IPv6 rule le (less-than-or-equal)."""
+        path = self.mappers[self.mapper_key].get_rule6_le(name, rule, le)
+        return self.add_set(path)
+
+    def delete_rule6_le(self, name: str, rule: str) -> "PrefixListBatchBuilder":
+        """Delete IPv6 rule le."""
+        path = self.mappers[self.mapper_key].get_rule6_le_path(name, rule)
+        return self.add_delete(path)
+
+    # ========================================================================
+    # Capabilities
+    # ========================================================================
+
+    def get_capabilities(self) -> Dict[str, Any]:
+        """Get capabilities for the current VyOS version."""
+        # Prefix lists have same features in 1.4 and 1.5
+        return {
+            "version": self.version,
+            "features": {
+                "ipv4_prefix_lists": {
+                    "supported": True,
+                    "description": "IPv4 prefix lists with permit/deny rules",
+                },
+                "ipv6_prefix_lists": {
+                    "supported": True,
+                    "description": "IPv6 prefix lists with permit/deny rules",
+                },
+                "ge_le_operators": {
+                    "supported": True,
+                    "description": "Greater-than-or-equal (ge) and less-than-or-equal (le) prefix length operators",
+                },
+                "rule_descriptions": {
+                    "supported": True,
+                    "description": "Rule-level descriptions",
+                },
+            },
+        }

--- a/backend/vyos_mappers/__init__.py
+++ b/backend/vyos_mappers/__init__.py
@@ -22,6 +22,8 @@ from .route_map import RouteMapMapper
 from .route_map.route_map_versions import get_route_map_mapper
 from .access_list import AccessListMapper
 from .access_list.access_list_versions import get_access_list_mapper
+from .prefix_list import PrefixListMapper
+from .prefix_list.prefix_list_versions import get_prefix_list_mapper
 
 # Auto-register all mappers
 # Ethernet uses factory for version-specific mappers
@@ -44,6 +46,8 @@ CommandMapperRegistry.register_feature("static_routes", get_static_routes_mapper
 CommandMapperRegistry.register_feature("route_map", get_route_map_mapper)
 # Access List uses factory for version-specific mappers
 CommandMapperRegistry.register_feature("access_list", get_access_list_mapper)
+# Prefix List uses factory for version-specific mappers
+CommandMapperRegistry.register_feature("prefix_list", get_prefix_list_mapper)
 
 __all__ = [
     "BaseFeatureMapper",
@@ -58,4 +62,5 @@ __all__ = [
     "StaticRoutesMapper",
     "RouteMapMapper",
     "AccessListMapper",
+    "PrefixListMapper",
 ]

--- a/backend/vyos_mappers/prefix_list/__init__.py
+++ b/backend/vyos_mappers/prefix_list/__init__.py
@@ -1,0 +1,5 @@
+"""Prefix List mapper module."""
+from .prefix_list import PrefixListMapper
+from .prefix_list_versions import get_prefix_list_mapper
+
+__all__ = ["PrefixListMapper", "get_prefix_list_mapper"]

--- a/backend/vyos_mappers/prefix_list/prefix_list.py
+++ b/backend/vyos_mappers/prefix_list/prefix_list.py
@@ -1,0 +1,129 @@
+"""
+Prefix List Command Mapper
+
+Handles command path generation for prefix-list configuration.
+Version-specific logic is in version-specific files.
+"""
+
+from typing import List
+from ..base import BaseFeatureMapper
+
+
+class PrefixListMapper(BaseFeatureMapper):
+    """Base mapper with common operations"""
+
+    def __init__(self, version: str):
+        """Initialize with VyOS version."""
+        super().__init__(version)
+
+    # ========================================================================
+    # Core Prefix List Paths (IPv4)
+    # ========================================================================
+
+    def get_prefix_list_path(self, name: str) -> List[str]:
+        """Get command path for prefix-list."""
+        return ["policy", "prefix-list", name]
+
+    def get_prefix_list_description(self, name: str, description: str) -> List[str]:
+        """Get command path for prefix-list description."""
+        return ["policy", "prefix-list", name, "description", description]
+
+    # ========================================================================
+    # Rule Paths (IPv4)
+    # ========================================================================
+
+    def get_rule_path(self, name: str, rule: str) -> List[str]:
+        """Get command path for rule."""
+        return ["policy", "prefix-list", name, "rule", rule]
+
+    def get_rule_action(self, name: str, rule: str, action: str) -> List[str]:
+        """Get command path for rule action (permit/deny)."""
+        return ["policy", "prefix-list", name, "rule", rule, "action", action]
+
+    def get_rule_description(self, name: str, rule: str, description: str) -> List[str]:
+        """Get command path for rule description."""
+        return ["policy", "prefix-list", name, "rule", rule, "description", description]
+
+    def get_rule_prefix(self, name: str, rule: str, prefix: str) -> List[str]:
+        """Get command path for rule prefix."""
+        return ["policy", "prefix-list", name, "rule", rule, "prefix", prefix]
+
+    def get_rule_ge(self, name: str, rule: str, ge: str) -> List[str]:
+        """Get command path for rule ge (greater-than-or-equal)."""
+        return ["policy", "prefix-list", name, "rule", rule, "ge", ge]
+
+    def get_rule_le(self, name: str, rule: str, le: str) -> List[str]:
+        """Get command path for rule le (less-than-or-equal)."""
+        return ["policy", "prefix-list", name, "rule", rule, "le", le]
+
+    # ========================================================================
+    # Delete Paths (IPv4)
+    # ========================================================================
+
+    def get_rule_description_path(self, name: str, rule: str) -> List[str]:
+        """Get command path for deleting rule description."""
+        return ["policy", "prefix-list", name, "rule", rule, "description"]
+
+    def get_rule_ge_path(self, name: str, rule: str) -> List[str]:
+        """Get command path for deleting rule ge."""
+        return ["policy", "prefix-list", name, "rule", rule, "ge"]
+
+    def get_rule_le_path(self, name: str, rule: str) -> List[str]:
+        """Get command path for deleting rule le."""
+        return ["policy", "prefix-list", name, "rule", rule, "le"]
+
+    # ========================================================================
+    # Core Prefix List Paths (IPv6)
+    # ========================================================================
+
+    def get_prefix_list6_path(self, name: str) -> List[str]:
+        """Get command path for prefix-list6."""
+        return ["policy", "prefix-list6", name]
+
+    def get_prefix_list6_description(self, name: str, description: str) -> List[str]:
+        """Get command path for prefix-list6 description."""
+        return ["policy", "prefix-list6", name, "description", description]
+
+    # ========================================================================
+    # Rule Paths (IPv6)
+    # ========================================================================
+
+    def get_rule6_path(self, name: str, rule: str) -> List[str]:
+        """Get command path for IPv6 rule."""
+        return ["policy", "prefix-list6", name, "rule", rule]
+
+    def get_rule6_action(self, name: str, rule: str, action: str) -> List[str]:
+        """Get command path for IPv6 rule action (permit/deny)."""
+        return ["policy", "prefix-list6", name, "rule", rule, "action", action]
+
+    def get_rule6_description(self, name: str, rule: str, description: str) -> List[str]:
+        """Get command path for IPv6 rule description."""
+        return ["policy", "prefix-list6", name, "rule", rule, "description", description]
+
+    def get_rule6_prefix(self, name: str, rule: str, prefix: str) -> List[str]:
+        """Get command path for IPv6 rule prefix."""
+        return ["policy", "prefix-list6", name, "rule", rule, "prefix", prefix]
+
+    def get_rule6_ge(self, name: str, rule: str, ge: str) -> List[str]:
+        """Get command path for IPv6 rule ge (greater-than-or-equal)."""
+        return ["policy", "prefix-list6", name, "rule", rule, "ge", ge]
+
+    def get_rule6_le(self, name: str, rule: str, le: str) -> List[str]:
+        """Get command path for IPv6 rule le (less-than-or-equal)."""
+        return ["policy", "prefix-list6", name, "rule", rule, "le", le]
+
+    # ========================================================================
+    # Delete Paths (IPv6)
+    # ========================================================================
+
+    def get_rule6_description_path(self, name: str, rule: str) -> List[str]:
+        """Get command path for deleting IPv6 rule description."""
+        return ["policy", "prefix-list6", name, "rule", rule, "description"]
+
+    def get_rule6_ge_path(self, name: str, rule: str) -> List[str]:
+        """Get command path for deleting IPv6 rule ge."""
+        return ["policy", "prefix-list6", name, "rule", rule, "ge"]
+
+    def get_rule6_le_path(self, name: str, rule: str) -> List[str]:
+        """Get command path for deleting IPv6 rule le."""
+        return ["policy", "prefix-list6", name, "rule", rule, "le"]

--- a/backend/vyos_mappers/prefix_list/prefix_list_versions/__init__.py
+++ b/backend/vyos_mappers/prefix_list/prefix_list_versions/__init__.py
@@ -1,0 +1,26 @@
+"""Factory for version-specific prefix-list mappers."""
+from ..prefix_list import PrefixListMapper
+from .v1_4 import PrefixListMapperV1_4
+from .v1_5 import PrefixListMapperV1_5
+
+
+def get_prefix_list_mapper(version: str):
+    """Factory function to get appropriate mapper for version."""
+    base = PrefixListMapper(version)
+
+    if "1.4" in version:
+        version_specific = PrefixListMapperV1_4()
+    elif "1.5" in version or "latest" in version:
+        version_specific = PrefixListMapperV1_5()
+    else:
+        version_specific = PrefixListMapperV1_5()  # Default to latest
+
+    # Merge base and version-specific mappers
+    class MergedMapper:
+        def __getattr__(self, name):
+            # Try version-specific first, fall back to base
+            if hasattr(version_specific, name):
+                return getattr(version_specific, name)
+            return getattr(base, name)
+
+    return MergedMapper()

--- a/backend/vyos_mappers/prefix_list/prefix_list_versions/v1_4.py
+++ b/backend/vyos_mappers/prefix_list/prefix_list_versions/v1_4.py
@@ -1,0 +1,8 @@
+"""VyOS 1.4 specific commands for prefix-list."""
+
+
+class PrefixListMapperV1_4:
+    """Version-specific mapper for VyOS 1.4."""
+
+    # No version-specific overrides needed - commands are identical to base
+    pass

--- a/backend/vyos_mappers/prefix_list/prefix_list_versions/v1_5.py
+++ b/backend/vyos_mappers/prefix_list/prefix_list_versions/v1_5.py
@@ -1,0 +1,8 @@
+"""VyOS 1.5 specific commands for prefix-list."""
+
+
+class PrefixListMapperV1_5:
+    """Version-specific mapper for VyOS 1.5."""
+
+    # No version-specific overrides needed - commands are identical to base
+    pass

--- a/frontend/src/app/policies/prefix-list/page.tsx
+++ b/frontend/src/app/policies/prefix-list/page.tsx
@@ -1,10 +1,613 @@
+"use client";
+
 import { AppLayout } from "@/components/layout/AppLayout";
-import { InProgress } from "@/components/layout/InProgress";
+import { Card, CardContent } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import {
+  Plus,
+  Search,
+  RefreshCw,
+  AlertCircle,
+  ListFilter,
+  Trash2,
+  Pencil,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
+import {
+  prefixListService,
+  type PrefixList,
+  type PrefixListConfigResponse,
+  type PrefixListRule,
+  type PrefixListCapabilitiesResponse,
+} from "@/lib/api/prefix-list";
+import { cn } from "@/lib/utils";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { CreatePrefixListModal } from "@/components/policies/CreatePrefixListModal";
+import { EditPrefixListModal } from "@/components/policies/EditPrefixListModal";
+import { DeletePrefixListModal } from "@/components/policies/DeletePrefixListModal";
+import { AddPrefixListRuleModal } from "@/components/policies/AddPrefixListRuleModal";
+import { EditPrefixListRuleModal } from "@/components/policies/EditPrefixListRuleModal";
+import { DeletePrefixListRuleModal } from "@/components/policies/DeletePrefixListRuleModal";
+import { PrefixListRuleRow } from "@/components/policies/PrefixListRuleRow";
+import { PrefixListReorderBanner } from "@/components/policies/PrefixListReorderBanner";
 
 export default function PrefixListPage() {
+  const [config, setConfig] = useState<PrefixListConfigResponse | null>(null);
+  const [capabilities, setCapabilities] = useState<PrefixListCapabilitiesResponse | null>(null);
+  const [selectedListType, setSelectedListType] = useState<"ipv4" | "ipv6">("ipv4");
+  const [selectedList, setSelectedList] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [ruleSearchQuery, setRuleSearchQuery] = useState("");
+
+  // Modal states
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [editingList, setEditingList] = useState<PrefixList | null>(null);
+  const [deletingList, setDeletingList] = useState<PrefixList | null>(null);
+  const [addRuleModalOpen, setAddRuleModalOpen] = useState(false);
+  const [editingRule, setEditingRule] = useState<PrefixListRule | null>(null);
+  const [deletingRule, setDeletingRule] = useState<PrefixListRule | null>(null);
+
+  // Drag and drop states
+  const [reorderedRules, setReorderedRules] = useState<PrefixListRule[]>([]);
+  const [originalRules, setOriginalRules] = useState<PrefixListRule[]>([]);
+  const [hasChanges, setHasChanges] = useState(false);
+  const [activeId, setActiveId] = useState<number | null>(null);
+  const [savingReorder, setSavingReorder] = useState(false);
+
+  // Drag and drop sensors - require 8px movement before drag starts
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    })
+  );
+
+  useEffect(() => {
+    fetchConfig();
+    fetchCapabilities();
+  }, []);
+
+  const fetchConfig = async (refresh: boolean = false) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await prefixListService.getConfig(refresh);
+      setConfig(data);
+
+      // Reset reorder state when new config is loaded
+      setHasChanges(false);
+      setReorderedRules([]);
+      setOriginalRules([]);
+
+      // Auto-select first list if none selected
+      if (!selectedList) {
+        const lists = selectedListType === "ipv4" ? data.ipv4_lists : data.ipv6_lists;
+        if (lists.length > 0) {
+          setSelectedList(lists[0].name);
+        }
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load prefix-list configuration"
+      );
+      console.error("Error fetching prefix-list config:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchCapabilities = async () => {
+    try {
+      const caps = await prefixListService.getCapabilities();
+      setCapabilities(caps);
+    } catch (err) {
+      console.error("Error fetching capabilities:", err);
+    }
+  };
+
+  const currentLists = selectedListType === "ipv4" ? config?.ipv4_lists || [] : config?.ipv6_lists || [];
+  const selectedListData = currentLists.find((list) => list.name === selectedList);
+
+  // Get current rules (reordered or original)
+  const currentRules = hasChanges && reorderedRules.length > 0
+    ? reorderedRules
+    : selectedListData?.rules || [];
+
+  // Filter lists based on search
+  const filteredLists = currentLists.filter((list) => {
+    if (!searchQuery) return true;
+    const query = searchQuery.toLowerCase();
+    return (
+      list.name.toLowerCase().includes(query) ||
+      list.description?.toLowerCase().includes(query)
+    );
+  });
+
+  // Filter rules based on search
+  const filteredRules = currentRules.filter((rule) => {
+    if (!ruleSearchQuery) return true;
+    const query = ruleSearchQuery.toLowerCase();
+    return (
+      rule.rule_number.toString().includes(query) ||
+      rule.description?.toLowerCase().includes(query) ||
+      rule.action.toLowerCase().includes(query) ||
+      rule.prefix?.toLowerCase().includes(query)
+    );
+  });
+
+  // Drag and drop handlers
+  const handleDragStart = (event: any) => {
+    setActiveId(event.active.id);
+  };
+
+  const handleDragEnd = (event: any) => {
+    const { active, over } = event;
+    setActiveId(null);
+
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = currentRules.findIndex((r) => r.rule_number === active.id);
+    const newIndex = currentRules.findIndex((r) => r.rule_number === over.id);
+
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const newRules = arrayMove(currentRules, oldIndex, newIndex);
+
+    // Store original rules if this is the first change
+    if (!hasChanges) {
+      setOriginalRules([...currentRules]);
+    }
+
+    setReorderedRules(newRules);
+    setHasChanges(true);
+  };
+
+  const handleCancelReorder = () => {
+    setReorderedRules([]);
+    setOriginalRules([]);
+    setHasChanges(false);
+  };
+
+  const handleSaveReorder = async () => {
+    if (!selectedList || reorderedRules.length === 0) return;
+
+    setSavingReorder(true);
+    try {
+      // Find the minimum rule number to preserve the starting point
+      const minRuleNumber = Math.min(...originalRules.map(r => r.rule_number));
+
+      // Calculate new rule numbers (renumber sequentially starting from original minimum)
+      const rulesWithNewNumbers = reorderedRules.map((rule, index) => ({
+        old_number: rule.rule_number,
+        new_number: minRuleNumber + index,
+        rule_data: rule,
+      }));
+
+      await prefixListService.reorderRules(selectedList, selectedListType, rulesWithNewNumbers);
+
+      // Refresh config and reset state
+      await fetchConfig(true);
+    } catch (err) {
+      console.error("Error saving reordered rules:", err);
+      setError(err instanceof Error ? err.message : "Failed to save reordered rules");
+    } finally {
+      setSavingReorder(false);
+    }
+  };
+
+  const handleListSelect = (name: string) => {
+    // Reset reorder state when changing lists
+    if (hasChanges) {
+      setHasChanges(false);
+      setReorderedRules([]);
+      setOriginalRules([]);
+    }
+    setSelectedList(name);
+    setRuleSearchQuery("");
+  };
+
+  const handleTabChange = (value: string) => {
+    const newType = value as "ipv4" | "ipv6";
+    setSelectedListType(newType);
+
+    // Reset reorder state
+    setHasChanges(false);
+    setReorderedRules([]);
+    setOriginalRules([]);
+
+    // Select first list of new type
+    const lists = newType === "ipv4" ? config?.ipv4_lists || [] : config?.ipv6_lists || [];
+    if (lists.length > 0) {
+      setSelectedList(lists[0].name);
+    } else {
+      setSelectedList(null);
+    }
+    setSearchQuery("");
+    setRuleSearchQuery("");
+  };
+
+  const handleDeleteList = (list: PrefixList) => {
+    setDeletingList(list);
+  };
+
+  const handleListDeleted = () => {
+    // If deleted list was selected, select another one
+    if (selectedList === deletingList?.name) {
+      const remaining = currentLists.filter((list) => list.name !== deletingList?.name);
+      setSelectedList(remaining.length > 0 ? remaining[0].name : null);
+    }
+    fetchConfig(true);
+  };
+
+  const ruleIds = filteredRules.map((r) => r.rule_number);
+
+  if (loading) {
+    return (
+      <AppLayout>
+        <div className="flex items-center justify-center h-full">
+          <LoadingSpinner />
+        </div>
+      </AppLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <AppLayout>
+        <div className="flex items-center justify-center h-full">
+          <div className="text-center space-y-4">
+            <AlertCircle className="h-12 w-12 text-destructive mx-auto" />
+            <h2 className="text-xl font-semibold text-foreground">Error Loading Prefix Lists</h2>
+            <p className="text-muted-foreground max-w-md">{error}</p>
+            <Button onClick={() => fetchConfig(true)} variant="outline">
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Retry
+            </Button>
+          </div>
+        </div>
+      </AppLayout>
+    );
+  }
+
   return (
     <AppLayout>
-      <InProgress />
+      <div className="flex h-full">
+        {/* Left Sidebar - Prefix List List */}
+        <div className="w-80 border-r border-border bg-card/50 flex flex-col">
+          <div className="p-6 pb-4 shrink-0">
+            <div className="flex items-center gap-3 mb-6">
+              <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                <ListFilter className="h-5 w-5 text-primary" />
+              </div>
+              <div>
+                <h1 className="text-lg font-semibold text-foreground">Prefix Lists</h1>
+                <p className="text-xs text-muted-foreground">
+                  {config?.total_ipv4 || 0} IPv4 · {config?.total_ipv6 || 0} IPv6
+                </p>
+              </div>
+            </div>
+
+            {/* Tabs for IPv4/IPv6 */}
+            <Tabs value={selectedListType} onValueChange={handleTabChange} className="mb-4">
+              <TabsList className="grid w-full grid-cols-2">
+                <TabsTrigger value="ipv4">IPv4</TabsTrigger>
+                <TabsTrigger value="ipv6">IPv6</TabsTrigger>
+              </TabsList>
+            </Tabs>
+
+            {/* Search Lists */}
+            <div className="relative mb-4">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Search lists..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+
+            <Button
+              onClick={() => setCreateModalOpen(true)}
+              className="w-full"
+              size="sm"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Create Prefix List
+            </Button>
+          </div>
+
+          <Separator className="shrink-0" />
+
+          {/* Prefix List List */}
+          <ScrollArea className="flex-1 px-3 min-h-0">
+            <div className="space-y-1 py-3">
+              {filteredLists.length === 0 ? (
+                <div className="px-2 py-8 text-center">
+                  <p className="text-sm text-muted-foreground">
+                    {searchQuery ? "No lists match your search" : "No prefix lists configured"}
+                  </p>
+                  {!searchQuery && (
+                    <Button
+                      variant="link"
+                      size="sm"
+                      onClick={() => setCreateModalOpen(true)}
+                      className="mt-2"
+                    >
+                      Create your first prefix list
+                    </Button>
+                  )}
+                </div>
+              ) : (
+                filteredLists.map((list) => (
+                  <div
+                    key={list.name}
+                    className={cn(
+                      "group relative rounded-lg transition-all",
+                      selectedList === list.name
+                        ? "bg-accent text-accent-foreground shadow-sm"
+                        : "hover:bg-accent/50"
+                    )}
+                  >
+                    <button
+                      onClick={() => handleListSelect(list.name)}
+                      className="w-full text-left px-3 py-2.5 pr-10"
+                    >
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="font-medium text-sm font-mono truncate">
+                          {list.name}
+                        </span>
+                        <Badge variant="secondary" className="ml-2 shrink-0">
+                          {list.rules.length}
+                        </Badge>
+                      </div>
+                      {list.description && (
+                        <p className="text-xs text-muted-foreground truncate">
+                          {list.description}
+                        </p>
+                      )}
+                    </button>
+                    <div className="absolute right-2 top-2.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDeleteList(list);
+                        }}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+
+        {/* Main Content Area - Rules Table */}
+        <div className="flex-1 flex flex-col">
+          {selectedListData ? (
+            <>
+              {/* Header */}
+              <div className="p-6 pb-4 border-b border-border">
+                <div className="flex items-center justify-between mb-4">
+                  <div>
+                    <div className="flex items-center gap-3">
+                      <h2 className="text-2xl font-bold text-foreground font-mono">
+                        {selectedListData.name}
+                      </h2>
+                      <Badge variant="outline">
+                        {selectedListType.toUpperCase()}
+                      </Badge>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setEditingList(selectedListData)}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    {selectedListData.description && (
+                      <p className="text-sm text-muted-foreground mt-1">
+                        {selectedListData.description}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Button onClick={() => fetchConfig(true)} variant="outline" size="sm">
+                      <RefreshCw className="h-4 w-4 mr-2" />
+                      Refresh
+                    </Button>
+                    <Button onClick={() => setAddRuleModalOpen(true)} size="sm">
+                      <Plus className="h-4 w-4 mr-2" />
+                      Add Rule
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Search Rules */}
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    placeholder="Search rules..."
+                    value={ruleSearchQuery}
+                    onChange={(e) => setRuleSearchQuery(e.target.value)}
+                    className="pl-10"
+                  />
+                </div>
+              </div>
+
+              {/* Reorder Banner */}
+              {hasChanges && (
+                <PrefixListReorderBanner
+                  onSave={handleSaveReorder}
+                  onCancel={handleCancelReorder}
+                  saving={savingReorder}
+                  count={reorderedRules.length}
+                />
+              )}
+
+              {/* Rules Table */}
+              <div className="flex-1 p-6 pt-4 overflow-hidden">
+                {filteredRules.length === 0 ? (
+                  <Card>
+                    <CardContent className="flex flex-col items-center justify-center py-12">
+                      <ListFilter className="h-12 w-12 text-muted-foreground mb-4" />
+                      <h3 className="text-lg font-semibold text-foreground mb-2">
+                        {ruleSearchQuery ? "No Rules Match Search" : "No Rules Configured"}
+                      </h3>
+                      <p className="text-sm text-muted-foreground mb-4 text-center max-w-sm">
+                        {ruleSearchQuery
+                          ? "Try adjusting your search criteria"
+                          : "Add rules to this prefix list to control route filtering"}
+                      </p>
+                      {!ruleSearchQuery && (
+                        <Button onClick={() => setAddRuleModalOpen(true)}>
+                          <Plus className="h-4 w-4 mr-2" />
+                          Add First Rule
+                        </Button>
+                      )}
+                    </CardContent>
+                  </Card>
+                ) : (
+                  <Card>
+                    <ScrollArea className="h-[calc(100vh-350px)]">
+                      <DndContext
+                        sensors={sensors}
+                        collisionDetection={closestCenter}
+                        onDragStart={handleDragStart}
+                        onDragEnd={handleDragEnd}
+                      >
+                        <Table>
+                          <TableHeader>
+                            <TableRow className="hover:bg-transparent">
+                              <TableHead className="w-12"></TableHead>
+                              <TableHead>Rule</TableHead>
+                              <TableHead>Action</TableHead>
+                              <TableHead>Description</TableHead>
+                              <TableHead>Prefix</TableHead>
+                              <TableHead>GE</TableHead>
+                              <TableHead>LE</TableHead>
+                              <TableHead className="text-right">Actions</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            <SortableContext
+                              items={ruleIds}
+                              strategy={verticalListSortingStrategy}
+                            >
+                              {filteredRules.map((rule) => (
+                                <PrefixListRuleRow
+                                  key={rule.rule_number}
+                                  rule={rule}
+                                  onEdit={setEditingRule}
+                                  onDelete={setDeletingRule}
+                                />
+                              ))}
+                            </SortableContext>
+                          </TableBody>
+                        </Table>
+                      </DndContext>
+                    </ScrollArea>
+                  </Card>
+                )}
+              </div>
+            </>
+          ) : (
+            <div className="flex-1 flex items-center justify-center">
+              <div className="text-center space-y-4">
+                <ListFilter className="h-16 w-16 text-muted-foreground mx-auto" />
+                <h2 className="text-xl font-semibold text-foreground">
+                  No Prefix List Selected
+                </h2>
+                <p className="text-muted-foreground max-w-md">
+                  {currentLists.length === 0
+                    ? "Create a prefix list to get started"
+                    : "Select a prefix list from the sidebar to view its rules"}
+                </p>
+                {currentLists.length === 0 && (
+                  <Button onClick={() => setCreateModalOpen(true)}>
+                    <Plus className="h-4 w-4 mr-2" />
+                    Create Prefix List
+                  </Button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Modals */}
+      <CreatePrefixListModal
+        open={createModalOpen}
+        onOpenChange={setCreateModalOpen}
+        onSuccess={() => fetchConfig(true)}
+        listType={selectedListType}
+        capabilities={capabilities}
+      />
+
+      <EditPrefixListModal
+        open={editingList !== null}
+        onOpenChange={(open) => !open && setEditingList(null)}
+        onSuccess={() => fetchConfig(true)}
+        prefixList={editingList}
+      />
+
+      <DeletePrefixListModal
+        open={deletingList !== null}
+        onOpenChange={(open) => !open && setDeletingList(null)}
+        onSuccess={handleListDeleted}
+        prefixList={deletingList}
+      />
+
+      {selectedListData && (
+        <>
+          <AddPrefixListRuleModal
+            open={addRuleModalOpen}
+            onOpenChange={setAddRuleModalOpen}
+            onSuccess={() => fetchConfig(true)}
+            prefixList={selectedListData}
+          />
+
+          <EditPrefixListRuleModal
+            open={editingRule !== null}
+            onOpenChange={(open) => !open && setEditingRule(null)}
+            onSuccess={() => fetchConfig(true)}
+            rule={editingRule}
+            listName={selectedList}
+            listType={selectedListType}
+          />
+
+          <DeletePrefixListRuleModal
+            open={deletingRule !== null}
+            onOpenChange={(open) => !open && setDeletingRule(null)}
+            onSuccess={() => fetchConfig(true)}
+            rule={deletingRule}
+            listName={selectedList}
+            listType={selectedListType}
+          />
+        </>
+      )}
     </AppLayout>
   );
 }

--- a/frontend/src/components/policies/AddPrefixListRuleModal.tsx
+++ b/frontend/src/components/policies/AddPrefixListRuleModal.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { AlertCircle } from "lucide-react";
+import { prefixListService, type PrefixList } from "@/lib/api/prefix-list";
+
+interface AddPrefixListRuleModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  prefixList: PrefixList | null;
+}
+
+export function AddPrefixListRuleModal({
+  open,
+  onOpenChange,
+  onSuccess,
+  prefixList,
+}: AddPrefixListRuleModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Form fields
+  const [ruleNumber, setRuleNumber] = useState(100);
+  const [action, setAction] = useState<"permit" | "deny">("permit");
+  const [ruleDescription, setRuleDescription] = useState("");
+  const [prefix, setPrefix] = useState("");
+  const [ge, setGe] = useState("");
+  const [le, setLe] = useState("");
+
+  useEffect(() => {
+    if (open && prefixList) {
+      // Calculate next rule number
+      const ruleNumbers = prefixList.rules.map(r => r.rule_number);
+      if (ruleNumbers.length === 0) {
+        setRuleNumber(100);
+      } else {
+        setRuleNumber(Math.max(...ruleNumbers) + 1);
+      }
+    }
+  }, [open, prefixList]);
+
+  const resetForm = () => {
+    setRuleNumber(100);
+    setAction("permit");
+    setRuleDescription("");
+    setPrefix("");
+    setGe("");
+    setLe("");
+  };
+
+  const handleClose = () => {
+    setError(null);
+    resetForm();
+    onOpenChange(false);
+  };
+
+  // Validate CIDR notation
+  const validateCIDR = (cidr: string): boolean => {
+    if (!cidr) return false;
+
+    const parts = cidr.split('/');
+    if (parts.length !== 2) return false;
+
+    const [ip, prefixLen] = parts;
+    const prefixLength = parseInt(prefixLen, 10);
+
+    if (!prefixList) return false;
+
+    if (prefixList.list_type === "ipv4") {
+      // IPv4 validation
+      const ipParts = ip.split('.');
+      if (ipParts.length !== 4) return false;
+      if (!ipParts.every(part => {
+        const num = parseInt(part, 10);
+        return num >= 0 && num <= 255;
+      })) return false;
+      if (isNaN(prefixLength) || prefixLength < 0 || prefixLength > 32) return false;
+    } else {
+      // IPv6 validation (basic)
+      if (isNaN(prefixLength) || prefixLength < 0 || prefixLength > 128) return false;
+    }
+
+    return true;
+  };
+
+  const handleSubmit = async () => {
+    if (!prefixList) return;
+
+    // Validation
+    if (!prefix.trim()) {
+      setError("Please enter a prefix in CIDR notation");
+      return;
+    }
+
+    if (!validateCIDR(prefix)) {
+      setError(`Invalid ${prefixList.list_type.toUpperCase()} CIDR notation. Format: ${prefixList.list_type === "ipv4" ? "192.168.1.0/24" : "2001:db8::/32"}`);
+      return;
+    }
+
+    // Validate ge/le if provided
+    if (ge && isNaN(parseInt(ge, 10))) {
+      setError("GE must be a valid number");
+      return;
+    }
+
+    if (le && isNaN(parseInt(le, 10))) {
+      setError("LE must be a valid number");
+      return;
+    }
+
+    // Get prefix length from CIDR
+    const prefixLength = parseInt(prefix.split('/')[1], 10);
+    const maxLength = prefixList.list_type === "ipv4" ? 32 : 128;
+
+    if (ge) {
+      const geNum = parseInt(ge, 10);
+      if (geNum < prefixLength || geNum > maxLength) {
+        setError(`GE must be between ${prefixLength} (prefix length) and ${maxLength}`);
+        return;
+      }
+    }
+
+    if (le) {
+      const leNum = parseInt(le, 10);
+      if (leNum < prefixLength || leNum > maxLength) {
+        setError(`LE must be between ${prefixLength} (prefix length) and ${maxLength}`);
+        return;
+      }
+    }
+
+    if (ge && le) {
+      const geNum = parseInt(ge, 10);
+      const leNum = parseInt(le, 10);
+      if (geNum > leNum) {
+        setError("GE must be less than or equal to LE");
+        return;
+      }
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const newRule: any = {
+        rule_number: ruleNumber,
+        action,
+        description: ruleDescription || null,
+        prefix: prefix.trim(),
+        ge: ge ? parseInt(ge, 10) : null,
+        le: le ? parseInt(le, 10) : null,
+      };
+
+      await prefixListService.addRule(
+        prefixList.name,
+        prefixList.list_type,
+        newRule
+      );
+      handleClose();
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add rule");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!prefixList) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Add Rule to {prefixList.name}</DialogTitle>
+          <DialogDescription>
+            Create a new rule for this prefix list
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="rule-number">Rule Number</Label>
+              <Input
+                id="rule-number"
+                type="number"
+                value={ruleNumber}
+                disabled
+                className="bg-muted"
+              />
+              <p className="text-xs text-muted-foreground">Auto-calculated based on existing rules</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="action">Action *</Label>
+              <Select value={action} onValueChange={(v) => setAction(v as "permit" | "deny")} disabled={loading}>
+                <SelectTrigger id="action">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="permit">Permit</SelectItem>
+                  <SelectItem value="deny">Deny</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="rule-description">Rule Description</Label>
+            <Input
+              id="rule-description"
+              value={ruleDescription}
+              onChange={(e) => setRuleDescription(e.target.value)}
+              placeholder="Enter rule description (optional)"
+              disabled={loading}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="prefix">Prefix (CIDR) *</Label>
+            <Input
+              id="prefix"
+              value={prefix}
+              onChange={(e) => setPrefix(e.target.value)}
+              placeholder={prefixList.list_type === "ipv4" ? "e.g., 192.168.1.0/24" : "e.g., 2001:db8::/32"}
+              disabled={loading}
+            />
+            <p className="text-xs text-muted-foreground">
+              Enter prefix in CIDR notation
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="ge">GE (Greater-than-or-equal)</Label>
+              <Input
+                id="ge"
+                type="number"
+                value={ge}
+                onChange={(e) => setGe(e.target.value)}
+                placeholder="Optional"
+                disabled={loading}
+                min={prefix ? parseInt(prefix.split('/')[1] || "0", 10) : 0}
+                max={prefixList.list_type === "ipv4" ? 32 : 128}
+              />
+              <p className="text-xs text-muted-foreground">
+                Minimum prefix length to match
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="le">LE (Less-than-or-equal)</Label>
+              <Input
+                id="le"
+                type="number"
+                value={le}
+                onChange={(e) => setLe(e.target.value)}
+                placeholder="Optional"
+                disabled={loading}
+                min={prefix ? parseInt(prefix.split('/')[1] || "0", 10) : 0}
+                max={prefixList.list_type === "ipv4" ? 32 : 128}
+              />
+              <p className="text-xs text-muted-foreground">
+                Maximum prefix length to match
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-lg bg-blue-500/10 border border-blue-500/20 p-3">
+            <div className="flex gap-2">
+              <AlertCircle className="h-5 w-5 text-blue-500 shrink-0 mt-0.5" />
+              <div className="text-sm text-muted-foreground">
+                <p className="font-medium text-foreground mb-1">About GE/LE</p>
+                <ul className="space-y-1 text-xs">
+                  <li>• GE specifies the minimum prefix length to match</li>
+                  <li>• LE specifies the maximum prefix length to match</li>
+                  <li>• Both are optional and refine the prefix match</li>
+                  <li>• Example: 10.0.0.0/8 ge 16 le 24 matches 10.x.y.0/16 through 10.x.y.z/24</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {error && (
+          <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3 flex items-start gap-2">
+            <AlertCircle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={loading}>
+            {loading ? "Adding..." : "Add Rule"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/policies/CreatePrefixListModal.tsx
+++ b/frontend/src/components/policies/CreatePrefixListModal.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { AlertCircle } from "lucide-react";
+import { prefixListService, type PrefixListCapabilitiesResponse } from "@/lib/api/prefix-list";
+
+interface CreatePrefixListModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  listType: "ipv4" | "ipv6";
+  capabilities: PrefixListCapabilitiesResponse | null;
+}
+
+export function CreatePrefixListModal({ open, onOpenChange, onSuccess, listType, capabilities }: CreatePrefixListModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState("basic");
+
+  // Basic tab
+  const [listName, setListName] = useState("");
+  const [listDescription, setListDescription] = useState("");
+
+  // First rule tab
+  const [ruleNumber, setRuleNumber] = useState(100);
+  const [action, setAction] = useState<"permit" | "deny">("permit");
+  const [ruleDescription, setRuleDescription] = useState("");
+  const [prefix, setPrefix] = useState("");
+  const [ge, setGe] = useState("");
+  const [le, setLe] = useState("");
+
+  const resetForm = () => {
+    setListName("");
+    setListDescription("");
+    setRuleNumber(100);
+    setAction("permit");
+    setRuleDescription("");
+    setPrefix("");
+    setGe("");
+    setLe("");
+    setActiveTab("basic");
+  };
+
+  const handleClose = () => {
+    setError(null);
+    resetForm();
+    onOpenChange(false);
+  };
+
+  // Validate CIDR notation
+  const validateCIDR = (cidr: string): boolean => {
+    if (!cidr) return false;
+
+    const parts = cidr.split('/');
+    if (parts.length !== 2) return false;
+
+    const [ip, prefixLen] = parts;
+    const prefixLength = parseInt(prefixLen, 10);
+
+    if (listType === "ipv4") {
+      // IPv4 validation
+      const ipParts = ip.split('.');
+      if (ipParts.length !== 4) return false;
+      if (!ipParts.every(part => {
+        const num = parseInt(part, 10);
+        return num >= 0 && num <= 255;
+      })) return false;
+      if (isNaN(prefixLength) || prefixLength < 0 || prefixLength > 32) return false;
+    } else {
+      // IPv6 validation (basic)
+      if (isNaN(prefixLength) || prefixLength < 0 || prefixLength > 128) return false;
+      // More detailed IPv6 validation could be added here
+    }
+
+    return true;
+  };
+
+  const handleSubmit = async () => {
+    // Validation
+    if (!listName.trim()) {
+      setError("Please enter a prefix list name");
+      setActiveTab("basic");
+      return;
+    }
+
+    if (!prefix.trim()) {
+      setError("Please enter a prefix in CIDR notation");
+      setActiveTab("rule");
+      return;
+    }
+
+    if (!validateCIDR(prefix)) {
+      setError(`Invalid ${listType.toUpperCase()} CIDR notation. Format: ${listType === "ipv4" ? "192.168.1.0/24" : "2001:db8::/32"}`);
+      setActiveTab("rule");
+      return;
+    }
+
+    // Validate ge/le if provided
+    if (ge && isNaN(parseInt(ge, 10))) {
+      setError("GE must be a valid number");
+      setActiveTab("rule");
+      return;
+    }
+
+    if (le && isNaN(parseInt(le, 10))) {
+      setError("LE must be a valid number");
+      setActiveTab("rule");
+      return;
+    }
+
+    // Get prefix length from CIDR
+    const prefixLength = parseInt(prefix.split('/')[1], 10);
+    const maxLength = listType === "ipv4" ? 32 : 128;
+
+    if (ge) {
+      const geNum = parseInt(ge, 10);
+      if (geNum < prefixLength || geNum > maxLength) {
+        setError(`GE must be between ${prefixLength} (prefix length) and ${maxLength}`);
+        setActiveTab("rule");
+        return;
+      }
+    }
+
+    if (le) {
+      const leNum = parseInt(le, 10);
+      if (leNum < prefixLength || leNum > maxLength) {
+        setError(`LE must be between ${prefixLength} (prefix length) and ${maxLength}`);
+        setActiveTab("rule");
+        return;
+      }
+    }
+
+    if (ge && le) {
+      const geNum = parseInt(ge, 10);
+      const leNum = parseInt(le, 10);
+      if (geNum > leNum) {
+        setError("GE must be less than or equal to LE");
+        setActiveTab("rule");
+        return;
+      }
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      // Build first rule
+      const firstRule: any = {
+        rule_number: ruleNumber,
+        action,
+        description: ruleDescription || null,
+        prefix: prefix.trim(),
+        ge: ge ? parseInt(ge, 10) : null,
+        le: le ? parseInt(le, 10) : null,
+      };
+
+      await prefixListService.createPrefixList(
+        listName.trim(),
+        listType,
+        listDescription || null,
+        firstRule
+      );
+      handleClose();
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create prefix list");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Create {listType.toUpperCase()} Prefix List</DialogTitle>
+          <DialogDescription>
+            Create a new prefix list with the first rule
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="basic">Basic</TabsTrigger>
+            <TabsTrigger value="rule">First Rule</TabsTrigger>
+          </TabsList>
+
+          {/* Basic Tab */}
+          <TabsContent value="basic" className="space-y-4 mt-4">
+            <div className="space-y-2">
+              <Label htmlFor="list-name">Prefix List Name *</Label>
+              <Input
+                id="list-name"
+                value={listName}
+                onChange={(e) => setListName(e.target.value)}
+                placeholder="e.g., MY-PREFIXES"
+                disabled={loading}
+              />
+              <p className="text-xs text-muted-foreground">
+                Enter a unique name for the prefix list
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="list-description">Description</Label>
+              <Input
+                id="list-description"
+                value={listDescription}
+                onChange={(e) => setListDescription(e.target.value)}
+                placeholder="Enter prefix list description (optional)"
+                disabled={loading}
+              />
+            </div>
+          </TabsContent>
+
+          {/* First Rule Tab */}
+          <TabsContent value="rule" className="space-y-4 mt-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="rule-number">Rule Number</Label>
+                <Input
+                  id="rule-number"
+                  type="number"
+                  value={ruleNumber}
+                  disabled
+                  className="bg-muted"
+                />
+                <p className="text-xs text-muted-foreground">Starting at 100</p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="action">Action *</Label>
+                <Select value={action} onValueChange={(v) => setAction(v as "permit" | "deny")} disabled={loading}>
+                  <SelectTrigger id="action">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="permit">Permit</SelectItem>
+                    <SelectItem value="deny">Deny</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="rule-description">Rule Description</Label>
+              <Input
+                id="rule-description"
+                value={ruleDescription}
+                onChange={(e) => setRuleDescription(e.target.value)}
+                placeholder="Enter rule description (optional)"
+                disabled={loading}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="prefix">Prefix (CIDR) *</Label>
+              <Input
+                id="prefix"
+                value={prefix}
+                onChange={(e) => setPrefix(e.target.value)}
+                placeholder={listType === "ipv4" ? "e.g., 192.168.1.0/24" : "e.g., 2001:db8::/32"}
+                disabled={loading}
+              />
+              <p className="text-xs text-muted-foreground">
+                Enter prefix in CIDR notation
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="ge">GE (Greater-than-or-equal)</Label>
+                <Input
+                  id="ge"
+                  type="number"
+                  value={ge}
+                  onChange={(e) => setGe(e.target.value)}
+                  placeholder="Optional"
+                  disabled={loading}
+                  min={prefix ? parseInt(prefix.split('/')[1] || "0", 10) : 0}
+                  max={listType === "ipv4" ? 32 : 128}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Minimum prefix length to match
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="le">LE (Less-than-or-equal)</Label>
+                <Input
+                  id="le"
+                  type="number"
+                  value={le}
+                  onChange={(e) => setLe(e.target.value)}
+                  placeholder="Optional"
+                  disabled={loading}
+                  min={prefix ? parseInt(prefix.split('/')[1] || "0", 10) : 0}
+                  max={listType === "ipv4" ? 32 : 128}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Maximum prefix length to match
+                </p>
+              </div>
+            </div>
+
+            <div className="rounded-lg bg-blue-500/10 border border-blue-500/20 p-3">
+              <div className="flex gap-2">
+                <AlertCircle className="h-5 w-5 text-blue-500 shrink-0 mt-0.5" />
+                <div className="text-sm text-muted-foreground">
+                  <p className="font-medium text-foreground mb-1">About GE/LE</p>
+                  <ul className="space-y-1 text-xs">
+                    <li>• GE specifies the minimum prefix length to match</li>
+                    <li>• LE specifies the maximum prefix length to match</li>
+                    <li>• Both are optional and refine the prefix match</li>
+                    <li>• Example: 10.0.0.0/8 ge 16 le 24 matches 10.x.y.0/16 through 10.x.y.z/24</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </TabsContent>
+        </Tabs>
+
+        {error && (
+          <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3 flex items-start gap-2">
+            <AlertCircle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={loading}>
+            {loading ? "Creating..." : "Create Prefix List"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/policies/DeletePrefixListModal.tsx
+++ b/frontend/src/components/policies/DeletePrefixListModal.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { AlertCircle, ListFilter } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { prefixListService, type PrefixList } from "@/lib/api/prefix-list";
+
+interface DeletePrefixListModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  prefixList: PrefixList | null;
+}
+
+export function DeletePrefixListModal({ open, onOpenChange, onSuccess, prefixList }: DeletePrefixListModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClose = () => {
+    setError(null);
+    onOpenChange(false);
+  };
+
+  const handleDelete = async () => {
+    if (!prefixList) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await prefixListService.deletePrefixList(prefixList.name, prefixList.list_type);
+      handleClose();
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete prefix list");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!prefixList) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Delete Prefix List</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete this prefix list? This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Prefix List Details */}
+        <div className="space-y-4 py-4">
+          <div className="border rounded-lg p-4 space-y-3">
+            <div className="flex items-start justify-between">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <ListFilter className="h-4 w-4 text-muted-foreground" />
+                  <span className="font-mono text-sm font-medium">{prefixList.name}</span>
+                  <Badge variant="outline">
+                    {prefixList.list_type.toUpperCase()}
+                  </Badge>
+                  <Badge variant="secondary">
+                    {prefixList.rules.length} rule{prefixList.rules.length !== 1 ? "s" : ""}
+                  </Badge>
+                </div>
+                {prefixList.description && (
+                  <p className="text-sm text-muted-foreground pl-6">{prefixList.description}</p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Warning */}
+          <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-4 flex items-start gap-3">
+            <AlertCircle className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-destructive">
+                This will permanently delete the prefix list and all its rules
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Any route filtering configured with this prefix list will be affected.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {error && (
+          <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3 flex items-start gap-3">
+            <AlertCircle className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={loading}>
+            {loading ? "Deleting..." : "Delete Prefix List"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/policies/DeletePrefixListRuleModal.tsx
+++ b/frontend/src/components/policies/DeletePrefixListRuleModal.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { AlertCircle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { prefixListService, type PrefixListRule } from "@/lib/api/prefix-list";
+
+interface DeletePrefixListRuleModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  rule: PrefixListRule | null;
+  listName: string | null;
+  listType: string;
+}
+
+export function DeletePrefixListRuleModal({
+  open,
+  onOpenChange,
+  onSuccess,
+  rule,
+  listName,
+  listType,
+}: DeletePrefixListRuleModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClose = () => {
+    setError(null);
+    onOpenChange(false);
+  };
+
+  const handleDelete = async () => {
+    if (!rule || !listName) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await prefixListService.deleteRule(listName, listType, rule.rule_number);
+      handleClose();
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete rule");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!rule) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Delete Prefix List Rule</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete this rule? This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Rule Details */}
+        <div className="space-y-4 py-4">
+          <div className="border rounded-lg p-4 space-y-3">
+            <div className="flex items-start justify-between">
+              <div className="space-y-2 flex-1">
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline" className="font-mono">
+                    Rule {rule.rule_number}
+                  </Badge>
+                  <Badge
+                    variant="outline"
+                    className={
+                      rule.action === "permit"
+                        ? "capitalize bg-green-500/10 text-green-500 border-green-500/20"
+                        : "capitalize bg-red-500/10 text-red-500 border-red-500/20"
+                    }
+                  >
+                    {rule.action}
+                  </Badge>
+                </div>
+                {rule.description && (
+                  <p className="text-sm text-muted-foreground">{rule.description}</p>
+                )}
+                <div className="space-y-1 text-sm">
+                  <div className="flex gap-2">
+                    <span className="text-muted-foreground min-w-24">Prefix:</span>
+                    <span className="font-mono">{rule.prefix || "—"}</span>
+                  </div>
+                  {(rule.ge !== null && rule.ge !== undefined) && (
+                    <div className="flex gap-2">
+                      <span className="text-muted-foreground min-w-24">GE:</span>
+                      <span className="font-mono">{rule.ge}</span>
+                    </div>
+                  )}
+                  {(rule.le !== null && rule.le !== undefined) && (
+                    <div className="flex gap-2">
+                      <span className="text-muted-foreground min-w-24">LE:</span>
+                      <span className="font-mono">{rule.le}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Warning */}
+          <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-4 flex items-start gap-3">
+            <AlertCircle className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-destructive">
+                This will permanently delete the rule
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Route filtering configured in this rule will be removed.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {error && (
+          <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3 flex items-start gap-3">
+            <AlertCircle className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={loading}>
+            {loading ? "Deleting..." : "Delete Rule"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/policies/EditPrefixListModal.tsx
+++ b/frontend/src/components/policies/EditPrefixListModal.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { AlertCircle, ListFilter } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { prefixListService, type PrefixList } from "@/lib/api/prefix-list";
+
+interface EditPrefixListModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  prefixList: PrefixList | null;
+}
+
+export function EditPrefixListModal({ open, onOpenChange, onSuccess, prefixList }: EditPrefixListModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    if (open && prefixList) {
+      setDescription(prefixList.description || "");
+    }
+  }, [open, prefixList]);
+
+  const handleClose = () => {
+    setError(null);
+    setDescription("");
+    onOpenChange(false);
+  };
+
+  const handleSubmit = async () => {
+    if (!prefixList) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await prefixListService.updatePrefixListDescription(
+        prefixList.name,
+        prefixList.list_type,
+        description || null
+      );
+      handleClose();
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update prefix list");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!prefixList) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Edit Prefix List</DialogTitle>
+          <DialogDescription>
+            Update the description for this prefix list
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Prefix List Details */}
+        <div className="space-y-4 py-4">
+          <div className="border rounded-lg p-4 space-y-3">
+            <div className="flex items-center gap-2">
+              <ListFilter className="h-4 w-4 text-muted-foreground" />
+              <span className="font-mono text-sm font-medium">{prefixList.name}</span>
+              <Badge variant="outline">
+                {prefixList.list_type.toUpperCase()}
+              </Badge>
+              <Badge variant="secondary">
+                {prefixList.rules.length} rule{prefixList.rules.length !== 1 ? "s" : ""}
+              </Badge>
+            </div>
+          </div>
+
+          {/* Description Field */}
+          <div className="space-y-2">
+            <Label htmlFor="description">Description</Label>
+            <Input
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Enter prefix list description (optional)"
+              disabled={loading}
+            />
+            <p className="text-xs text-muted-foreground">
+              Leave empty to remove the description
+            </p>
+          </div>
+        </div>
+
+        {error && (
+          <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3 flex items-start gap-3">
+            <AlertCircle className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={loading}>
+            {loading ? "Updating..." : "Update Prefix List"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/policies/EditPrefixListRuleModal.tsx
+++ b/frontend/src/components/policies/EditPrefixListRuleModal.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { AlertCircle } from "lucide-react";
+import { prefixListService, type PrefixListRule } from "@/lib/api/prefix-list";
+
+interface EditPrefixListRuleModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  rule: PrefixListRule | null;
+  listName: string | null;
+  listType: "ipv4" | "ipv6";
+}
+
+export function EditPrefixListRuleModal({
+  open,
+  onOpenChange,
+  onSuccess,
+  rule,
+  listName,
+  listType,
+}: EditPrefixListRuleModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Form fields
+  const [action, setAction] = useState<"permit" | "deny">("permit");
+  const [ruleDescription, setRuleDescription] = useState("");
+  const [prefix, setPrefix] = useState("");
+  const [ge, setGe] = useState("");
+  const [le, setLe] = useState("");
+
+  useEffect(() => {
+    if (open && rule) {
+      // Pre-populate form with existing rule data
+      setAction(rule.action as "permit" | "deny");
+      setRuleDescription(rule.description || "");
+      setPrefix(rule.prefix || "");
+      setGe(rule.ge !== null && rule.ge !== undefined ? rule.ge.toString() : "");
+      setLe(rule.le !== null && rule.le !== undefined ? rule.le.toString() : "");
+    }
+  }, [open, rule]);
+
+  const resetForm = () => {
+    setAction("permit");
+    setRuleDescription("");
+    setPrefix("");
+    setGe("");
+    setLe("");
+  };
+
+  const handleClose = () => {
+    setError(null);
+    resetForm();
+    onOpenChange(false);
+  };
+
+  // Validate CIDR notation
+  const validateCIDR = (cidr: string): boolean => {
+    if (!cidr) return false;
+
+    const parts = cidr.split('/');
+    if (parts.length !== 2) return false;
+
+    const [ip, prefixLen] = parts;
+    const prefixLength = parseInt(prefixLen, 10);
+
+    if (listType === "ipv4") {
+      // IPv4 validation
+      const ipParts = ip.split('.');
+      if (ipParts.length !== 4) return false;
+      if (!ipParts.every(part => {
+        const num = parseInt(part, 10);
+        return num >= 0 && num <= 255;
+      })) return false;
+      if (isNaN(prefixLength) || prefixLength < 0 || prefixLength > 32) return false;
+    } else {
+      // IPv6 validation (basic)
+      if (isNaN(prefixLength) || prefixLength < 0 || prefixLength > 128) return false;
+    }
+
+    return true;
+  };
+
+  const handleSubmit = async () => {
+    if (!rule || !listName) return;
+
+    // Validation
+    if (!prefix.trim()) {
+      setError("Please enter a prefix in CIDR notation");
+      return;
+    }
+
+    if (!validateCIDR(prefix)) {
+      setError(`Invalid ${listType.toUpperCase()} CIDR notation. Format: ${listType === "ipv4" ? "192.168.1.0/24" : "2001:db8::/32"}`);
+      return;
+    }
+
+    // Validate ge/le if provided
+    if (ge && isNaN(parseInt(ge, 10))) {
+      setError("GE must be a valid number");
+      return;
+    }
+
+    if (le && isNaN(parseInt(le, 10))) {
+      setError("LE must be a valid number");
+      return;
+    }
+
+    // Get prefix length from CIDR
+    const prefixLength = parseInt(prefix.split('/')[1], 10);
+    const maxLength = listType === "ipv4" ? 32 : 128;
+
+    if (ge) {
+      const geNum = parseInt(ge, 10);
+      if (geNum < prefixLength || geNum > maxLength) {
+        setError(`GE must be between ${prefixLength} (prefix length) and ${maxLength}`);
+        return;
+      }
+    }
+
+    if (le) {
+      const leNum = parseInt(le, 10);
+      if (leNum < prefixLength || leNum > maxLength) {
+        setError(`LE must be between ${prefixLength} (prefix length) and ${maxLength}`);
+        return;
+      }
+    }
+
+    if (ge && le) {
+      const geNum = parseInt(ge, 10);
+      const leNum = parseInt(le, 10);
+      if (geNum > leNum) {
+        setError("GE must be less than or equal to LE");
+        return;
+      }
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const updatedRule: any = {
+        action,
+        description: ruleDescription || null,
+        prefix: prefix.trim(),
+        ge: ge ? parseInt(ge, 10) : null,
+        le: le ? parseInt(le, 10) : null,
+      };
+
+      await prefixListService.updateRule(
+        listName,
+        listType,
+        rule.rule_number,
+        updatedRule
+      );
+      handleClose();
+      onSuccess();
+    } catch (err: any) {
+      console.error("Update rule error:", err);
+      let errorMsg = "Failed to update rule";
+      if (err.details?.detail) {
+        if (Array.isArray(err.details.detail)) {
+          errorMsg = err.details.detail.map((e: any) => `${e.loc?.join('.')}: ${e.msg}`).join(", ");
+        } else {
+          errorMsg = err.details.detail;
+        }
+      } else if (err.message) {
+        errorMsg = err.message;
+      }
+      setError(errorMsg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!rule) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Edit Rule {rule.rule_number}</DialogTitle>
+          <DialogDescription>
+            Update this rule's configuration
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="rule-number">Rule Number</Label>
+              <Input
+                id="rule-number"
+                type="number"
+                value={rule.rule_number}
+                disabled
+                className="bg-muted"
+              />
+              <p className="text-xs text-muted-foreground">Rule number cannot be changed</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="action">Action *</Label>
+              <Select value={action} onValueChange={(v) => setAction(v as "permit" | "deny")} disabled={loading}>
+                <SelectTrigger id="action">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="permit">Permit</SelectItem>
+                  <SelectItem value="deny">Deny</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="rule-description">Rule Description</Label>
+            <Input
+              id="rule-description"
+              value={ruleDescription}
+              onChange={(e) => setRuleDescription(e.target.value)}
+              placeholder="Enter rule description (optional)"
+              disabled={loading}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="prefix">Prefix (CIDR) *</Label>
+            <Input
+              id="prefix"
+              value={prefix}
+              onChange={(e) => setPrefix(e.target.value)}
+              placeholder={listType === "ipv4" ? "e.g., 192.168.1.0/24" : "e.g., 2001:db8::/32"}
+              disabled={loading}
+            />
+            <p className="text-xs text-muted-foreground">
+              Enter prefix in CIDR notation
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="ge">GE (Greater-than-or-equal)</Label>
+              <Input
+                id="ge"
+                type="number"
+                value={ge}
+                onChange={(e) => setGe(e.target.value)}
+                placeholder="Optional"
+                disabled={loading}
+                min={prefix ? parseInt(prefix.split('/')[1] || "0", 10) : 0}
+                max={listType === "ipv4" ? 32 : 128}
+              />
+              <p className="text-xs text-muted-foreground">
+                Minimum prefix length to match
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="le">LE (Less-than-or-equal)</Label>
+              <Input
+                id="le"
+                type="number"
+                value={le}
+                onChange={(e) => setLe(e.target.value)}
+                placeholder="Optional"
+                disabled={loading}
+                min={prefix ? parseInt(prefix.split('/')[1] || "0", 10) : 0}
+                max={listType === "ipv4" ? 32 : 128}
+              />
+              <p className="text-xs text-muted-foreground">
+                Maximum prefix length to match
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-lg bg-blue-500/10 border border-blue-500/20 p-3">
+            <div className="flex gap-2">
+              <AlertCircle className="h-5 w-5 text-blue-500 shrink-0 mt-0.5" />
+              <div className="text-sm text-muted-foreground">
+                <p className="font-medium text-foreground mb-1">About GE/LE</p>
+                <ul className="space-y-1 text-xs">
+                  <li>• GE specifies the minimum prefix length to match</li>
+                  <li>• LE specifies the maximum prefix length to match</li>
+                  <li>• Both are optional and refine the prefix match</li>
+                  <li>• Leave empty to remove GE/LE restrictions</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {error && (
+          <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3 flex items-start gap-2">
+            <AlertCircle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={loading}>
+            {loading ? "Updating..." : "Update Rule"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/policies/PrefixListReorderBanner.tsx
+++ b/frontend/src/components/policies/PrefixListReorderBanner.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Check, X, AlertCircle } from "lucide-react";
+
+interface PrefixListReorderBannerProps {
+  onSave: () => void;
+  onCancel: () => void;
+  saving: boolean;
+  count: number;
+}
+
+export function PrefixListReorderBanner({
+  onSave,
+  onCancel,
+  saving,
+  count,
+}: PrefixListReorderBannerProps) {
+  return (
+    <div className="bg-blue-500/10 border-y border-blue-500/20 px-6 py-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <AlertCircle className="h-5 w-5 text-blue-500" />
+          <div>
+            <p className="text-sm font-medium text-foreground">
+              Reorder in Progress
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {count} rule{count !== 1 ? "s" : ""} will be renumbered
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onCancel}
+            disabled={saving}
+          >
+            <X className="h-4 w-4 mr-2" />
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={onSave}
+            disabled={saving}
+            className="bg-blue-500 hover:bg-blue-600"
+          >
+            <Check className="h-4 w-4 mr-2" />
+            {saving ? "Saving..." : "Save Order"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/policies/PrefixListRuleRow.tsx
+++ b/frontend/src/components/policies/PrefixListRuleRow.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, Pencil, Trash2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { TableRow, TableCell } from "@/components/ui/table";
+import type { PrefixListRule } from "@/lib/api/prefix-list";
+
+interface PrefixListRuleRowProps {
+  rule: PrefixListRule;
+  onEdit: (rule: PrefixListRule) => void;
+  onDelete: (rule: PrefixListRule) => void;
+}
+
+export function PrefixListRuleRow({ rule, onEdit, onDelete }: PrefixListRuleRowProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: rule.rule_number });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <TableRow ref={setNodeRef} style={style} className="group">
+      <TableCell>
+        <button
+          {...attributes}
+          {...listeners}
+          className="cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+      </TableCell>
+      <TableCell className="font-mono font-semibold text-base">
+        {rule.rule_number}
+      </TableCell>
+      <TableCell>
+        <Badge
+          variant="outline"
+          className={
+            rule.action === "permit"
+              ? "capitalize bg-green-500/10 text-green-500 border-green-500/20"
+              : "capitalize bg-red-500/10 text-red-500 border-red-500/20"
+          }
+        >
+          {rule.action}
+        </Badge>
+      </TableCell>
+      <TableCell>
+        {rule.description || (
+          <span className="text-muted-foreground text-sm">—</span>
+        )}
+      </TableCell>
+      <TableCell>
+        {rule.prefix ? (
+          <Badge variant="secondary" className="text-xs font-mono">
+            {rule.prefix}
+          </Badge>
+        ) : (
+          <span className="text-muted-foreground text-sm">—</span>
+        )}
+      </TableCell>
+      <TableCell>
+        {rule.ge !== null && rule.ge !== undefined ? (
+          <Badge variant="outline" className="text-xs font-mono">
+            {rule.ge}
+          </Badge>
+        ) : (
+          <span className="text-muted-foreground text-sm">—</span>
+        )}
+      </TableCell>
+      <TableCell>
+        {rule.le !== null && rule.le !== undefined ? (
+          <Badge variant="outline" className="text-xs font-mono">
+            {rule.le}
+          </Badge>
+        ) : (
+          <span className="text-muted-foreground text-sm">—</span>
+        )}
+      </TableCell>
+      <TableCell className="text-right">
+        <div className="flex items-center justify-end gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onEdit(rule)}
+            className="h-8"
+          >
+            <Pencil className="h-4 w-4 mr-1" />
+            Edit
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onDelete(rule)}
+            className="h-8 text-destructive hover:text-destructive"
+          >
+            <Trash2 className="h-4 w-4 mr-1" />
+            Delete
+          </Button>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/frontend/src/lib/api/prefix-list.ts
+++ b/frontend/src/lib/api/prefix-list.ts
@@ -1,0 +1,392 @@
+import { apiClient } from "./client";
+
+// ============================================================================
+// TypeScript Interfaces
+// ============================================================================
+
+export interface PrefixListRule {
+  rule_number: number;
+  action: string;  // permit or deny
+  description?: string | null;
+  prefix?: string | null;  // CIDR notation (e.g., 10.0.0.0/8)
+  ge?: number | null;  // Greater-than-or-equal prefix length
+  le?: number | null;  // Less-than-or-equal prefix length
+}
+
+export interface PrefixList {
+  name: string;
+  description?: string | null;
+  rules: PrefixListRule[];
+  list_type: string;  // ipv4 or ipv6
+}
+
+export interface PrefixListConfigResponse {
+  ipv4_lists: PrefixList[];
+  ipv6_lists: PrefixList[];
+  total_ipv4: number;
+  total_ipv6: number;
+}
+
+export interface PrefixListCapabilitiesResponse {
+  version: string;
+  features: {
+    ipv4_prefix_lists: {
+      supported: boolean;
+      description: string;
+    };
+    ipv6_prefix_lists: {
+      supported: boolean;
+      description: string;
+    };
+    ge_le_operators: {
+      supported: boolean;
+      description: string;
+    };
+    rule_descriptions: {
+      supported: boolean;
+      description: string;
+    };
+  };
+  device_name?: string;
+}
+
+export interface PrefixListBatchOperation {
+  op: string;
+  value?: string;
+}
+
+export interface PrefixListBatchRequest {
+  name: string;
+  list_type: string;  // ipv4 or ipv6
+  rule_number?: number;
+  operations: PrefixListBatchOperation[];
+}
+
+// ============================================================================
+// API Service
+// ============================================================================
+
+class PrefixListService {
+  /**
+   * Get capabilities based on VyOS version
+   */
+  async getCapabilities(): Promise<PrefixListCapabilitiesResponse> {
+    return apiClient.get<PrefixListCapabilitiesResponse>("/vyos/prefix-list/capabilities");
+  }
+
+  /**
+   * Get all prefix-list configurations
+   */
+  async getConfig(refresh: boolean = false): Promise<PrefixListConfigResponse> {
+    return apiClient.get<PrefixListConfigResponse>("/vyos/prefix-list/config", {
+      refresh: refresh.toString(),
+    });
+  }
+
+  /**
+   * Refresh the cached configuration
+   */
+  async refreshConfig(): Promise<any> {
+    return apiClient.post("/vyos/config/refresh");
+  }
+
+  /**
+   * Execute batch operations
+   */
+  async batchConfigure(request: PrefixListBatchRequest): Promise<any> {
+    const result = await apiClient.post("/vyos/prefix-list/batch", request);
+    await this.refreshConfig();
+    return result;
+  }
+
+  /**
+   * Reorder rules in a prefix-list
+   */
+  async reorderRules(
+    name: string,
+    listType: string,
+    rules: Array<{ old_number: number; new_number: number; rule_data: PrefixListRule }>
+  ): Promise<any> {
+    const result = await apiClient.post("/vyos/prefix-list/reorder", {
+      name,
+      list_type: listType,
+      rules,
+    });
+    await this.refreshConfig();
+    return result;
+  }
+
+  /**
+   * Helper: Create a new prefix-list with first rule
+   */
+  async createPrefixList(
+    name: string,
+    listType: string,
+    description: string | null,
+    rule: Partial<PrefixListRule>
+  ): Promise<any> {
+    const operations: PrefixListBatchOperation[] = [];
+
+    // Create prefix-list
+    operations.push({ op: listType === "ipv4" ? "set_prefix_list" : "set_prefix_list6" });
+
+    // Add description if provided
+    if (description) {
+      operations.push({
+        op: listType === "ipv4" ? "set_prefix_list_description" : "set_prefix_list6_description",
+        value: description
+      });
+    }
+
+    // Create rule
+    operations.push({ op: listType === "ipv4" ? "set_rule" : "set_rule6" });
+
+    // Set rule action
+    operations.push({
+      op: listType === "ipv4" ? "set_rule_action" : "set_rule6_action",
+      value: rule.action || "permit"
+    });
+
+    // Set rule description
+    if (rule.description) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_description" : "set_rule6_description",
+        value: rule.description
+      });
+    }
+
+    // Set prefix
+    if (rule.prefix) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_prefix" : "set_rule6_prefix",
+        value: rule.prefix
+      });
+    }
+
+    // Set ge
+    if (rule.ge !== undefined && rule.ge !== null) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_ge" : "set_rule6_ge",
+        value: rule.ge.toString()
+      });
+    }
+
+    // Set le
+    if (rule.le !== undefined && rule.le !== null) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_le" : "set_rule6_le",
+        value: rule.le.toString()
+      });
+    }
+
+    return this.batchConfigure({
+      name,
+      list_type: listType,
+      rule_number: rule.rule_number,
+      operations,
+    });
+  }
+
+  /**
+   * Helper: Update prefix-list description
+   */
+  async updatePrefixListDescription(
+    name: string,
+    listType: string,
+    description: string | null
+  ): Promise<any> {
+    const operations: PrefixListBatchOperation[] = [];
+
+    if (description) {
+      operations.push({
+        op: listType === "ipv4" ? "set_prefix_list_description" : "set_prefix_list6_description",
+        value: description
+      });
+    } else {
+      operations.push({
+        op: listType === "ipv4" ? "delete_prefix_list_description" : "delete_prefix_list6_description"
+      });
+    }
+
+    return this.batchConfigure({
+      name,
+      list_type: listType,
+      operations,
+    });
+  }
+
+  /**
+   * Helper: Delete a prefix-list
+   */
+  async deletePrefixList(name: string, listType: string): Promise<any> {
+    const operations: PrefixListBatchOperation[] = [];
+    operations.push({
+      op: listType === "ipv4" ? "delete_prefix_list" : "delete_prefix_list6"
+    });
+
+    return this.batchConfigure({
+      name,
+      list_type: listType,
+      operations,
+    });
+  }
+
+  /**
+   * Helper: Add a rule to an existing prefix-list
+   */
+  async addRule(
+    name: string,
+    listType: string,
+    rule: Partial<PrefixListRule>
+  ): Promise<any> {
+    const operations: PrefixListBatchOperation[] = [];
+
+    // Create rule
+    operations.push({ op: listType === "ipv4" ? "set_rule" : "set_rule6" });
+
+    // Set rule action
+    operations.push({
+      op: listType === "ipv4" ? "set_rule_action" : "set_rule6_action",
+      value: rule.action || "permit"
+    });
+
+    // Set rule description
+    if (rule.description) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_description" : "set_rule6_description",
+        value: rule.description
+      });
+    }
+
+    // Set prefix
+    if (rule.prefix) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_prefix" : "set_rule6_prefix",
+        value: rule.prefix
+      });
+    }
+
+    // Set ge
+    if (rule.ge !== undefined && rule.ge !== null) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_ge" : "set_rule6_ge",
+        value: rule.ge.toString()
+      });
+    }
+
+    // Set le
+    if (rule.le !== undefined && rule.le !== null) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_le" : "set_rule6_le",
+        value: rule.le.toString()
+      });
+    }
+
+    return this.batchConfigure({
+      name,
+      list_type: listType,
+      rule_number: rule.rule_number,
+      operations,
+    });
+  }
+
+  /**
+   * Helper: Update an existing rule
+   */
+  async updateRule(
+    name: string,
+    listType: string,
+    ruleNumber: number,
+    rule: Partial<PrefixListRule>
+  ): Promise<any> {
+    const operations: PrefixListBatchOperation[] = [];
+
+    // IMPORTANT: Process deletes FIRST, then sets
+    // This ensures VyOS properly removes fields before setting new values
+
+    // Delete operations first
+    if (rule.description !== undefined && !rule.description) {
+      operations.push({
+        op: listType === "ipv4" ? "delete_rule_description" : "delete_rule6_description"
+      });
+    }
+
+    if (rule.ge !== undefined && rule.ge === null) {
+      operations.push({
+        op: listType === "ipv4" ? "delete_rule_ge" : "delete_rule6_ge"
+      });
+    }
+
+    if (rule.le !== undefined && rule.le === null) {
+      operations.push({
+        op: listType === "ipv4" ? "delete_rule_le" : "delete_rule6_le"
+      });
+    }
+
+    // Set operations after deletes
+    if (rule.action) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_action" : "set_rule6_action",
+        value: rule.action
+      });
+    }
+
+    if (rule.description !== undefined && rule.description) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_description" : "set_rule6_description",
+        value: rule.description
+      });
+    }
+
+    if (rule.prefix !== undefined && rule.prefix) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_prefix" : "set_rule6_prefix",
+        value: rule.prefix
+      });
+    }
+
+    if (rule.ge !== undefined && rule.ge !== null) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_ge" : "set_rule6_ge",
+        value: rule.ge.toString()
+      });
+    }
+
+    if (rule.le !== undefined && rule.le !== null) {
+      operations.push({
+        op: listType === "ipv4" ? "set_rule_le" : "set_rule6_le",
+        value: rule.le.toString()
+      });
+    }
+
+    return this.batchConfigure({
+      name,
+      list_type: listType,
+      rule_number: ruleNumber,
+      operations,
+    });
+  }
+
+  /**
+   * Helper: Delete a rule
+   */
+  async deleteRule(
+    name: string,
+    listType: string,
+    ruleNumber: number
+  ): Promise<any> {
+    const operations: PrefixListBatchOperation[] = [];
+    operations.push({
+      op: listType === "ipv4" ? "delete_rule" : "delete_rule6"
+    });
+
+    return this.batchConfigure({
+      name,
+      list_type: listType,
+      rule_number: ruleNumber,
+      operations,
+    });
+  }
+}
+
+export const prefixListService = new PrefixListService();


### PR DESCRIPTION
- Implemented DeletePrefixListModal for deleting prefix lists with confirmation.
- Implemented DeletePrefixListRuleModal for deleting individual rules with confirmation.
- Implemented EditPrefixListModal for updating the description of prefix lists.
- Implemented EditPrefixListRuleModal for editing rules with validation for CIDR notation and GE/LE constraints.
- Added PrefixListReorderBanner for displaying reorder status and actions.
- Added PrefixListRuleRow for displaying individual rules with edit and delete options.
- Created prefix-list API service to handle CRUD operations for prefix lists and rules.