### PR TITLE
Fix: enhance EditRouteMapRuleModal with IPv6 support and dropdown

### DIFF
--- a/backend/vyos_builders/access_list/access_list.py
+++ b/backend/vyos_builders/access_list/access_list.py
@@ -296,6 +296,13 @@ class AccessListBatchBuilder:
         path = self.mappers[self.mapper_key].get_rule6_source_any(name, rule)
         return self.add_set(path)
 
+    def set_rule6_source_exact_match(
+        self, name: str, rule: str
+    ) -> "AccessListBatchBuilder":
+        """Set IPv6 rule source exact-match flag."""
+        path = self.mappers[self.mapper_key].get_rule6_source_exact_match(name, rule)
+        return self.add_set(path)
+
     def set_rule6_source_network(
         self, name: str, rule: str, network: str
     ) -> "AccessListBatchBuilder":
@@ -310,30 +317,8 @@ class AccessListBatchBuilder:
         path = self.mappers[self.mapper_key].get_rule6_source_path(name, rule)
         return self.add_delete(path)
 
-    # ========================================================================
-    # IPv6 Rule Destination Operations
-    # ========================================================================
-
-    def set_rule6_destination_any(
-        self, name: str, rule: str
-    ) -> "AccessListBatchBuilder":
-        """Set IPv6 rule destination to any."""
-        path = self.mappers[self.mapper_key].get_rule6_destination_any(name, rule)
-        return self.add_set(path)
-
-    def set_rule6_destination_network(
-        self, name: str, rule: str, network: str
-    ) -> "AccessListBatchBuilder":
-        """Set IPv6 rule destination network."""
-        path = self.mappers[self.mapper_key].get_rule6_destination_network(name, rule, network)
-        return self.add_set(path)
-
-    def delete_rule6_destination(
-        self, name: str, rule: str
-    ) -> "AccessListBatchBuilder":
-        """Delete IPv6 rule destination."""
-        path = self.mappers[self.mapper_key].get_rule6_destination_path(name, rule)
-        return self.add_delete(path)
+    # NOTE: IPv6 access-lists do NOT have destination fields
+    # They only match on source (any or network)
 
     # ========================================================================
     # Capabilities

--- a/backend/vyos_mappers/access_list/access_list.py
+++ b/backend/vyos_mappers/access_list/access_list.py
@@ -128,17 +128,16 @@ class AccessListMapper(BaseFeatureMapper):
         """Get command path for IPv6 rule source any."""
         return ["policy", "access-list6", name, "rule", rule, "source", "any"]
 
+    def get_rule6_source_exact_match(self, name: str, rule: str) -> List[str]:
+        """Get command path for IPv6 rule source exact-match."""
+        return ["policy", "access-list6", name, "rule", rule, "source", "exact-match"]
+
     def get_rule6_source_network(self, name: str, rule: str, network: str) -> List[str]:
         """Get command path for IPv6 rule source network."""
         return ["policy", "access-list6", name, "rule", rule, "source", "network", network]
 
-    def get_rule6_destination_any(self, name: str, rule: str) -> List[str]:
-        """Get command path for IPv6 rule destination any."""
-        return ["policy", "access-list6", name, "rule", rule, "destination", "any"]
-
-    def get_rule6_destination_network(self, name: str, rule: str, network: str) -> List[str]:
-        """Get command path for IPv6 rule destination network."""
-        return ["policy", "access-list6", name, "rule", rule, "destination", "network", network]
+    # NOTE: IPv6 access-lists do NOT have destination fields
+    # They only match on source (any or network)
 
     # ========================================================================
     # Delete Paths (IPv6)
@@ -147,7 +146,3 @@ class AccessListMapper(BaseFeatureMapper):
     def get_rule6_source_path(self, name: str, rule: str) -> List[str]:
         """Get command path for deleting IPv6 rule source."""
         return ["policy", "access-list6", name, "rule", rule, "source"]
-
-    def get_rule6_destination_path(self, name: str, rule: str) -> List[str]:
-        """Get command path for deleting IPv6 rule destination."""
-        return ["policy", "access-list6", name, "rule", rule, "destination"]

--- a/backend/vyos_mappers/route_map/route_map.py
+++ b/backend/vyos_mappers/route_map/route_map.py
@@ -164,6 +164,22 @@ class RouteMapMapper(BaseFeatureMapper):
         """Match IPv6 next-hop address."""
         return ["policy", "route-map", name, "rule", rule, "match", "ipv6", "nexthop", "address", address]
 
+    def get_match_ipv6_nexthop_access_list(self, name: str, rule: str, access_list: str) -> List[str]:
+        """Match IPv6 next-hop via access-list."""
+        return ["policy", "route-map", name, "rule", rule, "match", "ipv6", "nexthop", "access-list", access_list]
+
+    def get_match_ipv6_nexthop_prefix_len(self, name: str, rule: str, prefix_len: str) -> List[str]:
+        """Match IPv6 next-hop prefix length."""
+        return ["policy", "route-map", name, "rule", rule, "match", "ipv6", "nexthop", "prefix-len", prefix_len]
+
+    def get_match_ipv6_nexthop_prefix_list(self, name: str, rule: str, prefix_list: str) -> List[str]:
+        """Match IPv6 next-hop via prefix-list."""
+        return ["policy", "route-map", name, "rule", rule, "match", "ipv6", "nexthop", "prefix-list", prefix_list]
+
+    def get_match_ipv6_nexthop_type(self, name: str, rule: str, nh_type: str) -> List[str]:
+        """Match IPv6 next-hop type."""
+        return ["policy", "route-map", name, "rule", rule, "match", "ipv6", "nexthop", "type", nh_type]
+
     # ========================================================================
     # Match Conditions - Route Source
     # ========================================================================

--- a/frontend/src/app/policies/access-list/page.tsx
+++ b/frontend/src/app/policies/access-list/page.tsx
@@ -512,7 +512,7 @@ export default function AccessListPage() {
                               <TableHead>Action</TableHead>
                               <TableHead>Description</TableHead>
                               <TableHead>Source</TableHead>
-                              <TableHead>Destination</TableHead>
+                              {selectedListType === "ipv4" && <TableHead>Destination</TableHead>}
                               <TableHead className="text-right">Actions</TableHead>
                             </TableRow>
                           </TableHeader>
@@ -525,6 +525,7 @@ export default function AccessListPage() {
                                 <AccessListRuleRow
                                   key={rule.rule_number}
                                   rule={rule}
+                                  listType={selectedListType}
                                   onEdit={setEditingRule}
                                   onDelete={setDeletingRule}
                                 />

--- a/frontend/src/components/policies/EditAccessListRuleModal.tsx
+++ b/frontend/src/components/policies/EditAccessListRuleModal.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { AlertCircle } from "lucide-react";
 import { accessListService, type AccessListRule } from "@/lib/api/access-list";
@@ -37,6 +38,10 @@ export function EditAccessListRuleModal({
   const [sourceNetworkFormat, setSourceNetworkFormat] = useState<"network" | "inverse-mask">("network");
   const [sourceAddress, setSourceAddress] = useState("");
   const [sourceMask, setSourceMask] = useState("");
+  // IPv6 specific fields
+  const [sourceAny, setSourceAny] = useState(false);
+  const [sourceExactMatch, setSourceExactMatch] = useState(false);
+  const [sourceNetwork, setSourceNetwork] = useState("");
   const [destinationType, setDestinationType] = useState<"any" | "host" | "network">("any");
   const [destinationNetworkFormat, setDestinationNetworkFormat] = useState<"network" | "inverse-mask">("network");
   const [destinationAddress, setDestinationAddress] = useState("");
@@ -48,29 +53,36 @@ export function EditAccessListRuleModal({
       setAction(rule.action as "permit" | "deny");
       setRuleDescription(rule.description || "");
 
-      // Map source type
-      if (rule.source_type === "inverse-mask") {
-        setSourceType("network");
-        setSourceNetworkFormat("inverse-mask");
-      } else {
-        setSourceType((rule.source_type as any) || "any");
-        setSourceNetworkFormat("network");
-      }
-      setSourceAddress(rule.source_address || "");
-      setSourceMask(rule.source_mask || "");
+      if (listType === "ipv4") {
+        // IPv4 source mapping
+        if (rule.source_type === "inverse-mask") {
+          setSourceType("network");
+          setSourceNetworkFormat("inverse-mask");
+        } else {
+          setSourceType((rule.source_type as any) || "any");
+          setSourceNetworkFormat("network");
+        }
+        setSourceAddress(rule.source_address || "");
+        setSourceMask(rule.source_mask || "");
 
-      // Map destination type
-      if (rule.destination_type === "inverse-mask") {
-        setDestinationType("network");
-        setDestinationNetworkFormat("inverse-mask");
+        // IPv4 destination mapping
+        if (rule.destination_type === "inverse-mask") {
+          setDestinationType("network");
+          setDestinationNetworkFormat("inverse-mask");
+        } else {
+          setDestinationType((rule.destination_type as any) || "any");
+          setDestinationNetworkFormat("network");
+        }
+        setDestinationAddress(rule.destination_address || "");
+        setDestinationMask(rule.destination_mask || "");
       } else {
-        setDestinationType((rule.destination_type as any) || "any");
-        setDestinationNetworkFormat("network");
+        // IPv6 source mapping - handle combinations
+        setSourceAny(rule.source_type === "any");
+        setSourceExactMatch(rule.source_exact_match || false);
+        setSourceNetwork(rule.source_address || "");
       }
-      setDestinationAddress(rule.destination_address || "");
-      setDestinationMask(rule.destination_mask || "");
     }
-  }, [open, rule]);
+  }, [open, rule, listType]);
 
   // Clear source fields when type changes
   useEffect(() => {
@@ -92,12 +104,29 @@ export function EditAccessListRuleModal({
     }
   }, [destinationType]);
 
+  // Mutual exclusivity for IPv6: exact-match and network are mutually exclusive
+  // But "any" can coexist with either
+  useEffect(() => {
+    if (sourceNetwork.trim() && sourceExactMatch) {
+      setSourceExactMatch(false);
+    }
+  }, [sourceNetwork]);
+
+  useEffect(() => {
+    if (sourceExactMatch && sourceNetwork.trim()) {
+      setSourceNetwork("");
+    }
+  }, [sourceExactMatch]);
+
   const resetForm = () => {
     setAction("permit");
     setRuleDescription("");
     setSourceType("any");
     setSourceAddress("");
     setSourceMask("");
+    setSourceAny(false);
+    setSourceExactMatch(false);
+    setSourceNetwork("");
     setDestinationType("any");
     setDestinationAddress("");
     setDestinationMask("");
@@ -113,58 +142,97 @@ export function EditAccessListRuleModal({
     if (!rule) return;
 
     // Validation
-    if (sourceType === "host" && !sourceAddress.trim()) {
-      setError("Please enter a source address for host type");
-      return;
-    }
-    if (sourceType === "inverse-mask" && (!sourceAddress.trim() || !sourceMask.trim())) {
-      setError("Please enter both source address and mask for inverse-mask type");
-      return;
-    }
-    if (sourceType === "network" && !sourceAddress.trim()) {
-      setError("Please enter a source address for network type");
-      return;
-    }
-    if (sourceType === "network" && listType === "ipv4" && !sourceMask.trim()) {
-      setError("Please enter a source mask for network type");
-      return;
-    }
+    if (listType === "ipv4") {
+      // IPv4 validation
+      if (sourceType === "host" && !sourceAddress.trim()) {
+        setError("Please enter a source address for host type");
+        return;
+      }
+      if (sourceType === "network" && !sourceAddress.trim()) {
+        setError("Please enter a source address for network type");
+        return;
+      }
+      if (sourceType === "network" && !sourceMask.trim()) {
+        setError("Please enter a source mask for network type");
+        return;
+      }
 
-    if (destinationType === "host" && !destinationAddress.trim()) {
-      setError("Please enter a destination address for host type");
-      return;
-    }
-    if (destinationType === "inverse-mask" && (!destinationAddress.trim() || !destinationMask.trim())) {
-      setError("Please enter both destination address and mask for inverse-mask type");
-      return;
-    }
-    if (destinationType === "network" && !destinationAddress.trim()) {
-      setError("Please enter a destination address for network type");
-      return;
-    }
-    if (destinationType === "network" && listType === "ipv4" && !destinationMask.trim()) {
-      setError("Please enter a destination mask for network type");
-      return;
+      // Destination validation (IPv4 only)
+      if (destinationType === "host" && !destinationAddress.trim()) {
+        setError("Please enter a destination address for host type");
+        return;
+      }
+      if (destinationType === "network" && !destinationAddress.trim()) {
+        setError("Please enter a destination address for network type");
+        return;
+      }
+      if (destinationType === "network" && !destinationMask.trim()) {
+        setError("Please enter a destination mask for network type");
+        return;
+      }
+    } else {
+      // IPv6 validation
+      if (sourceNetwork.trim()) {
+        // Validate IPv6 CIDR format
+        if (!sourceNetwork.includes('/')) {
+          setError("IPv6 network must be in CIDR format (e.g., 2001:db8::/32)");
+          return;
+        }
+      }
+
+      // At least one option must be selected
+      if (!sourceAny && !sourceExactMatch && !sourceNetwork.trim()) {
+        setError("Please select at least one source option (Any, Exact Match, or Network)");
+        return;
+      }
+
+      // Exact-match and network are mutually exclusive
+      if (sourceExactMatch && sourceNetwork.trim()) {
+        setError("Exact Match and Network cannot be used together");
+        return;
+      }
     }
 
     setLoading(true);
     setError(null);
 
     try {
-      // Map network type to inverse-mask (always use inverse-mask for network in IPv4)
-      const actualSourceType = sourceType === "network" ? "inverse-mask" : sourceType;
-      const actualDestinationType = destinationType === "network" ? "inverse-mask" : destinationType;
-
-      const updatedRule: any = {
+      let updatedRule: any = {
         action,
         description: ruleDescription || null,
-        source_type: actualSourceType,
-        source_address: sourceAddress || null,
-        source_mask: sourceMask || null,
-        destination_type: actualDestinationType,
-        destination_address: destinationAddress || null,
-        destination_mask: destinationMask || null,
       };
+
+      if (listType === "ipv4") {
+        // IPv4 rule - map network type to inverse-mask
+        const actualSourceType = sourceType === "network" ? "inverse-mask" : sourceType;
+        const actualDestinationType = destinationType === "network" ? "inverse-mask" : destinationType;
+
+        updatedRule.source_type = actualSourceType;
+        updatedRule.source_address = sourceAddress || null;
+        updatedRule.source_mask = sourceMask || null;
+        updatedRule.destination_type = actualDestinationType;
+        updatedRule.destination_address = destinationAddress || null;
+        updatedRule.destination_mask = destinationMask || null;
+      } else {
+        // IPv6 rule - handle combinations
+        // any can coexist with network or exact-match
+        // exact-match and network are mutually exclusive
+        if (sourceAny) {
+          updatedRule.source_type = "any";
+        }
+
+        if (sourceNetwork.trim()) {
+          updatedRule.source_address = sourceNetwork;
+          // If we don't have "any" already set, set source_type to "network"
+          if (!sourceAny) {
+            updatedRule.source_type = "network";
+          }
+        }
+
+        if (sourceExactMatch) {
+          updatedRule.source_exact_match = true;
+        }
+      }
 
       await accessListService.updateRule(
         listNumber,
@@ -240,38 +308,40 @@ export function EditAccessListRuleModal({
           {/* Source Configuration */}
           <div className="space-y-3 border rounded-lg p-4">
             <Label>Source</Label>
-            <RadioGroup value={sourceType} onValueChange={(v: any) => setSourceType(v)} disabled={loading}>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="any" id="source-any" />
-                <Label htmlFor="source-any" className="font-normal cursor-pointer">Any</Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="host" id="source-host" />
-                <Label htmlFor="source-host" className="font-normal cursor-pointer">Host</Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="network" id="source-network" />
-                <Label htmlFor="source-network" className="font-normal cursor-pointer">Network</Label>
-              </div>
-            </RadioGroup>
 
-            {sourceType === "host" && (
-              <div className="space-y-2 mt-3">
-                <Label htmlFor="source-address">Host Address *</Label>
-                <Input
-                  id="source-address"
-                  value={sourceAddress}
-                  onChange={(e) => setSourceAddress(e.target.value)}
-                  placeholder={listType === "ipv4" ? "e.g., 192.168.1.1" : "e.g., 2001:db8::1"}
-                  disabled={loading}
-                />
-              </div>
-            )}
+            {listType === "ipv4" ? (
+              /* IPv4 Source - Radio Buttons */
+              <>
+                <RadioGroup value={sourceType} onValueChange={(v: any) => setSourceType(v)} disabled={loading}>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="any" id="source-any" />
+                    <Label htmlFor="source-any" className="font-normal cursor-pointer">Any</Label>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="host" id="source-host" />
+                    <Label htmlFor="source-host" className="font-normal cursor-pointer">Host</Label>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="network" id="source-network" />
+                    <Label htmlFor="source-network" className="font-normal cursor-pointer">Network</Label>
+                  </div>
+                </RadioGroup>
 
-            {sourceType === "network" && (
-              <div className="space-y-3 mt-3">
-                {listType === "ipv4" ? (
-                  <div className="grid grid-cols-2 gap-4">
+                {sourceType === "host" && (
+                  <div className="space-y-2 mt-3">
+                    <Label htmlFor="source-address">Host Address *</Label>
+                    <Input
+                      id="source-address"
+                      value={sourceAddress}
+                      onChange={(e) => setSourceAddress(e.target.value)}
+                      placeholder="e.g., 192.168.1.1"
+                      disabled={loading}
+                    />
+                  </div>
+                )}
+
+                {sourceType === "network" && (
+                  <div className="grid grid-cols-2 gap-4 mt-3">
                     <div className="space-y-2">
                       <Label htmlFor="source-address-net">Network Address *</Label>
                       <Input
@@ -293,25 +363,56 @@ export function EditAccessListRuleModal({
                       />
                     </div>
                   </div>
-                ) : (
-                  <div className="space-y-2">
-                    <Label htmlFor="source-address-net6">Network (CIDR) *</Label>
-                    <Input
-                      id="source-address-net6"
-                      value={sourceAddress}
-                      onChange={(e) => setSourceAddress(e.target.value)}
-                      placeholder="e.g., 2001:db8::/32"
+                )}
+              </>
+            ) : (
+              /* IPv6 Source - Checkboxes for Any/Exact-Match, separate Network field */
+              <>
+                <div className="space-y-3">
+                  <div className="flex items-center space-x-2">
+                    <Checkbox
+                      id="source-any-v6"
+                      checked={sourceAny}
+                      onCheckedChange={(checked) => setSourceAny(checked as boolean)}
                       disabled={loading}
                     />
+                    <Label htmlFor="source-any-v6" className="font-normal cursor-pointer">Any</Label>
                   </div>
-                )}
-              </div>
+                  <div className="flex items-center space-x-2">
+                    <Checkbox
+                      id="source-exact-match"
+                      checked={sourceExactMatch}
+                      onCheckedChange={(checked) => setSourceExactMatch(checked as boolean)}
+                      disabled={loading || !!sourceNetwork.trim()}
+                    />
+                    <Label htmlFor="source-exact-match" className="font-normal cursor-pointer">Exact Match</Label>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Any can coexist with Exact Match OR Network. Exact Match and Network are mutually exclusive.
+                  </p>
+                </div>
+
+                <div className="space-y-2 mt-4">
+                  <Label htmlFor="source-network-v6">Network (CIDR)</Label>
+                  <Input
+                    id="source-network-v6"
+                    value={sourceNetwork}
+                    onChange={(e) => setSourceNetwork(e.target.value)}
+                    placeholder="e.g., 2001:db8::/32"
+                    disabled={loading || sourceExactMatch}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Must include prefix length (e.g., /32, /64). Can coexist with Any, but not Exact Match.
+                  </p>
+                </div>
+              </>
             )}
           </div>
 
-          {/* Destination Configuration */}
-          <div className="space-y-3 border rounded-lg p-4">
-            <Label>Destination</Label>
+          {/* Destination Configuration (IPv4 only) */}
+          {listType === "ipv4" && (
+            <div className="space-y-3 border rounded-lg p-4">
+              <Label>Destination</Label>
             <RadioGroup value={destinationType} onValueChange={(v: any) => setDestinationType(v)} disabled={loading}>
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="any" id="dest-any" />
@@ -379,7 +480,8 @@ export function EditAccessListRuleModal({
                 )}
               </div>
             )}
-          </div>
+            </div>
+          )}
         </div>
 
         {error && (

--- a/frontend/src/components/policies/EditRouteMapRuleModal.tsx
+++ b/frontend/src/components/policies/EditRouteMapRuleModal.tsx
@@ -13,6 +13,12 @@ import { AlertCircle, X, Plus } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { routeMapService } from "@/lib/api/route-map";
 import type { RouteMapRule, MatchConditions, SetActions } from "@/lib/api/route-map";
+import { asPathListService } from "@/lib/api/as-path-list";
+import { communityListService } from "@/lib/api/community-list";
+import { extcommunityListService } from "@/lib/api/extcommunity-list";
+import { largeCommunityListService } from "@/lib/api/large-community-list";
+import { accessListService } from "@/lib/api/access-list";
+import { prefixListService } from "@/lib/api/prefix-list";
 
 interface EditRouteMapRuleModalProps {
   open: boolean;
@@ -67,8 +73,12 @@ export function EditRouteMapRuleModal({
   const [matchIpNexthopAddress, setMatchIpNexthopAddress] = useState("");
   const [matchIpNexthopPrefixLen, setMatchIpNexthopPrefixLen] = useState("");
   const [matchIpNexthopPrefixList, setMatchIpNexthopPrefixList] = useState("");
-  const [matchIpNexthopType, setMatchIpNexthopType] = useState("");
+  const [matchIpNexthopType, setMatchIpNexthopType] = useState(false);
+  const [matchIpv6NexthopAccessList, setMatchIpv6NexthopAccessList] = useState("");
   const [matchIpv6NexthopAddress, setMatchIpv6NexthopAddress] = useState("");
+  const [matchIpv6NexthopPrefixLen, setMatchIpv6NexthopPrefixLen] = useState("");
+  const [matchIpv6NexthopPrefixList, setMatchIpv6NexthopPrefixList] = useState("");
+  const [matchIpv6NexthopType, setMatchIpv6NexthopType] = useState(false);
 
   // Match Conditions - Route Source
   const [matchIpRouteSourceAccessList, setMatchIpRouteSourceAccessList] = useState("");
@@ -147,6 +157,54 @@ export function EditRouteMapRuleModal({
   const [setSrc, setSetSrc] = useState("");
   const [setTable, setSetTable] = useState("");
   const [setTag, setSetTag] = useState("");
+
+  // Dropdown options loaded from API
+  const [asPathLists, setAsPathLists] = useState<string[]>([]);
+  const [communityLists, setCommunityLists] = useState<string[]>([]);
+  const [extcommunityLists, setExtcommunityLists] = useState<string[]>([]);
+  const [largeCommunityLists, setLargeCommunityLists] = useState<string[]>([]);
+  const [ipv4AccessLists, setIpv4AccessLists] = useState<string[]>([]);
+  const [ipv6AccessLists, setIpv6AccessLists] = useState<string[]>([]);
+  const [ipv4PrefixLists, setIpv4PrefixLists] = useState<string[]>([]);
+  const [ipv6PrefixLists, setIpv6PrefixLists] = useState<string[]>([]);
+
+  // Load dropdown options when modal opens
+  useEffect(() => {
+    if (open) {
+      loadDropdownOptions();
+    }
+  }, [open]);
+
+  const loadDropdownOptions = async () => {
+    try {
+      const [
+        asPathConfig,
+        communityConfig,
+        extcommunityConfig,
+        largeCommunityConfig,
+        accessListConfig,
+        prefixListConfig
+      ] = await Promise.all([
+        asPathListService.getConfig(),
+        communityListService.getConfig(),
+        extcommunityListService.getConfig(),
+        largeCommunityListService.getConfig(),
+        accessListService.getConfig(),
+        prefixListService.getConfig(),
+      ]);
+
+      setAsPathLists(asPathConfig.as_path_lists.map(list => list.name));
+      setCommunityLists(communityConfig.community_lists.map(list => list.name));
+      setExtcommunityLists(extcommunityConfig.extcommunity_lists.map(list => list.name));
+      setLargeCommunityLists(largeCommunityConfig.large_community_lists.map(list => list.name));
+      setIpv4AccessLists(accessListConfig.ipv4_lists.map(list => list.number));
+      setIpv6AccessLists(accessListConfig.ipv6_lists.map(list => list.number));
+      setIpv4PrefixLists(prefixListConfig.ipv4_lists.map(list => list.name));
+      setIpv6PrefixLists(prefixListConfig.ipv6_lists.map(list => list.name));
+    } catch (err) {
+      console.error("Failed to load dropdown options:", err);
+    }
+  };
 
   // Load rule data when modal opens
   useEffect(() => {
@@ -340,8 +398,12 @@ export function EditRouteMapRuleModal({
     setMatchIpNexthopAddress(match.ip_nexthop_address || "");
     setMatchIpNexthopPrefixLen(match.ip_nexthop_prefix_len !== null ? String(match.ip_nexthop_prefix_len) : "");
     setMatchIpNexthopPrefixList(match.ip_nexthop_prefix_list || "");
-    setMatchIpNexthopType(match.ip_nexthop_type || "");
+    setMatchIpNexthopType(match.ip_nexthop_type === "blackhole");
+    setMatchIpv6NexthopAccessList(match.ipv6_nexthop_access_list || "");
     setMatchIpv6NexthopAddress(match.ipv6_nexthop_address || "");
+    setMatchIpv6NexthopPrefixLen(match.ipv6_nexthop_prefix_len !== null ? String(match.ipv6_nexthop_prefix_len) : "");
+    setMatchIpv6NexthopPrefixList(match.ipv6_nexthop_prefix_list || "");
+    setMatchIpv6NexthopType(match.ipv6_nexthop_type === "blackhole");
     setMatchIpRouteSourceAccessList(match.ip_route_source_access_list || "");
     setMatchIpRouteSourcePrefixList(match.ip_route_source_prefix_list || "");
     setMatchInterface(match.interface || "");
@@ -440,6 +502,9 @@ export function EditRouteMapRuleModal({
     setSetTag(set.tag !== null ? String(set.tag) : "");
   };
 
+
+
+
   const handleClose = () => {
     setError(null);
     onOpenChange(false);
@@ -474,8 +539,12 @@ export function EditRouteMapRuleModal({
       if (matchIpNexthopAddress.trim()) match.ip_nexthop_address = matchIpNexthopAddress.trim();
       if (matchIpNexthopPrefixLen.trim()) match.ip_nexthop_prefix_len = parseInt(matchIpNexthopPrefixLen);
       if (matchIpNexthopPrefixList.trim()) match.ip_nexthop_prefix_list = matchIpNexthopPrefixList.trim();
-      if (matchIpNexthopType.trim()) match.ip_nexthop_type = matchIpNexthopType.trim();
+      if (matchIpNexthopType) match.ip_nexthop_type = "blackhole";
+      if (matchIpv6NexthopAccessList.trim()) match.ipv6_nexthop_access_list = matchIpv6NexthopAccessList.trim();
       if (matchIpv6NexthopAddress.trim()) match.ipv6_nexthop_address = matchIpv6NexthopAddress.trim();
+      if (matchIpv6NexthopPrefixLen.trim()) match.ipv6_nexthop_prefix_len = parseInt(matchIpv6NexthopPrefixLen);
+      if (matchIpv6NexthopPrefixList.trim()) match.ipv6_nexthop_prefix_list = matchIpv6NexthopPrefixList.trim();
+      if (matchIpv6NexthopType) match.ipv6_nexthop_type = "blackhole";
       if (matchIpRouteSourceAccessList.trim()) match.ip_route_source_access_list = matchIpRouteSourceAccessList.trim();
       if (matchIpRouteSourcePrefixList.trim()) match.ip_route_source_prefix_list = matchIpRouteSourcePrefixList.trim();
       if (matchInterface.trim()) match.interface = matchInterface.trim();
@@ -649,12 +718,17 @@ export function EditRouteMapRuleModal({
                   <div className="grid grid-cols-2 gap-4">
                     <div className="space-y-2">
                       <Label htmlFor="matchAsPath">AS Path List</Label>
-                      <Input
-                        id="matchAsPath"
-                        placeholder="AS path list name"
-                        value={matchAsPath}
-                        onChange={(e) => setMatchAsPath(e.target.value)}
-                      />
+                      <Select value={matchAsPath || "none"} onValueChange={(val) => setMatchAsPath(val === "none" ? "" : val)}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select AS path list" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">None</SelectItem>
+                          {asPathLists.map((name) => (
+                            <SelectItem key={name} value={name}>{name}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     </div>
 
                     <div className="space-y-2">
@@ -674,12 +748,17 @@ export function EditRouteMapRuleModal({
 
                     <div className="space-y-2">
                       <Label htmlFor="matchCommunityList">Community List</Label>
-                      <Input
-                        id="matchCommunityList"
-                        placeholder="Community list name"
-                        value={matchCommunityList}
-                        onChange={(e) => setMatchCommunityList(e.target.value)}
-                      />
+                      <Select value={matchCommunityList || "none"} onValueChange={(val) => setMatchCommunityList(val === "none" ? "" : val)}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select community list" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">None</SelectItem>
+                          {communityLists.map((name) => (
+                            <SelectItem key={name} value={name}>{name}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                       <div className="flex items-center space-x-2 mt-2">
                         <Checkbox
                           id="matchCommunityExact"
@@ -694,22 +773,32 @@ export function EditRouteMapRuleModal({
 
                     <div className="space-y-2">
                       <Label htmlFor="matchExtcommunity">Extended Community</Label>
-                      <Input
-                        id="matchExtcommunity"
-                        placeholder="Extcommunity list name"
-                        value={matchExtcommunity}
-                        onChange={(e) => setMatchExtcommunity(e.target.value)}
-                      />
+                      <Select value={matchExtcommunity || "none"} onValueChange={(val) => setMatchExtcommunity(val === "none" ? "" : val)}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select extended community list" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">None</SelectItem>
+                          {extcommunityLists.map((name) => (
+                            <SelectItem key={name} value={name}>{name}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     </div>
 
                     <div className="space-y-2">
                       <Label htmlFor="matchLargeCommunityList">Large Community List</Label>
-                      <Input
-                        id="matchLargeCommunityList"
-                        placeholder="Large community list name"
-                        value={matchLargeCommunityList}
-                        onChange={(e) => setMatchLargeCommunityList(e.target.value)}
-                      />
+                      <Select value={matchLargeCommunityList || "none"} onValueChange={(val) => setMatchLargeCommunityList(val === "none" ? "" : val)}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select large community list" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">None</SelectItem>
+                          {largeCommunityLists.map((name) => (
+                            <SelectItem key={name} value={name}>{name}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     </div>
 
                     <div className="space-y-2">
@@ -843,12 +932,17 @@ export function EditRouteMapRuleModal({
                     <div className="grid grid-cols-2 gap-4">
                       <div className="space-y-2">
                         <Label htmlFor="matchIpNexthopAccessList">Access List</Label>
-                        <Input
-                          id="matchIpNexthopAccessList"
-                          placeholder="Access list number/name"
-                          value={matchIpNexthopAccessList}
-                          onChange={(e) => setMatchIpNexthopAccessList(e.target.value)}
-                        />
+                        <Select value={matchIpNexthopAccessList || "none"} onValueChange={(val) => setMatchIpNexthopAccessList(val === "none" ? "" : val)}>
+                          <SelectTrigger id="matchIpNexthopAccessList">
+                            <SelectValue placeholder="Select access list" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="none">None</SelectItem>
+                            {ipv4AccessLists.map((number) => (
+                              <SelectItem key={number} value={number}>{number}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                       </div>
                       <div className="space-y-2">
                         <Label htmlFor="matchIpNexthopAddress">Address</Label>
@@ -861,12 +955,17 @@ export function EditRouteMapRuleModal({
                       </div>
                       <div className="space-y-2">
                         <Label htmlFor="matchIpNexthopPrefixList">Prefix List</Label>
-                        <Input
-                          id="matchIpNexthopPrefixList"
-                          placeholder="Prefix list name"
-                          value={matchIpNexthopPrefixList}
-                          onChange={(e) => setMatchIpNexthopPrefixList(e.target.value)}
-                        />
+                        <Select value={matchIpNexthopPrefixList || "none"} onValueChange={(val) => setMatchIpNexthopPrefixList(val === "none" ? "" : val)}>
+                          <SelectTrigger id="matchIpNexthopPrefixList">
+                            <SelectValue placeholder="Select prefix list" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="none">None</SelectItem>
+                            {ipv4PrefixLists.map((name) => (
+                              <SelectItem key={name} value={name}>{name}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                       </div>
                       <div className="space-y-2">
                         <Label htmlFor="matchIpNexthopPrefixLen">Prefix Length</Label>
@@ -879,25 +978,80 @@ export function EditRouteMapRuleModal({
                         />
                       </div>
                       <div className="space-y-2">
-                        <Label htmlFor="matchIpNexthopType">Type</Label>
-                        <Input
-                          id="matchIpNexthopType"
-                          placeholder="e.g., blackhole"
-                          value={matchIpNexthopType}
-                          onChange={(e) => setMatchIpNexthopType(e.target.value)}
-                        />
+                        <div className="flex items-center space-x-2 pt-7">
+                          <Checkbox
+                            id="matchIpNexthopType"
+                            checked={matchIpNexthopType}
+                            onCheckedChange={(checked) => setMatchIpNexthopType(checked as boolean)}
+                          />
+                          <Label htmlFor="matchIpNexthopType" className="cursor-pointer">
+                            Blackhole Type
+                          </Label>
+                        </div>
                       </div>
                     </div>
 
                     <h4 className="font-medium text-sm pt-4">IPv6 Next-Hop</h4>
-                    <div className="space-y-2">
-                      <Label htmlFor="matchIpv6NexthopAddress">Address</Label>
-                      <Input
-                        id="matchIpv6NexthopAddress"
-                        placeholder="e.g., 2001:db8::1"
-                        value={matchIpv6NexthopAddress}
-                        onChange={(e) => setMatchIpv6NexthopAddress(e.target.value)}
-                      />
+                    <div className="grid grid-cols-2 gap-4">
+                      <div className="space-y-2">
+                        <Label htmlFor="matchIpv6NexthopAccessList">Access List</Label>
+                        <Select value={matchIpv6NexthopAccessList || "none"} onValueChange={(val) => setMatchIpv6NexthopAccessList(val === "none" ? "" : val)}>
+                          <SelectTrigger id="matchIpv6NexthopAccessList">
+                            <SelectValue placeholder="Select access list" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="none">None</SelectItem>
+                            {ipv6AccessLists.map((number) => (
+                              <SelectItem key={number} value={number}>{number}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="matchIpv6NexthopAddress">Address</Label>
+                        <Input
+                          id="matchIpv6NexthopAddress"
+                          placeholder="e.g., 2001:db8::1"
+                          value={matchIpv6NexthopAddress}
+                          onChange={(e) => setMatchIpv6NexthopAddress(e.target.value)}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="matchIpv6NexthopPrefixList">Prefix List</Label>
+                        <Select value={matchIpv6NexthopPrefixList || "none"} onValueChange={(val) => setMatchIpv6NexthopPrefixList(val === "none" ? "" : val)}>
+                          <SelectTrigger id="matchIpv6NexthopPrefixList">
+                            <SelectValue placeholder="Select prefix list" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="none">None</SelectItem>
+                            {ipv6PrefixLists.map((name) => (
+                              <SelectItem key={name} value={name}>{name}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="matchIpv6NexthopPrefixLen">Prefix Length</Label>
+                        <Input
+                          id="matchIpv6NexthopPrefixLen"
+                          type="number"
+                          placeholder="0-128"
+                          value={matchIpv6NexthopPrefixLen}
+                          onChange={(e) => setMatchIpv6NexthopPrefixLen(e.target.value)}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <div className="flex items-center space-x-2 pt-7">
+                          <Checkbox
+                            id="matchIpv6NexthopType"
+                            checked={matchIpv6NexthopType}
+                            onCheckedChange={(checked) => setMatchIpv6NexthopType(checked as boolean)}
+                          />
+                          <Label htmlFor="matchIpv6NexthopType" className="cursor-pointer">
+                            Blackhole Type
+                          </Label>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </AccordionContent>
@@ -1096,19 +1250,31 @@ export function EditRouteMapRuleModal({
                                 </Button>
                               </div>
                             ))}
-                            <div className="flex gap-2">
-                              <Input
-                                value={newCommunityDelete}
-                                onChange={(e) => setNewCommunityDelete(e.target.value)}
-                                placeholder="e.g., 65000:200"
-                                onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), handleAddCommunityDelete())}
-                              />
-                              <Button type="button" variant="outline" size="sm" onClick={handleAddCommunityDelete}>
-                                <Plus className="h-4 w-4 mr-1" />
-                                Add
-                              </Button>
+                            <div className="space-y-2">
+                              <Select
+                                value="none"
+                                onValueChange={(value) => {
+                                  if (value !== "none" && !communityDeleteValues.includes(value)) {
+                                    setCommunityDeleteValues([...communityDeleteValues, value]);
+                                  }
+                                }}
+                              >
+                                <SelectTrigger>
+                                  <SelectValue placeholder="Select community list to delete" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="none">Select community list...</SelectItem>
+                                  {communityLists.map((listName) => (
+                                    <SelectItem key={listName} value={listName} disabled={communityDeleteValues.includes(listName)}>
+                                      {listName}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <p className="text-xs text-muted-foreground">
+                                Select community list(s) to delete all matching communities
+                              </p>
                             </div>
-                            <p className="text-xs text-muted-foreground">Note: Community dropdown will be added in future update</p>
                           </div>
                         )}
                       </div>
@@ -1230,19 +1396,31 @@ export function EditRouteMapRuleModal({
                                 </Button>
                               </div>
                             ))}
-                            <div className="flex gap-2">
-                              <Input
-                                value={newLargeCommunityDelete}
-                                onChange={(e) => setNewLargeCommunityDelete(e.target.value)}
-                                placeholder="e.g., 65000:2:200"
-                                onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), handleAddLargeCommunityDelete())}
-                              />
-                              <Button type="button" variant="outline" size="sm" onClick={handleAddLargeCommunityDelete}>
-                                <Plus className="h-4 w-4 mr-1" />
-                                Add
-                              </Button>
+                            <div className="space-y-2">
+                              <Select
+                                value="none"
+                                onValueChange={(value) => {
+                                  if (value !== "none" && !largeCommunityDeleteValues.includes(value)) {
+                                    setLargeCommunityDeleteValues([...largeCommunityDeleteValues, value]);
+                                  }
+                                }}
+                              >
+                                <SelectTrigger>
+                                  <SelectValue placeholder="Select large community list to delete" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="none">Select large community list...</SelectItem>
+                                  {largeCommunityLists.map((listName) => (
+                                    <SelectItem key={listName} value={listName} disabled={largeCommunityDeleteValues.includes(listName)}>
+                                      {listName}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <p className="text-xs text-muted-foreground">
+                                Select large community list(s) to delete all matching communities
+                              </p>
                             </div>
-                            <p className="text-xs text-muted-foreground">Note: Community dropdown will be added in future update</p>
                           </div>
                         )}
                       </div>

--- a/frontend/src/lib/api/access-list.ts
+++ b/frontend/src/lib/api/access-list.ts
@@ -11,6 +11,7 @@ export interface AccessListRule {
   source_type?: string | null;  // any, host, inverse-mask, network
   source_address?: string | null;
   source_mask?: string | null;
+  source_exact_match?: boolean;  // IPv6 exact-match flag (can coexist with any)
   destination_type?: string | null;  // any, host, inverse-mask, network
   destination_address?: string | null;
   destination_mask?: string | null;
@@ -160,63 +161,76 @@ class AccessListService {
     }
 
     // Set source
-    if (rule.source_type === "any") {
-      operations.push({
-        op: listType === "ipv4" ? "set_rule_source_any" : "set_rule6_source_any"
-      });
-    } else if (rule.source_type === "host" && rule.source_address) {
-      operations.push({
-        op: "set_rule_source_host",
-        value: rule.source_address
-      });
-    } else if (rule.source_type === "inverse-mask" && rule.source_address && rule.source_mask) {
-      operations.push({
-        op: "set_rule_source_inverse_mask",
-        value: rule.source_address,
-        value2: rule.source_mask
-      });
-    } else if (rule.source_type === "network" && rule.source_address) {
-      if (listType === "ipv4" && rule.source_mask) {
+    if (listType === "ipv4") {
+      // IPv4 source handling
+      if (rule.source_type === "any") {
+        operations.push({
+          op: "set_rule_source_any"
+        });
+      } else if (rule.source_type === "host" && rule.source_address) {
+        operations.push({
+          op: "set_rule_source_host",
+          value: rule.source_address
+        });
+      } else if (rule.source_type === "inverse-mask" && rule.source_address && rule.source_mask) {
+        operations.push({
+          op: "set_rule_source_inverse_mask",
+          value: rule.source_address,
+          value2: rule.source_mask
+        });
+      } else if (rule.source_type === "network" && rule.source_address && rule.source_mask) {
         operations.push({
           op: "set_rule_source_network",
           value: rule.source_address,
           value2: rule.source_mask
         });
-      } else if (listType === "ipv6") {
+      }
+    } else {
+      // IPv6 source handling - any can coexist with network or exact-match
+      // exact-match and network are mutually exclusive
+      if (rule.source_type === "any") {
+        operations.push({
+          op: "set_rule6_source_any"
+        });
+      }
+
+      if (rule.source_address) {
+        // Network can coexist with "any"
         operations.push({
           op: "set_rule6_source_network",
           value: rule.source_address
         });
       }
+
+      if (rule.source_exact_match) {
+        operations.push({
+          op: "set_rule6_source_exact_match"
+        });
+      }
     }
 
-    // Set destination
-    if (rule.destination_type === "any") {
-      operations.push({
-        op: listType === "ipv4" ? "set_rule_destination_any" : "set_rule6_destination_any"
-      });
-    } else if (rule.destination_type === "host" && rule.destination_address) {
-      operations.push({
-        op: "set_rule_destination_host",
-        value: rule.destination_address
-      });
-    } else if (rule.destination_type === "inverse-mask" && rule.destination_address && rule.destination_mask) {
-      operations.push({
-        op: "set_rule_destination_inverse_mask",
-        value: rule.destination_address,
-        value2: rule.destination_mask
-      });
-    } else if (rule.destination_type === "network" && rule.destination_address) {
-      if (listType === "ipv4" && rule.destination_mask) {
+    // Set destination (IPv4 only - IPv6 access-lists don't have destination)
+    if (listType === "ipv4") {
+      if (rule.destination_type === "any") {
+        operations.push({
+          op: "set_rule_destination_any"
+        });
+      } else if (rule.destination_type === "host" && rule.destination_address) {
+        operations.push({
+          op: "set_rule_destination_host",
+          value: rule.destination_address
+        });
+      } else if (rule.destination_type === "inverse-mask" && rule.destination_address && rule.destination_mask) {
+        operations.push({
+          op: "set_rule_destination_inverse_mask",
+          value: rule.destination_address,
+          value2: rule.destination_mask
+        });
+      } else if (rule.destination_type === "network" && rule.destination_address && rule.destination_mask) {
         operations.push({
           op: "set_rule_destination_network",
           value: rule.destination_address,
           value2: rule.destination_mask
-        });
-      } else if (listType === "ipv6") {
-        operations.push({
-          op: "set_rule6_destination_network",
-          value: rule.destination_address
         });
       }
     }
@@ -301,63 +315,76 @@ class AccessListService {
     }
 
     // Set source
-    if (rule.source_type === "any") {
-      operations.push({
-        op: listType === "ipv4" ? "set_rule_source_any" : "set_rule6_source_any"
-      });
-    } else if (rule.source_type === "host" && rule.source_address) {
-      operations.push({
-        op: "set_rule_source_host",
-        value: rule.source_address
-      });
-    } else if (rule.source_type === "inverse-mask" && rule.source_address && rule.source_mask) {
-      operations.push({
-        op: "set_rule_source_inverse_mask",
-        value: rule.source_address,
-        value2: rule.source_mask
-      });
-    } else if (rule.source_type === "network" && rule.source_address) {
-      if (listType === "ipv4" && rule.source_mask) {
+    if (listType === "ipv4") {
+      // IPv4 source handling
+      if (rule.source_type === "any") {
+        operations.push({
+          op: "set_rule_source_any"
+        });
+      } else if (rule.source_type === "host" && rule.source_address) {
+        operations.push({
+          op: "set_rule_source_host",
+          value: rule.source_address
+        });
+      } else if (rule.source_type === "inverse-mask" && rule.source_address && rule.source_mask) {
+        operations.push({
+          op: "set_rule_source_inverse_mask",
+          value: rule.source_address,
+          value2: rule.source_mask
+        });
+      } else if (rule.source_type === "network" && rule.source_address && rule.source_mask) {
         operations.push({
           op: "set_rule_source_network",
           value: rule.source_address,
           value2: rule.source_mask
         });
-      } else if (listType === "ipv6") {
+      }
+    } else {
+      // IPv6 source handling - any can coexist with network or exact-match
+      // exact-match and network are mutually exclusive
+      if (rule.source_type === "any") {
+        operations.push({
+          op: "set_rule6_source_any"
+        });
+      }
+
+      if (rule.source_address) {
+        // Network can coexist with "any"
         operations.push({
           op: "set_rule6_source_network",
           value: rule.source_address
         });
       }
+
+      if (rule.source_exact_match) {
+        operations.push({
+          op: "set_rule6_source_exact_match"
+        });
+      }
     }
 
-    // Set destination
-    if (rule.destination_type === "any") {
-      operations.push({
-        op: listType === "ipv4" ? "set_rule_destination_any" : "set_rule6_destination_any"
-      });
-    } else if (rule.destination_type === "host" && rule.destination_address) {
-      operations.push({
-        op: "set_rule_destination_host",
-        value: rule.destination_address
-      });
-    } else if (rule.destination_type === "inverse-mask" && rule.destination_address && rule.destination_mask) {
-      operations.push({
-        op: "set_rule_destination_inverse_mask",
-        value: rule.destination_address,
-        value2: rule.destination_mask
-      });
-    } else if (rule.destination_type === "network" && rule.destination_address) {
-      if (listType === "ipv4" && rule.destination_mask) {
+    // Set destination (IPv4 only - IPv6 access-lists don't have destination)
+    if (listType === "ipv4") {
+      if (rule.destination_type === "any") {
+        operations.push({
+          op: "set_rule_destination_any"
+        });
+      } else if (rule.destination_type === "host" && rule.destination_address) {
+        operations.push({
+          op: "set_rule_destination_host",
+          value: rule.destination_address
+        });
+      } else if (rule.destination_type === "inverse-mask" && rule.destination_address && rule.destination_mask) {
+        operations.push({
+          op: "set_rule_destination_inverse_mask",
+          value: rule.destination_address,
+          value2: rule.destination_mask
+        });
+      } else if (rule.destination_type === "network" && rule.destination_address && rule.destination_mask) {
         operations.push({
           op: "set_rule_destination_network",
           value: rule.destination_address,
           value2: rule.destination_mask
-        });
-      } else if (listType === "ipv6") {
-        operations.push({
-          op: "set_rule6_destination_network",
-          value: rule.destination_address
         });
       }
     }
@@ -381,13 +408,17 @@ class AccessListService {
   ): Promise<any> {
     const operations: AccessListBatchOperation[] = [];
 
-    // Delete existing source and destination first
+    // Delete existing source first
     operations.push({
       op: listType === "ipv4" ? "delete_rule_source" : "delete_rule6_source"
     });
-    operations.push({
-      op: listType === "ipv4" ? "delete_rule_destination" : "delete_rule6_destination"
-    });
+
+    // Delete existing destination (IPv4 only - IPv6 doesn't have destination)
+    if (listType === "ipv4") {
+      operations.push({
+        op: "delete_rule_destination"
+      });
+    }
 
     // Update action
     if (rule.action) {
@@ -412,63 +443,76 @@ class AccessListService {
     }
 
     // Set new source
-    if (rule.source_type === "any") {
-      operations.push({
-        op: listType === "ipv4" ? "set_rule_source_any" : "set_rule6_source_any"
-      });
-    } else if (rule.source_type === "host" && rule.source_address) {
-      operations.push({
-        op: "set_rule_source_host",
-        value: rule.source_address
-      });
-    } else if (rule.source_type === "inverse-mask" && rule.source_address && rule.source_mask) {
-      operations.push({
-        op: "set_rule_source_inverse_mask",
-        value: rule.source_address,
-        value2: rule.source_mask
-      });
-    } else if (rule.source_type === "network" && rule.source_address) {
-      if (listType === "ipv4" && rule.source_mask) {
+    if (listType === "ipv4") {
+      // IPv4 source handling
+      if (rule.source_type === "any") {
+        operations.push({
+          op: "set_rule_source_any"
+        });
+      } else if (rule.source_type === "host" && rule.source_address) {
+        operations.push({
+          op: "set_rule_source_host",
+          value: rule.source_address
+        });
+      } else if (rule.source_type === "inverse-mask" && rule.source_address && rule.source_mask) {
+        operations.push({
+          op: "set_rule_source_inverse_mask",
+          value: rule.source_address,
+          value2: rule.source_mask
+        });
+      } else if (rule.source_type === "network" && rule.source_address && rule.source_mask) {
         operations.push({
           op: "set_rule_source_network",
           value: rule.source_address,
           value2: rule.source_mask
         });
-      } else if (listType === "ipv6") {
+      }
+    } else {
+      // IPv6 source handling - any can coexist with network or exact-match
+      // exact-match and network are mutually exclusive
+      if (rule.source_type === "any") {
+        operations.push({
+          op: "set_rule6_source_any"
+        });
+      }
+
+      if (rule.source_address) {
+        // Network can coexist with "any"
         operations.push({
           op: "set_rule6_source_network",
           value: rule.source_address
         });
       }
+
+      if (rule.source_exact_match) {
+        operations.push({
+          op: "set_rule6_source_exact_match"
+        });
+      }
     }
 
-    // Set new destination
-    if (rule.destination_type === "any") {
-      operations.push({
-        op: listType === "ipv4" ? "set_rule_destination_any" : "set_rule6_destination_any"
-      });
-    } else if (rule.destination_type === "host" && rule.destination_address) {
-      operations.push({
-        op: "set_rule_destination_host",
-        value: rule.destination_address
-      });
-    } else if (rule.destination_type === "inverse-mask" && rule.destination_address && rule.destination_mask) {
-      operations.push({
-        op: "set_rule_destination_inverse_mask",
-        value: rule.destination_address,
-        value2: rule.destination_mask
-      });
-    } else if (rule.destination_type === "network" && rule.destination_address) {
-      if (listType === "ipv4" && rule.destination_mask) {
+    // Set new destination (IPv4 only - IPv6 access-lists don't have destination)
+    if (listType === "ipv4") {
+      if (rule.destination_type === "any") {
+        operations.push({
+          op: "set_rule_destination_any"
+        });
+      } else if (rule.destination_type === "host" && rule.destination_address) {
+        operations.push({
+          op: "set_rule_destination_host",
+          value: rule.destination_address
+        });
+      } else if (rule.destination_type === "inverse-mask" && rule.destination_address && rule.destination_mask) {
+        operations.push({
+          op: "set_rule_destination_inverse_mask",
+          value: rule.destination_address,
+          value2: rule.destination_mask
+        });
+      } else if (rule.destination_type === "network" && rule.destination_address && rule.destination_mask) {
         operations.push({
           op: "set_rule_destination_network",
           value: rule.destination_address,
           value2: rule.destination_mask
-        });
-      } else if (listType === "ipv6") {
-        operations.push({
-          op: "set_rule6_destination_network",
-          value: rule.destination_address
         });
       }
     }

--- a/frontend/src/lib/api/route-map.ts
+++ b/frontend/src/lib/api/route-map.ts
@@ -32,7 +32,11 @@ export interface MatchConditions {
   ip_nexthop_prefix_len?: number | null;
   ip_nexthop_prefix_list?: string | null;
   ip_nexthop_type?: string | null;
+  ipv6_nexthop_access_list?: string | null;
   ipv6_nexthop_address?: string | null;
+  ipv6_nexthop_prefix_len?: number | null;
+  ipv6_nexthop_prefix_list?: string | null;
+  ipv6_nexthop_type?: string | null;
 
   // Route Source
   ip_route_source_access_list?: string | null;


### PR DESCRIPTION
- Added state management for IPv6 nexthop fields including address, prefix length, access list, and type.
- Implemented dropdowns for AS Path, Community, Extended Community, Large Community, and Access Lists, loading options from respective APIs.
- Updated the handling of match conditions to include IPv6 nexthop and route source fields.
- Refactored input fields to use Select components for better user experience.
- Modified AccessListService to support exact match for IPv6 sources.
- Updated route-map API interface to include new IPv6 fields.