### PR TITLE
feat: Refactor extended community list modals to use radio buttons 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ yarn-error.log*
 
 # Docker
 docker-compose.override.yml
+docker-compose.yml
 
 # Misc
 .vercel

--- a/backend/routers/as_path_list/as_path_list.py
+++ b/backend/routers/as_path_list/as_path_list.py
@@ -104,7 +104,7 @@ async def get_as_path_list_capabilities(request: Request):
     await require_read_permission(request, FeatureGroup.BGP_AS_PATH)
 
     try:
-        service = get_session_vyos_service(http_request)
+        service = get_session_vyos_service(request)
         version = service.get_version()
         builder = AsPathListBatchBuilder(version=version)
         capabilities = builder.get_capabilities()
@@ -194,7 +194,7 @@ def parse_rule(rule_number: int, rule_data: dict) -> AsPathListRule:
 
 
 @router.post("/batch")
-async def as_path_list_batch_configure(http_request: Request, request: AsPathListBatchRequest):
+async def as_path_list_batch_configure(http_request: Request, body: AsPathListBatchRequest):
     """
     Execute a batch of configuration operations.
 

--- a/backend/routers/community_list/community_list.py
+++ b/backend/routers/community_list/community_list.py
@@ -104,7 +104,7 @@ async def get_community_list_capabilities(request: Request):
     await require_read_permission(request, FeatureGroup.BGP_COMMUNITY)
 
     try:
-        service = get_session_vyos_service(http_request)
+        service = get_session_vyos_service(request)
         version = service.get_version()
         builder = CommunityListBatchBuilder(version=version)
         capabilities = builder.get_capabilities()
@@ -194,7 +194,7 @@ def parse_rule(rule_number: int, rule_data: dict) -> CommunityListRule:
 
 
 @router.post("/batch")
-async def community_list_batch_configure(http_request: Request, request: CommunityListBatchRequest):
+async def community_list_batch_configure(http_request: Request, body: CommunityListBatchRequest):
     """
     Execute a batch of configuration operations.
 

--- a/backend/routers/extcommunity_list/extcommunity_list.py
+++ b/backend/routers/extcommunity_list/extcommunity_list.py
@@ -104,7 +104,7 @@ async def get_extcommunity_list_capabilities(request: Request):
     await require_read_permission(request, FeatureGroup.BGP_EXTENDED_COMMUNITY)
 
     try:
-        service = get_session_vyos_service(http_request)
+        service = get_session_vyos_service(request)
         version = service.get_version()
         builder = ExtCommunityListBatchBuilder(version=version)
         capabilities = builder.get_capabilities()
@@ -124,7 +124,7 @@ async def get_extcommunity_list_capabilities(request: Request):
 
 
 @router.get("/config", response_model=ExtCommunityListConfig)
-async def get_extcommunity_list_config(request: Request, refresh: bool = False):
+async def get_extcommunity_list_config(http_request: Request, refresh: bool = False):
     """
     Get all extcommunity-list configuration from VyOS in a generalized format.
 
@@ -194,7 +194,7 @@ def parse_rule(rule_number: int, rule_data: dict) -> ExtCommunityListRule:
 
 
 @router.post("/batch")
-async def extcommunity_list_batch_configure(http_request: Request, request: ExtCommunityListBatchRequest):
+async def extcommunity_list_batch_configure(http_request: Request, body: ExtCommunityListBatchRequest):
     """
     Execute a batch of configuration operations.
 

--- a/backend/routers/large_community_list/large_community_list.py
+++ b/backend/routers/large_community_list/large_community_list.py
@@ -104,7 +104,7 @@ async def get_large_community_list_capabilities(request: Request):
     await require_read_permission(request, FeatureGroup.BGP_LARGE_COMMUNITY)
 
     try:
-        service = get_session_vyos_service(http_request)
+        service = get_session_vyos_service(request)
         version = service.get_version()
         builder = LargeCommunityListBatchBuilder(version=version)
         capabilities = builder.get_capabilities()
@@ -194,7 +194,7 @@ def parse_rule(rule_number: int, rule_data: dict) -> LargeCommunityListRule:
 
 
 @router.post("/batch")
-async def large_community_list_batch_configure(http_request: Request, request: LargeCommunityListBatchRequest):
+async def large_community_list_batch_configure(http_request: Request, body: LargeCommunityListBatchRequest):
     """
     Execute a batch of configuration operations.
 

--- a/backend/routers/route/route.py
+++ b/backend/routers/route/route.py
@@ -196,7 +196,7 @@ async def get_route_capabilities(request: Request):
     await require_read_permission(request, FeatureGroup.ROUTE_POLICY)
 
     try:
-        service = get_session_vyos_service(http_request)
+        service = get_session_vyos_service(request)
         version = service.get_version()
         builder = RouteBatchBuilder(version=version)
         capabilities = builder.get_capabilities()

--- a/frontend/src/app/policies/bgp-extended-community/page.tsx
+++ b/frontend/src/app/policies/bgp-extended-community/page.tsx
@@ -33,6 +33,46 @@ import { ExtCommunityListReorderBanner } from "@/components/policies/ExtCommunit
 import { cn } from "@/lib/utils";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 
+// Helper function to determine regex type, extract value, and styling
+function getRegexTypeInfo(regex: string | null | undefined): { type: string; label: string; value: string; className: string } {
+  if (!regex) {
+    return { type: "none", label: "", value: "—", className: "text-muted-foreground" };
+  }
+
+  const trimmed = regex.trim();
+  const lowerTrimmed = trimmed.toLowerCase();
+
+  if (lowerTrimmed.startsWith("rt ")) {
+    // Extract the value part after "rt "
+    const value = trimmed.substring(3).trim();
+    return {
+      type: "rt",
+      label: "RT",
+      value: value,
+      className: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20",
+    };
+  }
+
+  if (lowerTrimmed.startsWith("soo ")) {
+    // Extract the value part after "soo "
+    const value = trimmed.substring(4).trim();
+    return {
+      type: "soo",
+      label: "SoO",
+      value: value,
+      className: "bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/20",
+    };
+  }
+
+  // Advanced regex (anything else)
+  return {
+    type: "regex",
+    label: "Regex",
+    value: trimmed,
+    className: "bg-amber-500/10 text-amber-600 dark:text-amber-400 border border-amber-500/20",
+  };
+}
+
 // Sortable row component
 function ExtCommunityListRuleRow({ rule, onEdit, onDelete }: any) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -44,6 +84,8 @@ function ExtCommunityListRuleRow({ rule, onEdit, onDelete }: any) {
     transition,
     opacity: isDragging ? 0.5 : 1,
   };
+
+  const regexInfo = getRegexTypeInfo(rule.regex);
 
   return (
     <TableRow ref={setNodeRef} style={style} className={cn(isDragging && "bg-accent")}>
@@ -69,7 +111,13 @@ function ExtCommunityListRuleRow({ rule, onEdit, onDelete }: any) {
         </Badge>
       </TableCell>
       <TableCell>
-        <code className="text-xs bg-muted px-2 py-1 rounded">{rule.regex || "—"}</code>
+        {rule.regex ? (
+          <code className={cn("text-xs font-mono px-2 py-1 rounded", regexInfo.className)}>
+            {regexInfo.label}: {regexInfo.value}
+          </code>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
       </TableCell>
       <TableCell className="text-right">
         <div className="flex items-center justify-end gap-2">
@@ -522,7 +570,7 @@ export default function BGPExtCommunityPage() {
                               <TableHead>Rule #</TableHead>
                               <TableHead>Description</TableHead>
                               <TableHead>Action</TableHead>
-                              <TableHead>Regex</TableHead>
+                              <TableHead>Pattern</TableHead>
                               <TableHead className="text-right">Actions</TableHead>
                             </TableRow>
                           </TableHeader>

--- a/frontend/src/components/policies/CreateCommunityListModal.tsx
+++ b/frontend/src/components/policies/CreateCommunityListModal.tsx
@@ -27,7 +27,6 @@ export function CreateCommunityListModal({
   // Form fields
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [ruleNumber, setRuleNumber] = useState("100");
   const [ruleDescription, setRuleDescription] = useState("");
   const [action, setAction] = useState<"permit" | "deny">("permit");
   const [regex, setRegex] = useState("");
@@ -35,7 +34,6 @@ export function CreateCommunityListModal({
   const resetForm = () => {
     setName("");
     setDescription("");
-    setRuleNumber("100");
     setRuleDescription("");
     setAction("permit");
     setRegex("");
@@ -45,11 +43,6 @@ export function CreateCommunityListModal({
   const handleSubmit = async () => {
     if (!name.trim()) {
       setError("Community list name is required");
-      return;
-    }
-
-    if (!ruleNumber || isNaN(Number(ruleNumber))) {
-      setError("Valid rule number is required");
       return;
     }
 
@@ -66,7 +59,7 @@ export function CreateCommunityListModal({
         name.trim(),
         description.trim() || null,
         {
-          rule_number: Number(ruleNumber),
+          rule_number: 100,
           description: ruleDescription.trim() || null,
           action,
           regex: regex.trim(),
@@ -130,31 +123,17 @@ export function CreateCommunityListModal({
             <h3 className="font-semibold text-sm mb-4">Initial Rule</h3>
 
             <div className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="ruleNumber">Rule Number *</Label>
-                  <Input
-                    id="ruleNumber"
-                    type="number"
-                    placeholder="100"
-                    value={ruleNumber}
-                    onChange={(e) => setRuleNumber(e.target.value)}
-                    disabled={loading}
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="action">Action *</Label>
-                  <Select value={action} onValueChange={(v) => setAction(v as "permit" | "deny")} disabled={loading}>
-                    <SelectTrigger id="action">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="permit">Permit</SelectItem>
-                      <SelectItem value="deny">Deny</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
+              <div className="space-y-2">
+                <Label htmlFor="action">Action *</Label>
+                <Select value={action} onValueChange={(v) => setAction(v as "permit" | "deny")} disabled={loading}>
+                  <SelectTrigger id="action">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="permit">Permit</SelectItem>
+                    <SelectItem value="deny">Deny</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
 
               <div className="space-y-2">

--- a/frontend/src/components/policies/CreateExtCommunityListModal.tsx
+++ b/frontend/src/components/policies/CreateExtCommunityListModal.tsx
@@ -6,8 +6,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { AlertCircle, Loader2 } from "lucide-react";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { AlertCircle, Loader2, Info, Eye } from "lucide-react";
 import { extcommunityListService } from "@/lib/api/extcommunity-list";
 
 interface CreateExtCommunityListModalProps {
@@ -30,7 +30,15 @@ export function CreateExtCommunityListModal({
   const [ruleNumber, setRuleNumber] = useState("100");
   const [ruleDescription, setRuleDescription] = useState("");
   const [action, setAction] = useState<"permit" | "deny">("permit");
-  const [regex, setRegex] = useState("");
+  const [matchType, setMatchType] = useState<"rt" | "soo" | "regex">("rt");
+
+  // Separate fields for the three-part format aa:nn:nn
+  const [adminField, setAdminField] = useState("");
+  const [assignedNum1, setAssignedNum1] = useState("");
+  const [assignedNum2, setAssignedNum2] = useState("");
+
+  // Raw regex for advanced mode
+  const [rawRegex, setRawRegex] = useState("");
 
   const resetForm = () => {
     setName("");
@@ -38,8 +46,29 @@ export function CreateExtCommunityListModal({
     setRuleNumber("100");
     setRuleDescription("");
     setAction("permit");
-    setRegex("");
+    setMatchType("rt");
+    setAdminField("");
+    setAssignedNum1("");
+    setAssignedNum2("");
+    setRawRegex("");
     setError(null);
+  };
+
+  const buildRegexPattern = (): string => {
+    if (matchType === "regex") {
+      return rawRegex.trim();
+    }
+    return `${matchType} ${adminField.trim()}:${assignedNum1.trim()}:${assignedNum2.trim()}`;
+  };
+
+  const getPreview = (): string => {
+    if (matchType === "regex") {
+      return rawRegex.trim() || "(enter pattern)";
+    }
+    const admin = adminField.trim() || "?";
+    const num1 = assignedNum1.trim() || "?";
+    const num2 = assignedNum2.trim() || "?";
+    return `${matchType} ${admin}:${num1}:${num2}`;
   };
 
   const handleSubmit = async () => {
@@ -53,15 +82,45 @@ export function CreateExtCommunityListModal({
       return;
     }
 
-    if (!regex.trim()) {
-      setError("Regex pattern is required");
-      return;
+    // Validation for pattern
+    if (matchType === "regex") {
+      if (!rawRegex.trim()) {
+        setError("Regex pattern is required");
+        return;
+      }
+    } else {
+      if (!adminField.trim()) {
+        setError("Administrator field (AS Number) is required");
+        return;
+      }
+      if (!assignedNum1.trim()) {
+        setError("Assigned Number 1 is required");
+        return;
+      }
+      if (!assignedNum2.trim()) {
+        setError("Assigned Number 2 is required");
+        return;
+      }
+      if (!/^\d+$/.test(adminField.trim())) {
+        setError("Administrator field must be a valid number (e.g., 65000)");
+        return;
+      }
+      if (!/^\d+$/.test(assignedNum1.trim())) {
+        setError("Assigned Number 1 must be a valid number");
+        return;
+      }
+      if (!/^\d+$/.test(assignedNum2.trim())) {
+        setError("Assigned Number 2 must be a valid number");
+        return;
+      }
     }
 
     setLoading(true);
     setError(null);
 
     try {
+      const regexValue = buildRegexPattern();
+
       await extcommunityListService.createExtCommunityList(
         name.trim(),
         description.trim() || null,
@@ -69,7 +128,7 @@ export function CreateExtCommunityListModal({
           rule_number: Number(ruleNumber),
           description: ruleDescription.trim() || null,
           action,
-          regex: regex.trim(),
+          regex: regexValue,
         }
       );
 
@@ -92,32 +151,36 @@ export function CreateExtCommunityListModal({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[600px]">
+      <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Create ExtCommunity List</DialogTitle>
+          <DialogTitle>Create Extended Community List</DialogTitle>
           <DialogDescription>
-            Create a new BGP ExtCommunity list with an initial rule
+            Create a new BGP Extended Community list with an initial rule
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-4">
-          {/* ExtCommunity List Fields */}
+        <div className="space-y-5 py-4">
+          {/* ExtCommunity List Name */}
           <div className="space-y-2">
-            <Label htmlFor="name">ExtCommunity List Name *</Label>
+            <Label htmlFor="name">List Name *</Label>
             <Input
               id="name"
-              placeholder="e.g., ALLOW_AS65000"
+              placeholder="e.g., DATACENTER_RT or VPN_SOO"
               value={name}
               onChange={(e) => setName(e.target.value)}
               disabled={loading}
             />
+            <p className="text-xs text-muted-foreground">
+              A unique name to identify this extended community list
+            </p>
           </div>
 
+          {/* Description */}
           <div className="space-y-2">
-            <Label htmlFor="description">Description</Label>
+            <Label htmlFor="description">List Description (Optional)</Label>
             <Textarea
               id="description"
-              placeholder="Optional description"
+              placeholder="e.g., Route targets for datacenter VPN"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               disabled={loading}
@@ -125,48 +188,185 @@ export function CreateExtCommunityListModal({
             />
           </div>
 
-          {/* Initial Rule */}
+          {/* Initial Rule Section */}
           <div className="pt-4 border-t">
-            <h3 className="font-semibold text-sm mb-4">Initial Rule (Rule #{ruleNumber})</h3>
+            <h3 className="font-semibold text-sm mb-4">Initial Rule Configuration</h3>
 
-            <div className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="action">Action *</Label>
-                <Select value={action} onValueChange={(v) => setAction(v as "permit" | "deny")} disabled={loading}>
-                  <SelectTrigger id="action">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="permit">Permit</SelectItem>
-                    <SelectItem value="deny">Deny</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+            {/* Action Selection */}
+            <div className="space-y-3 mb-4">
+              <Label className="text-sm font-medium">Rule Action</Label>
+              <RadioGroup
+                value={action}
+                onValueChange={(v) => setAction(v as "permit" | "deny")}
+                className="flex gap-4"
+                disabled={loading}
+              >
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="permit" id="permit" />
+                  <Label htmlFor="permit" className="font-normal cursor-pointer">
+                    <span className="inline-flex items-center gap-1.5">
+                      <span className="w-2 h-2 rounded-full bg-green-500"></span>
+                      Permit
+                    </span>
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="deny" id="deny" />
+                  <Label htmlFor="deny" className="font-normal cursor-pointer">
+                    <span className="inline-flex items-center gap-1.5">
+                      <span className="w-2 h-2 rounded-full bg-red-500"></span>
+                      Deny
+                    </span>
+                  </Label>
+                </div>
+              </RadioGroup>
+            </div>
 
-              <div className="space-y-2">
-                <Label htmlFor="regex">Regex Pattern *</Label>
-                <Input
-                  id="regex"
-                  placeholder="e.g., ^65000_"
-                  value={regex}
-                  onChange={(e) => setRegex(e.target.value)}
-                  disabled={loading}
-                />
-                <p className="text-xs text-muted-foreground">
-                  Regular expression to match AS paths (e.g., "64501 64502")
+            {/* Match Type Selection */}
+            <div className="space-y-3 mb-4">
+              <Label className="text-sm font-medium">Community Type</Label>
+              <RadioGroup
+                value={matchType}
+                onValueChange={(v) => setMatchType(v as "rt" | "soo" | "regex")}
+                className="grid grid-cols-1 gap-2"
+                disabled={loading}
+              >
+                <div className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-muted/50 transition-colors">
+                  <RadioGroupItem value="rt" id="rt" className="mt-0.5" />
+                  <div className="flex-1">
+                    <Label htmlFor="rt" className="font-medium cursor-pointer">Route Target (RT)</Label>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      Used for VPN route distribution between VRFs
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-muted/50 transition-colors">
+                  <RadioGroupItem value="soo" id="soo" className="mt-0.5" />
+                  <div className="flex-1">
+                    <Label htmlFor="soo" className="font-medium cursor-pointer">Site of Origin (SoO)</Label>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      Used to prevent routing loops in multi-homed sites
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-muted/50 transition-colors">
+                  <RadioGroupItem value="regex" id="regex" className="mt-0.5" />
+                  <div className="flex-1">
+                    <Label htmlFor="regex" className="font-medium cursor-pointer">Advanced (Regex Pattern)</Label>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      Enter a custom regex pattern for complex matching
+                    </p>
+                  </div>
+                </div>
+              </RadioGroup>
+            </div>
+
+            {/* Community Value Fields */}
+            {matchType !== "regex" ? (
+              <div className="space-y-3 p-4 bg-muted/30 rounded-lg border mb-4">
+                <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-3">
+                  <Info className="h-4 w-4" />
+                  Enter the {matchType === "rt" ? "Route Target" : "Site of Origin"} values (format: aa:nn:nn)
+                </div>
+                <div className="grid grid-cols-3 gap-3">
+                  <div className="space-y-2">
+                    <Label htmlFor="adminField">AS Number</Label>
+                    <Input
+                      id="adminField"
+                      placeholder="65000"
+                      value={adminField}
+                      onChange={(e) => setAdminField(e.target.value)}
+                      disabled={loading}
+                      type="number"
+                      min="1"
+                      max="4294967295"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Administrator
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="assignedNum1">Value 1</Label>
+                    <Input
+                      id="assignedNum1"
+                      placeholder="100"
+                      value={assignedNum1}
+                      onChange={(e) => setAssignedNum1(e.target.value)}
+                      disabled={loading}
+                      type="number"
+                      min="0"
+                      max="65535"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Assigned #1
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="assignedNum2">Value 2</Label>
+                    <Input
+                      id="assignedNum2"
+                      placeholder="200"
+                      value={assignedNum2}
+                      onChange={(e) => setAssignedNum2(e.target.value)}
+                      disabled={loading}
+                      type="number"
+                      min="0"
+                      max="65535"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Assigned #2
+                    </p>
+                  </div>
+                </div>
+                <p className="text-xs text-muted-foreground mt-2">
+                  Example: <code className="bg-muted px-1 rounded">65000:100:200</code> creates {matchType} 65000:100:200
                 </p>
               </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="ruleDescription">Rule Description</Label>
-                <Input
-                  id="ruleDescription"
-                  placeholder="Optional rule description"
-                  value={ruleDescription}
-                  onChange={(e) => setRuleDescription(e.target.value)}
-                  disabled={loading}
-                />
+            ) : (
+              <div className="space-y-3 p-4 bg-muted/30 rounded-lg border mb-4">
+                <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-3">
+                  <Info className="h-4 w-4" />
+                  Enter a regex pattern to match extended communities
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="rawRegex">Regex Pattern</Label>
+                  <Input
+                    id="rawRegex"
+                    placeholder="e.g., rt 65000:100:200 or soo 65000:.*:.*"
+                    value={rawRegex}
+                    onChange={(e) => setRawRegex(e.target.value)}
+                    disabled={loading}
+                    className="font-mono text-sm"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Examples: <code className="bg-muted px-1 rounded">rt 65000:.*:.*</code> (all RTs from AS 65000),
+                    <code className="bg-muted px-1 rounded ml-1">soo .*:100:.*</code> (all SoOs with value 100)
+                  </p>
+                </div>
               </div>
+            )}
+
+            {/* Preview */}
+            <div className="flex items-center gap-3 p-3 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded-lg mb-4">
+              <Eye className="h-4 w-4 text-blue-600 dark:text-blue-400 shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-xs text-blue-600 dark:text-blue-400 font-medium">Configuration Preview</p>
+                <p className="text-sm font-mono truncate mt-0.5">
+                  {action} extended-community: <span className="font-semibold">{getPreview()}</span>
+                </p>
+              </div>
+            </div>
+
+            {/* Rule Description */}
+            <div className="space-y-2">
+              <Label htmlFor="ruleDescription">Rule Description (Optional)</Label>
+              <Input
+                id="ruleDescription"
+                placeholder="e.g., Allow route targets from datacenter"
+                value={ruleDescription}
+                onChange={(e) => setRuleDescription(e.target.value)}
+                disabled={loading}
+              />
             </div>
           </div>
 
@@ -184,7 +384,7 @@ export function CreateExtCommunityListModal({
           </Button>
           <Button onClick={handleSubmit} disabled={loading}>
             {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            {loading ? "Creating..." : "Create ExtCommunity List"}
+            {loading ? "Creating..." : "Create List"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/policies/CreateExtCommunityListRuleModal.tsx
+++ b/frontend/src/components/policies/CreateExtCommunityListRuleModal.tsx
@@ -5,8 +5,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { AlertCircle, Loader2 } from "lucide-react";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { AlertCircle, Loader2, Info, Eye } from "lucide-react";
 import { extcommunityListService, type ExtCommunityListCapabilities } from "@/lib/api/extcommunity-list";
 
 interface CreateExtCommunityListRuleModalProps {
@@ -31,7 +31,15 @@ export function CreateExtCommunityListRuleModal({
   const [ruleNumber, setRuleNumber] = useState<number>(100);
   const [description, setDescription] = useState("");
   const [action, setAction] = useState<"permit" | "deny">("permit");
-  const [regex, setRegex] = useState("");
+  const [matchType, setMatchType] = useState<"rt" | "soo" | "regex">("rt");
+
+  // Separate fields for the three-part format aa:nn:nn
+  const [adminField, setAdminField] = useState("");      // First part (aa) - AS number or IP
+  const [assignedNum1, setAssignedNum1] = useState("");  // Second part (nn)
+  const [assignedNum2, setAssignedNum2] = useState("");  // Third part (nn)
+
+  // Raw regex for advanced mode
+  const [rawRegex, setRawRegex] = useState("");
 
   useEffect(() => {
     if (open) {
@@ -60,25 +68,78 @@ export function CreateExtCommunityListRuleModal({
   const resetForm = () => {
     setDescription("");
     setAction("permit");
-    setRegex("");
+    setMatchType("rt");
+    setAdminField("");
+    setAssignedNum1("");
+    setAssignedNum2("");
+    setRawRegex("");
     setError(null);
   };
 
+  const buildRegexPattern = (): string => {
+    if (matchType === "regex") {
+      return rawRegex.trim();
+    }
+    // For rt and soo, build the pattern in aa:nn:nn format
+    return `${matchType} ${adminField.trim()}:${assignedNum1.trim()}:${assignedNum2.trim()}`;
+  };
+
+  const getPreview = (): string => {
+    if (matchType === "regex") {
+      return rawRegex.trim() || "(enter pattern)";
+    }
+    const admin = adminField.trim() || "?";
+    const num1 = assignedNum1.trim() || "?";
+    const num2 = assignedNum2.trim() || "?";
+    return `${matchType} ${admin}:${num1}:${num2}`;
+  };
+
   const handleSubmit = async () => {
-    if (!regex.trim()) {
-      setError("Regex pattern is required");
-      return;
+    // Validation
+    if (matchType === "regex") {
+      if (!rawRegex.trim()) {
+        setError("Regex pattern is required");
+        return;
+      }
+    } else {
+      if (!adminField.trim()) {
+        setError("Administrator field (AS Number) is required");
+        return;
+      }
+      if (!assignedNum1.trim()) {
+        setError("Assigned Number 1 is required");
+        return;
+      }
+      if (!assignedNum2.trim()) {
+        setError("Assigned Number 2 is required");
+        return;
+      }
+      // Validate all fields are numeric
+      if (!/^\d+$/.test(adminField.trim())) {
+        setError("Administrator field must be a valid number (e.g., 65000)");
+        return;
+      }
+      if (!/^\d+$/.test(assignedNum1.trim())) {
+        setError("Assigned Number 1 must be a valid number");
+        return;
+      }
+      if (!/^\d+$/.test(assignedNum2.trim())) {
+        setError("Assigned Number 2 must be a valid number");
+        return;
+      }
     }
 
     setLoading(true);
     setError(null);
 
     try {
+      const regexValue = buildRegexPattern();
+
       await extcommunityListService.addRule(extcommunityListName, {
         rule_number: ruleNumber,
         description: description.trim() || null,
         action,
-        regex: regex.trim(),
+        regex: regexValue,
       });
 
       resetForm();
@@ -100,47 +161,186 @@ export function CreateExtCommunityListRuleModal({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[500px]">
+      <DialogContent className="sm:max-w-[550px]">
         <DialogHeader>
-          <DialogTitle>Add Rule</DialogTitle>
+          <DialogTitle>Add Extended Community Rule</DialogTitle>
           <DialogDescription>
-            Add a new rule to ExtCommunity list: {extcommunityListName} (Rule #{ruleNumber})
+            Add a new rule to ExtCommunity list: <span className="font-medium">{extcommunityListName}</span>
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-4">
-          <div className="space-y-2">
-            <Label htmlFor="action">Action *</Label>
-            <Select value={action} onValueChange={(v) => setAction(v as "permit" | "deny")} disabled={loading}>
-              <SelectTrigger id="action">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="permit">Permit</SelectItem>
-                <SelectItem value="deny">Deny</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="regex">Regex Pattern *</Label>
-            <Input
-              id="regex"
-              placeholder="e.g., ^65000_"
-              value={regex}
-              onChange={(e) => setRegex(e.target.value)}
+        <div className="space-y-5 py-4">
+          {/* Action Selection */}
+          <div className="space-y-3">
+            <Label className="text-sm font-medium">Rule Action</Label>
+            <RadioGroup
+              value={action}
+              onValueChange={(v) => setAction(v as "permit" | "deny")}
+              className="flex gap-4"
               disabled={loading}
-            />
-            <p className="text-xs text-muted-foreground">
-              Regular expression to match AS paths (e.g., "64501 64502")
-            </p>
+            >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="permit" id="permit" />
+                <Label htmlFor="permit" className="font-normal cursor-pointer">
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-green-500"></span>
+                    Permit
+                  </span>
+                </Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="deny" id="deny" />
+                <Label htmlFor="deny" className="font-normal cursor-pointer">
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-red-500"></span>
+                    Deny
+                  </span>
+                </Label>
+              </div>
+            </RadioGroup>
           </div>
 
+          {/* Match Type Selection */}
+          <div className="space-y-3">
+            <Label className="text-sm font-medium">Community Type</Label>
+            <RadioGroup
+              value={matchType}
+              onValueChange={(v) => setMatchType(v as "rt" | "soo" | "regex")}
+              className="grid grid-cols-1 gap-2"
+              disabled={loading}
+            >
+              <div className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-muted/50 transition-colors">
+                <RadioGroupItem value="rt" id="rt" className="mt-0.5" />
+                <div className="flex-1">
+                  <Label htmlFor="rt" className="font-medium cursor-pointer">Route Target (RT)</Label>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Used for VPN route distribution between VRFs
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-muted/50 transition-colors">
+                <RadioGroupItem value="soo" id="soo" className="mt-0.5" />
+                <div className="flex-1">
+                  <Label htmlFor="soo" className="font-medium cursor-pointer">Site of Origin (SoO)</Label>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Used to prevent routing loops in multi-homed sites
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-muted/50 transition-colors">
+                <RadioGroupItem value="regex" id="regex" className="mt-0.5" />
+                <div className="flex-1">
+                  <Label htmlFor="regex" className="font-medium cursor-pointer">Advanced (Regex Pattern)</Label>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Enter a custom regex pattern for complex matching
+                  </p>
+                </div>
+              </div>
+            </RadioGroup>
+          </div>
+
+          {/* Community Value Fields */}
+          {matchType !== "regex" ? (
+            <div className="space-y-3 p-4 bg-muted/30 rounded-lg border">
+              <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-3">
+                <Info className="h-4 w-4" />
+                Enter the {matchType === "rt" ? "Route Target" : "Site of Origin"} values (format: aa:nn:nn)
+              </div>
+              <div className="grid grid-cols-3 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="adminField">AS Number</Label>
+                  <Input
+                    id="adminField"
+                    placeholder="65000"
+                    value={adminField}
+                    onChange={(e) => setAdminField(e.target.value)}
+                    disabled={loading}
+                    type="number"
+                    min="1"
+                    max="4294967295"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Administrator
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="assignedNum1">Value 1</Label>
+                  <Input
+                    id="assignedNum1"
+                    placeholder="100"
+                    value={assignedNum1}
+                    onChange={(e) => setAssignedNum1(e.target.value)}
+                    disabled={loading}
+                    type="number"
+                    min="0"
+                    max="65535"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Assigned #1
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="assignedNum2">Value 2</Label>
+                  <Input
+                    id="assignedNum2"
+                    placeholder="200"
+                    value={assignedNum2}
+                    onChange={(e) => setAssignedNum2(e.target.value)}
+                    disabled={loading}
+                    type="number"
+                    min="0"
+                    max="65535"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Assigned #2
+                  </p>
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground mt-2">
+                Example: <code className="bg-muted px-1 rounded">65000:100:200</code> creates {matchType} 65000:100:200
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3 p-4 bg-muted/30 rounded-lg border">
+              <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-3">
+                <Info className="h-4 w-4" />
+                Enter a regex pattern to match extended communities
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="rawRegex">Regex Pattern</Label>
+                <Input
+                  id="rawRegex"
+                  placeholder="e.g., rt 65000:100:200 or soo 65000:.*:.*"
+                  value={rawRegex}
+                  onChange={(e) => setRawRegex(e.target.value)}
+                  disabled={loading}
+                  className="font-mono text-sm"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Examples: <code className="bg-muted px-1 rounded">rt 65000:.*:.*</code> (all RTs from AS 65000),
+                  <code className="bg-muted px-1 rounded ml-1">soo .*:100:.*</code> (all SoOs with value 100)
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Preview */}
+          <div className="flex items-center gap-3 p-3 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded-lg">
+            <Eye className="h-4 w-4 text-blue-600 dark:text-blue-400 shrink-0" />
+            <div className="flex-1 min-w-0">
+              <p className="text-xs text-blue-600 dark:text-blue-400 font-medium">Configuration Preview</p>
+              <p className="text-sm font-mono truncate mt-0.5">
+                {action} extended-community: <span className="font-semibold">{getPreview()}</span>
+              </p>
+            </div>
+          </div>
+
+          {/* Description */}
           <div className="space-y-2">
-            <Label htmlFor="description">Description</Label>
+            <Label htmlFor="description">Description (Optional)</Label>
             <Input
               id="description"
-              placeholder="Optional description"
+              placeholder="e.g., Allow route targets from datacenter"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               disabled={loading}

--- a/frontend/src/components/policies/EditExtCommunityListRuleModal.tsx
+++ b/frontend/src/components/policies/EditExtCommunityListRuleModal.tsx
@@ -5,8 +5,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { AlertCircle, Loader2 } from "lucide-react";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { AlertCircle, Loader2, Info, Eye } from "lucide-react";
 import { extcommunityListService, type ExtCommunityListCapabilities, type ExtCommunityListRule } from "@/lib/api/extcommunity-list";
 
 interface EditExtCommunityListRuleModalProps {
@@ -32,31 +32,116 @@ export function EditExtCommunityListRuleModal({
   // Form fields
   const [description, setDescription] = useState("");
   const [action, setAction] = useState<"permit" | "deny">("permit");
-  const [regex, setRegex] = useState("");
+  const [matchType, setMatchType] = useState<"rt" | "soo" | "regex">("rt");
+
+  // Separate fields for the three-part format aa:nn:nn
+  const [adminField, setAdminField] = useState("");      // First part (aa) - AS number
+  const [assignedNum1, setAssignedNum1] = useState("");  // Second part (nn)
+  const [assignedNum2, setAssignedNum2] = useState("");  // Third part (nn)
+
+  // Raw regex for advanced mode
+  const [rawRegex, setRawRegex] = useState("");
+
+  // Parse the existing regex to determine matchType and values (three-part format aa:nn:nn)
+  const parseRegex = (regex: string): { matchType: "rt" | "soo" | "regex"; adminField: string; assignedNum1: string; assignedNum2: string; rawRegex: string } => {
+    if (!regex) {
+      return { matchType: "rt", adminField: "", assignedNum1: "", assignedNum2: "", rawRegex: "" };
+    }
+
+    // Check for rt or soo prefix with three-part format (aa:nn:nn)
+    const rtMatch = regex.match(/^rt\s+(\d+):(\d+):(\d+)$/);
+    if (rtMatch) {
+      return { matchType: "rt", adminField: rtMatch[1], assignedNum1: rtMatch[2], assignedNum2: rtMatch[3], rawRegex: "" };
+    }
+
+    const sooMatch = regex.match(/^soo\s+(\d+):(\d+):(\d+)$/);
+    if (sooMatch) {
+      return { matchType: "soo", adminField: sooMatch[1], assignedNum1: sooMatch[2], assignedNum2: sooMatch[3], rawRegex: "" };
+    }
+
+    // If it doesn't match the standard format, treat as regex
+    return { matchType: "regex", adminField: "", assignedNum1: "", assignedNum2: "", rawRegex: regex };
+  };
 
   useEffect(() => {
     if (open && rule) {
       setDescription(rule.description || "");
       setAction(rule.action as "permit" | "deny");
-      setRegex(rule.regex || "");
+
+      const parsed = parseRegex(rule.regex || "");
+      setMatchType(parsed.matchType);
+      setAdminField(parsed.adminField);
+      setAssignedNum1(parsed.assignedNum1);
+      setAssignedNum2(parsed.assignedNum2);
+      setRawRegex(parsed.rawRegex);
+
       setError(null);
     }
   }, [open, rule]);
 
+  const buildRegexPattern = (): string => {
+    if (matchType === "regex") {
+      return rawRegex.trim();
+    }
+    // For rt and soo, build the pattern in aa:nn:nn format
+    return `${matchType} ${adminField.trim()}:${assignedNum1.trim()}:${assignedNum2.trim()}`;
+  };
+
+  const getPreview = (): string => {
+    if (matchType === "regex") {
+      return rawRegex.trim() || "(enter pattern)";
+    }
+    const admin = adminField.trim() || "?";
+    const num1 = assignedNum1.trim() || "?";
+    const num2 = assignedNum2.trim() || "?";
+    return `${matchType} ${admin}:${num1}:${num2}`;
+  };
+
   const handleSubmit = async () => {
-    if (!regex.trim()) {
-      setError("Regex pattern is required");
-      return;
+    // Validation
+    if (matchType === "regex") {
+      if (!rawRegex.trim()) {
+        setError("Regex pattern is required");
+        return;
+      }
+    } else {
+      if (!adminField.trim()) {
+        setError("Administrator field (AS Number) is required");
+        return;
+      }
+      if (!assignedNum1.trim()) {
+        setError("Assigned Number 1 is required");
+        return;
+      }
+      if (!assignedNum2.trim()) {
+        setError("Assigned Number 2 is required");
+        return;
+      }
+      // Validate all fields are numeric
+      if (!/^\d+$/.test(adminField.trim())) {
+        setError("Administrator field must be a valid number (e.g., 65000)");
+        return;
+      }
+      if (!/^\d+$/.test(assignedNum1.trim())) {
+        setError("Assigned Number 1 must be a valid number");
+        return;
+      }
+      if (!/^\d+$/.test(assignedNum2.trim())) {
+        setError("Assigned Number 2 must be a valid number");
+        return;
+      }
     }
 
     setLoading(true);
     setError(null);
 
     try {
+      const regexValue = buildRegexPattern();
+
       await extcommunityListService.updateRule(extcommunityListName, rule.rule_number, {
         description: description.trim() || undefined,
         action,
-        regex: regex.trim(),
+        regex: regexValue,
       });
 
       onOpenChange(false);
@@ -77,47 +162,186 @@ export function EditExtCommunityListRuleModal({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[500px]">
+      <DialogContent className="sm:max-w-[550px]">
         <DialogHeader>
-          <DialogTitle>Edit Rule #{rule.rule_number}</DialogTitle>
+          <DialogTitle>Edit Extended Community Rule #{rule.rule_number}</DialogTitle>
           <DialogDescription>
-            Editing rule in ExtCommunity list: {extcommunityListName}
+            Editing rule in ExtCommunity list: <span className="font-medium">{extcommunityListName}</span>
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-4">
-          <div className="space-y-2">
-            <Label htmlFor="action">Action *</Label>
-            <Select value={action} onValueChange={(v) => setAction(v as "permit" | "deny")} disabled={loading}>
-              <SelectTrigger id="action">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="permit">Permit</SelectItem>
-                <SelectItem value="deny">Deny</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="regex">Regex Pattern *</Label>
-            <Input
-              id="regex"
-              placeholder="e.g., ^65000_"
-              value={regex}
-              onChange={(e) => setRegex(e.target.value)}
+        <div className="space-y-5 py-4">
+          {/* Action Selection */}
+          <div className="space-y-3">
+            <Label className="text-sm font-medium">Rule Action</Label>
+            <RadioGroup
+              value={action}
+              onValueChange={(v) => setAction(v as "permit" | "deny")}
+              className="flex gap-4"
               disabled={loading}
-            />
-            <p className="text-xs text-muted-foreground">
-              Regular expression to match AS paths (e.g., "64501 64502")
-            </p>
+            >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="permit" id="edit-permit" />
+                <Label htmlFor="edit-permit" className="font-normal cursor-pointer">
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-green-500"></span>
+                    Permit
+                  </span>
+                </Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="deny" id="edit-deny" />
+                <Label htmlFor="edit-deny" className="font-normal cursor-pointer">
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-red-500"></span>
+                    Deny
+                  </span>
+                </Label>
+              </div>
+            </RadioGroup>
           </div>
 
+          {/* Match Type Selection */}
+          <div className="space-y-3">
+            <Label className="text-sm font-medium">Community Type</Label>
+            <RadioGroup
+              value={matchType}
+              onValueChange={(v) => setMatchType(v as "rt" | "soo" | "regex")}
+              className="grid grid-cols-1 gap-2"
+              disabled={loading}
+            >
+              <div className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-muted/50 transition-colors">
+                <RadioGroupItem value="rt" id="edit-rt" className="mt-0.5" />
+                <div className="flex-1">
+                  <Label htmlFor="edit-rt" className="font-medium cursor-pointer">Route Target (RT)</Label>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Used for VPN route distribution between VRFs
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-muted/50 transition-colors">
+                <RadioGroupItem value="soo" id="edit-soo" className="mt-0.5" />
+                <div className="flex-1">
+                  <Label htmlFor="edit-soo" className="font-medium cursor-pointer">Site of Origin (SoO)</Label>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Used to prevent routing loops in multi-homed sites
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-muted/50 transition-colors">
+                <RadioGroupItem value="regex" id="edit-regex" className="mt-0.5" />
+                <div className="flex-1">
+                  <Label htmlFor="edit-regex" className="font-medium cursor-pointer">Advanced (Regex Pattern)</Label>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Enter a custom regex pattern for complex matching
+                  </p>
+                </div>
+              </div>
+            </RadioGroup>
+          </div>
+
+          {/* Community Value Fields */}
+          {matchType !== "regex" ? (
+            <div className="space-y-3 p-4 bg-muted/30 rounded-lg border">
+              <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-3">
+                <Info className="h-4 w-4" />
+                Enter the {matchType === "rt" ? "Route Target" : "Site of Origin"} values (format: aa:nn:nn)
+              </div>
+              <div className="grid grid-cols-3 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="edit-adminField">AS Number</Label>
+                  <Input
+                    id="edit-adminField"
+                    placeholder="65000"
+                    value={adminField}
+                    onChange={(e) => setAdminField(e.target.value)}
+                    disabled={loading}
+                    type="number"
+                    min="1"
+                    max="4294967295"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Administrator
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-assignedNum1">Value 1</Label>
+                  <Input
+                    id="edit-assignedNum1"
+                    placeholder="100"
+                    value={assignedNum1}
+                    onChange={(e) => setAssignedNum1(e.target.value)}
+                    disabled={loading}
+                    type="number"
+                    min="0"
+                    max="65535"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Assigned #1
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-assignedNum2">Value 2</Label>
+                  <Input
+                    id="edit-assignedNum2"
+                    placeholder="200"
+                    value={assignedNum2}
+                    onChange={(e) => setAssignedNum2(e.target.value)}
+                    disabled={loading}
+                    type="number"
+                    min="0"
+                    max="65535"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Assigned #2
+                  </p>
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground mt-2">
+                Example: <code className="bg-muted px-1 rounded">65000:100:200</code> creates {matchType} 65000:100:200
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3 p-4 bg-muted/30 rounded-lg border">
+              <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-3">
+                <Info className="h-4 w-4" />
+                Enter a regex pattern to match extended communities
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-rawRegex">Regex Pattern</Label>
+                <Input
+                  id="edit-rawRegex"
+                  placeholder="e.g., rt 65000:100:200 or soo 65000:.*:.*"
+                  value={rawRegex}
+                  onChange={(e) => setRawRegex(e.target.value)}
+                  disabled={loading}
+                  className="font-mono text-sm"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Examples: <code className="bg-muted px-1 rounded">rt 65000:.*:.*</code> (all RTs from AS 65000),
+                  <code className="bg-muted px-1 rounded ml-1">soo .*:100:.*</code> (all SoOs with value 100)
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Preview */}
+          <div className="flex items-center gap-3 p-3 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded-lg">
+            <Eye className="h-4 w-4 text-blue-600 dark:text-blue-400 shrink-0" />
+            <div className="flex-1 min-w-0">
+              <p className="text-xs text-blue-600 dark:text-blue-400 font-medium">Configuration Preview</p>
+              <p className="text-sm font-mono truncate mt-0.5">
+                {action} extended-community: <span className="font-semibold">{getPreview()}</span>
+              </p>
+            </div>
+          </div>
+
+          {/* Description */}
           <div className="space-y-2">
-            <Label htmlFor="description">Description</Label>
+            <Label htmlFor="edit-description">Description (Optional)</Label>
             <Input
-              id="description"
-              placeholder="Optional description"
+              id="edit-description"
+              placeholder="e.g., Allow route targets from datacenter"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               disabled={loading}


### PR DESCRIPTION
For action and match type selection

- Updated CreateExtCommunityListModal, CreateExtCommunityListRuleModal, and EditExtCommunityListRuleModal components to replace select inputs with radio buttons for action and community type selection.
- Introduced separate fields for Route Target (RT) and Site of Origin (SoO) values in a three-part format (aa:nn:nn).
- Added raw regex input for advanced matching mode.
- Implemented validation for numeric fields and regex patterns.
- Enhanced user experience with configuration previews and improved descriptions.