### PR TITLE
feat(firewall-zones): enhance zone rule panel and policy table

### DIFF
--- a/backend/vyos_builders/firewall/ipv4.py
+++ b/backend/vyos_builders/firewall/ipv4.py
@@ -244,6 +244,11 @@ class FirewallIPv4BatchBuilder:
         path = self.mappers[self.mapper_key].get_rule_source_group_address(chain, rule_number, group_name, is_custom)
         return self.add_set(path)
 
+    def delete_rule_source_group(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv4BatchBuilder":
+        """Delete entire source group node."""
+        path = self.mappers[self.mapper_key].get_rule_source_group_path(chain, rule_number, is_custom)
+        return self.add_delete(path)
+
     def delete_rule_source_group_address(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv4BatchBuilder":
         """Delete source address group."""
         path = self.mappers[self.mapper_key].get_rule_source_group_address_path(chain, rule_number, is_custom)
@@ -357,6 +362,11 @@ class FirewallIPv4BatchBuilder:
         """Set destination address group."""
         path = self.mappers[self.mapper_key].get_rule_destination_group_address(chain, rule_number, group_name, is_custom)
         return self.add_set(path)
+
+    def delete_rule_destination_group(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv4BatchBuilder":
+        """Delete entire destination group node."""
+        path = self.mappers[self.mapper_key].get_rule_destination_group_path(chain, rule_number, is_custom)
+        return self.add_delete(path)
 
     def delete_rule_destination_group_address(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv4BatchBuilder":
         """Delete destination address group."""

--- a/backend/vyos_builders/firewall/ipv6.py
+++ b/backend/vyos_builders/firewall/ipv6.py
@@ -244,6 +244,11 @@ class FirewallIPv6BatchBuilder:
         path = self.mappers[self.mapper_key].get_rule_source_group_address(chain, rule_number, group_name, is_custom)
         return self.add_set(path)
 
+    def delete_rule_source_group(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv6BatchBuilder":
+        """Delete entire source group node."""
+        path = self.mappers[self.mapper_key].get_rule_source_group_path(chain, rule_number, is_custom)
+        return self.add_delete(path)
+
     def delete_rule_source_group_address(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv6BatchBuilder":
         """Delete source address group."""
         path = self.mappers[self.mapper_key].get_rule_source_group_address_path(chain, rule_number, is_custom)
@@ -337,6 +342,11 @@ class FirewallIPv6BatchBuilder:
         """Set destination address group."""
         path = self.mappers[self.mapper_key].get_rule_destination_group_address(chain, rule_number, group_name, is_custom)
         return self.add_set(path)
+
+    def delete_rule_destination_group(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv6BatchBuilder":
+        """Delete entire destination group node."""
+        path = self.mappers[self.mapper_key].get_rule_destination_group_path(chain, rule_number, is_custom)
+        return self.add_delete(path)
 
     def delete_rule_destination_group_address(self, chain: str, rule_number: int, is_custom: bool = False) -> "FirewallIPv6BatchBuilder":
         """Delete destination address group."""

--- a/backend/vyos_mappers/firewall/ipv4.py
+++ b/backend/vyos_mappers/firewall/ipv4.py
@@ -218,6 +218,12 @@ class FirewallIPv4Mapper(BaseFeatureMapper):
             return ["firewall", "ipv4", "name", chain, "rule", str(rule_number), "source", "group", "address-group", group_name]
         return ["firewall", "ipv4", chain, "filter", "rule", str(rule_number), "source", "group", "address-group", group_name]
 
+    def get_rule_source_group_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
+        """Get command path for the entire source group node (for deletion)."""
+        if is_custom:
+            return ["firewall", "ipv4", "name", chain, "rule", str(rule_number), "source", "group"]
+        return ["firewall", "ipv4", chain, "filter", "rule", str(rule_number), "source", "group"]
+
     def get_rule_source_group_address_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
         """Get command path for source address group (for deletion)."""
         if is_custom:
@@ -353,6 +359,12 @@ class FirewallIPv4Mapper(BaseFeatureMapper):
         if is_custom:
             return ["firewall", "ipv4", "name", chain, "rule", str(rule_number), "destination", "group", "address-group", group_name]
         return ["firewall", "ipv4", chain, "filter", "rule", str(rule_number), "destination", "group", "address-group", group_name]
+
+    def get_rule_destination_group_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
+        """Get command path for the entire destination group node (for deletion)."""
+        if is_custom:
+            return ["firewall", "ipv4", "name", chain, "rule", str(rule_number), "destination", "group"]
+        return ["firewall", "ipv4", chain, "filter", "rule", str(rule_number), "destination", "group"]
 
     def get_rule_destination_group_address_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
         """Get command path for destination address group (for deletion)."""

--- a/backend/vyos_mappers/firewall/ipv6.py
+++ b/backend/vyos_mappers/firewall/ipv6.py
@@ -218,6 +218,12 @@ class FirewallIPv6Mapper(BaseFeatureMapper):
             return ["firewall", "ipv6", "name", chain, "rule", str(rule_number), "source", "group", "address-group", group_name]
         return ["firewall", "ipv6", chain, "filter", "rule", str(rule_number), "source", "group", "address-group", group_name]
 
+    def get_rule_source_group_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
+        """Get command path for the entire source group node (for deletion)."""
+        if is_custom:
+            return ["firewall", "ipv6", "name", chain, "rule", str(rule_number), "source", "group"]
+        return ["firewall", "ipv6", chain, "filter", "rule", str(rule_number), "source", "group"]
+
     def get_rule_source_group_address_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
         """Get command path for source address group (for deletion)."""
         if is_custom:
@@ -329,6 +335,12 @@ class FirewallIPv6Mapper(BaseFeatureMapper):
         if is_custom:
             return ["firewall", "ipv6", "name", chain, "rule", str(rule_number), "destination", "group", "address-group", group_name]
         return ["firewall", "ipv6", chain, "filter", "rule", str(rule_number), "destination", "group", "address-group", group_name]
+
+    def get_rule_destination_group_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
+        """Get command path for the entire destination group node (for deletion)."""
+        if is_custom:
+            return ["firewall", "ipv6", "name", chain, "rule", str(rule_number), "destination", "group"]
+        return ["firewall", "ipv6", chain, "filter", "rule", str(rule_number), "destination", "group"]
 
     def get_rule_destination_group_address_path(self, chain: str, rule_number: int, is_custom: bool = False) -> List[str]:
         """Get command path for destination address group (for deletion)."""

--- a/frontend/src/app/firewall/zones/page.tsx
+++ b/frontend/src/app/firewall/zones/page.tsx
@@ -25,14 +25,16 @@ import {
   Plus,
   GripVertical,
   ArrowUpDown,
+  Globe,
 } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useState, useEffect, useCallback, type CSSProperties } from "react";
 import { firewallZonesService, resolveChainName } from "@/lib/api/firewall-zones";
+import { firewallGroupsService, type FirewallGroup } from "@/lib/api/firewall-groups";
 import { firewallIPv4Service } from "@/lib/api/firewall-ipv4";
 import { firewallIPv6Service } from "@/lib/api/firewall-ipv6";
 import type { FirewallZone, ZonesCapabilities } from "@/lib/api/types/firewall-zones";
-import type { FirewallConfigResponse, FirewallRule } from "@/lib/api/firewall-ipv4";
+import type { FirewallConfigResponse, FirewallRule, FirewallCapabilitiesResponse } from "@/lib/api/firewall-ipv4";
 import { CreateZoneModal } from "@/components/firewall/zones/CreateZoneModal";
 import { EditZoneModal } from "@/components/firewall/zones/EditZoneModal";
 import { ZoneRulePanel } from "@/components/firewall/zones/ZoneRulePanel";
@@ -77,11 +79,13 @@ function SortableRuleRow({
   row,
   onClick,
   isReordering,
+  groups,
 }: {
   id: string;
   row: PolicyRow;
   onClick: () => void;
   isReordering: boolean;
+  groups: FirewallGroup[];
 }) {
   const {
     attributes,
@@ -97,22 +101,88 @@ function SortableRuleRow({
     transition,
   };
 
-  function getAddr(obj: { address?: string | null; group?: Record<string, string> | null } | null | undefined): string {
-    if (!obj) return "Any";
-    if (obj.address) return obj.address;
-    if (obj.group) {
-      const entries = Object.entries(obj.group).filter(([k]) => k !== "port-group");
-      const [, val] = entries[0] ?? [];
-      return val ?? "Any";
-    }
-    return "Any";
+  function getGroupMembers(name: string): string[] {
+    return groups.find((g) => g.name === name)?.members ?? [];
   }
 
-  function getPort(obj: { port?: string | null; group?: Record<string, string> | null } | null | undefined): string {
-    if (!obj) return "Any";
-    if (obj.port) return obj.port;
-    if (obj.group?.["port-group"]) return obj.group["port-group"];
-    return "Any";
+  type AddrObj = { address?: string | null; group?: Record<string, string> | null; geoip?: { country_code?: string[] | null; inverse_match?: boolean | null } | null; mac_address?: string | null } | null | undefined;
+  type PortObj = { port?: string | null; group?: Record<string, string> | null } | null | undefined;
+
+  function renderAddr(obj: AddrObj) {
+    if (!obj) return <span className="text-muted-foreground">Any</span>;
+    const nonPortGroups = obj.group ? Object.entries(obj.group).filter(([k]) => k !== "port-group") : [];
+    const hasContent = obj.address || nonPortGroups.length > 0 || (obj.geoip?.country_code?.length ?? 0) > 0 || obj.mac_address;
+    if (!hasContent) return <span className="text-muted-foreground">Any</span>;
+    return (
+      <div className="flex flex-col gap-1">
+        {obj.address && (
+          <code className="text-xs bg-muted/50 px-1.5 py-0.5 rounded font-mono">{obj.address}</code>
+        )}
+        {obj.mac_address && (
+          <code className="text-xs bg-muted/50 px-1.5 py-0.5 rounded font-mono">{obj.mac_address}</code>
+        )}
+        {nonPortGroups.map(([, name]) => {
+          const members = getGroupMembers(name);
+          return (
+            <Tooltip key={name}>
+              <TooltipTrigger asChild>
+                <Badge variant="outline" className="text-xs cursor-help w-fit">{name}</Badge>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="font-semibold text-xs mb-1">{name}</p>
+                <p className="text-xs">{members.length > 0 ? members.join(", ") : "No members"}</p>
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+        {(obj.geoip?.country_code?.length ?? 0) > 0 && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge
+                variant="outline"
+                className={cn(
+                  "text-xs cursor-help gap-1 w-fit",
+                  obj.geoip!.inverse_match
+                    ? "bg-orange-500/10 text-orange-500 border-orange-500/20"
+                    : "bg-purple-500/10 text-purple-500 border-purple-500/20"
+                )}
+              >
+                <Globe className="h-3 w-3" />
+                {obj.geoip!.inverse_match && "!"}
+                {obj.geoip!.country_code!.length === 1
+                  ? obj.geoip!.country_code![0].toUpperCase()
+                  : `Countries (${obj.geoip!.country_code!.length})`}
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="font-semibold text-xs mb-1">{obj.geoip!.inverse_match ? "Excluded Countries" : "Countries"}</p>
+              <p className="text-xs">{obj.geoip!.country_code!.map((c) => c.toUpperCase()).join(", ")}</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    );
+  }
+
+  function renderPort(obj: PortObj) {
+    if (!obj) return <span className="text-muted-foreground">Any</span>;
+    if (obj.port) return <span className="font-mono text-xs">{obj.port}</span>;
+    if (obj.group?.["port-group"]) {
+      const name = obj.group["port-group"];
+      const members = getGroupMembers(name);
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge variant="outline" className="text-xs bg-blue-500/10 text-blue-500 border-blue-500/20 cursor-help">{name}</Badge>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="font-semibold text-xs mb-1">{name}</p>
+            <p className="text-xs">{members.length > 0 ? members.join(", ") : "No ports"}</p>
+          </TooltipContent>
+        </Tooltip>
+      );
+    }
+    return <span className="text-muted-foreground">Any</span>;
   }
 
   return (
@@ -183,15 +253,15 @@ function SortableRuleRow({
         <Badge variant="outline" className="font-mono text-[10px]">{row.sourceZone}</Badge>
       </TableCell>
 
-      <TableCell className="font-mono text-xs">{getAddr(row.rule.source)}</TableCell>
-      <TableCell className="font-mono">{getPort(row.rule.source)}</TableCell>
+      <TableCell>{renderAddr(row.rule.source)}</TableCell>
+      <TableCell>{renderPort(row.rule.source)}</TableCell>
 
       <TableCell>
         <Badge variant="outline" className="font-mono text-[10px]">{row.destZone}</Badge>
       </TableCell>
 
-      <TableCell className="font-mono text-xs">{getAddr(row.rule.destination)}</TableCell>
-      <TableCell className="font-mono">{getPort(row.rule.destination)}</TableCell>
+      <TableCell>{renderAddr(row.rule.destination)}</TableCell>
+      <TableCell>{renderPort(row.rule.destination)}</TableCell>
     </TableRow>
   );
 }
@@ -265,6 +335,8 @@ export default function FirewallZonesPage() {
   const [capabilities, setCapabilities] = useState<ZonesCapabilities | null>(null);
   const [ipv4Config, setIpv4Config] = useState<FirewallConfigResponse | null>(null);
   const [ipv6Config, setIpv6Config] = useState<FirewallConfigResponse | null>(null);
+  const [firewallCaps, setFirewallCaps] = useState<FirewallCapabilitiesResponse | null>(null);
+  const [groups, setGroups] = useState<FirewallGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -301,16 +373,30 @@ export default function FirewallZonesPage() {
     setLoading(true);
     setError(null);
     try {
-      const [caps, zonesData, v4, v6] = await Promise.all([
+      const [caps, zonesData, v4, v6, fwCaps, groupsData] = await Promise.all([
         firewallZonesService.getCapabilities(),
         firewallZonesService.getConfig(refresh),
         firewallIPv4Service.getConfig(refresh),
         firewallIPv6Service.getConfig(refresh),
+        firewallIPv4Service.getCapabilities(),
+        firewallGroupsService.getConfig(refresh),
       ]);
       setCapabilities(caps);
       setZones(zonesData.zones);
       setIpv4Config(v4);
       setIpv6Config(v6);
+      setFirewallCaps(fwCaps);
+      setGroups([
+        ...groupsData.address_groups,
+        ...groupsData.ipv6_address_groups,
+        ...groupsData.network_groups,
+        ...groupsData.ipv6_network_groups,
+        ...groupsData.port_groups,
+        ...groupsData.interface_groups,
+        ...groupsData.mac_groups,
+        ...groupsData.domain_groups,
+        ...groupsData.remote_groups,
+      ]);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load firewall zones");
     } finally {
@@ -911,6 +997,7 @@ export default function FirewallZonesPage() {
                               row={row}
                               isReordering={isReordering}
                               onClick={() => openEditPanel(row)}
+                              groups={groups}
                             />
                           );
                         })}
@@ -991,7 +1078,7 @@ export default function FirewallZonesPage() {
           zones={zones}
           existingRules={panelExistingRules}
           getChainRules={getChainRules}
-          capabilities={null}
+          capabilities={firewallCaps}
           canEdit={canEdit}
         />
 

--- a/frontend/src/components/firewall/zones/ZoneRulePanel.tsx
+++ b/frontend/src/components/firewall/zones/ZoneRulePanel.tsx
@@ -278,7 +278,11 @@ export function ZoneRulePanel({
 
     // Source
     const src = r.source;
-    if (!src || (!src.address && !src.group && !src.geoip && !src.mac_address)) {
+    // Non-port group entries determine the source match mode
+    const srcNonPortGroup = src?.group
+      ? Object.entries(src.group).filter(([k]) => k !== "port-group")
+      : [];
+    if (!src || (!src.address && srcNonPortGroup.length === 0 && !src.geoip && !src.mac_address)) {
       setSrcMode("any");
     } else if (src.mac_address) {
       setSrcMode("mac");
@@ -287,9 +291,9 @@ export function ZoneRulePanel({
       setSrcMode("geoip");
       setSrcGeoip(src.geoip.country_code ?? []);
       setSrcGeoipInverse(src.geoip.inverse_match ?? false);
-    } else if (src.group) {
+    } else if (srcNonPortGroup.length > 0) {
       setSrcMode("group");
-      const [groupType, groupName] = Object.entries(src.group)[0] ?? [];
+      const [groupType, groupName] = srcNonPortGroup[0];
       setSrcGroupType(groupType ?? "address-group");
       setSrcGroupName(groupName ?? "");
     } else if (src.address) {
@@ -315,15 +319,19 @@ export function ZoneRulePanel({
 
     // Destination
     const dst = r.destination;
-    if (!dst || (!dst.address && !dst.group && !dst.geoip)) {
+    // Non-port group entries determine the destination match mode
+    const dstNonPortGroup = dst?.group
+      ? Object.entries(dst.group).filter(([k]) => k !== "port-group")
+      : [];
+    if (!dst || (!dst.address && dstNonPortGroup.length === 0 && !dst.geoip)) {
       setDstMode("any");
     } else if (dst.geoip) {
       setDstMode("geoip");
       setDstGeoip(dst.geoip.country_code ?? []);
       setDstGeoipInverse(dst.geoip.inverse_match ?? false);
-    } else if (dst.group) {
+    } else if (dstNonPortGroup.length > 0) {
       setDstMode("group");
-      const [groupType, groupName] = Object.entries(dst.group)[0] ?? [];
+      const [groupType, groupName] = dstNonPortGroup[0];
       setDstGroupType(groupType ?? "address-group");
       setDstGroupName(groupName ?? "");
     } else if (dst.address) {
@@ -379,7 +387,7 @@ export function ZoneRulePanel({
     // Load auxiliary data
     const loadGroups = async () => {
       try {
-        const cfg = await firewallGroupsService.getConfig();
+        const cfg = await firewallGroupsService.getConfig(true);
         const allGroups = [
           ...cfg.address_groups,
           ...cfg.ipv6_address_groups,
@@ -498,10 +506,10 @@ export function ZoneRulePanel({
       if (action === "jump" && jumpTarget) config.jump_target = jumpTarget;
       if (action === "offload" && offloadTarget) config.offload_target = offloadTarget;
 
-      // Source
+      // Source — always set (empty object = "any", triggers delete in updateRule)
       const hasSrc = srcMode !== "any" || srcPortMode !== "any";
+      config.source = {};
       if (hasSrc) {
-        config.source = {};
         if (srcMode === "address" && srcAddress.trim()) {
           config.source.address = srcAddressInvert ? `!${srcAddress.trim()}` : srcAddress.trim();
         } else if (srcMode === "group" && srcGroupName) {
@@ -519,9 +527,10 @@ export function ZoneRulePanel({
       }
 
       // Destination
+      // Destination — always set (empty object = "any", triggers delete in updateRule)
       const hasDst = dstMode !== "any" || dstPortMode !== "any";
+      config.destination = {};
       if (hasDst) {
-        config.destination = {};
         if (dstMode === "address" && dstAddress.trim()) {
           config.destination.address = dstAddressInvert ? `!${dstAddress.trim()}` : dstAddress.trim();
         } else if (dstMode === "group" && dstGroupName) {
@@ -622,19 +631,20 @@ export function ZoneRulePanel({
   };
 
   // ── Address group type options ────────────────────────────────────────────
+  const supportsRemoteGroup = capabilities?.features.remote_group?.supported ?? false;
   const addrGroupTypeOptions = isV6
     ? [
         { value: "ipv6-address-group", label: "IPv6 Address Group" },
         { value: "ipv6-network-group", label: "IPv6 Network Group" },
         { value: "domain-group", label: "Domain Group" },
-        { value: "remote-group", label: "Remote Group" },
+        ...(supportsRemoteGroup ? [{ value: "remote-group", label: "Remote Group" }] : []),
       ]
     : [
         { value: "address-group", label: "Address Group" },
         { value: "network-group", label: "Network Group" },
         { value: "domain-group", label: "Domain Group" },
         { value: "mac-group", label: "MAC Group" },
-        { value: "remote-group", label: "Remote Group" },
+        ...(supportsRemoteGroup ? [{ value: "remote-group", label: "Remote Group" }] : []),
       ];
 
   // ── Render ────────────────────────────────────────────────────────────────
@@ -861,7 +871,6 @@ export function ZoneRulePanel({
                           {addrGroupTypeOptions.map((o) => (
                             <SelectItem key={o.value} value={o.value} className="text-xs">{o.label}</SelectItem>
                           ))}
-                          <SelectItem value="port-group" className="text-xs">Port Group</SelectItem>
                         </SelectContent>
                       </Select>
                       <Select value={srcGroupName} onValueChange={setSrcGroupName} disabled={!canEdit}>

--- a/frontend/src/lib/api/firewall-groups.ts
+++ b/frontend/src/lib/api/firewall-groups.ts
@@ -23,8 +23,10 @@ class FirewallGroupsService {
   /**
    * Get all firewall group configurations
    */
-  async getConfig(): Promise<GroupsConfigResponse> {
-    return apiClient.get<GroupsConfigResponse>("/vyos/firewall/groups/config");
+  async getConfig(refresh = false): Promise<GroupsConfigResponse> {
+    return apiClient.get<GroupsConfigResponse>("/vyos/firewall/groups/config", {
+      refresh: refresh.toString(),
+    });
   }
 
   /**

--- a/frontend/src/lib/api/firewall-ipv4.ts
+++ b/frontend/src/lib/api/firewall-ipv4.ts
@@ -292,6 +292,8 @@ class FirewallIPv4Service {
             operations.push({ op: "set_rule_source_group_mac", value: groupName });
           } else if (groupType.includes("domain")) {
             operations.push({ op: "set_rule_source_group_domain", value: groupName });
+          } else if (groupType.includes("remote")) {
+            operations.push({ op: "set_rule_source_group_remote", value: groupName });
           }
         }
       }
@@ -329,6 +331,8 @@ class FirewallIPv4Service {
             operations.push({ op: "set_rule_destination_group_mac", value: groupName });
           } else if (groupType.includes("domain")) {
             operations.push({ op: "set_rule_destination_group_domain", value: groupName });
+          } else if (groupType.includes("remote")) {
+            operations.push({ op: "set_rule_destination_group_remote", value: groupName });
           }
         }
       }
@@ -492,18 +496,24 @@ class FirewallIPv4Service {
           operations.push({ op: "delete_rule_source_geoip" });
         }
         if (currentRule.source?.group) {
-          // Delete ALL existing groups (address, network, port, etc.)
-          for (const [groupType] of Object.entries(currentRule.source.group)) {
-            if (groupType.includes("address")) {
-              operations.push({ op: "delete_rule_source_group_address" });
-            } else if (groupType.includes("network")) {
-              operations.push({ op: "delete_rule_source_group_network" });
-            } else if (groupType.includes("port")) {
-              operations.push({ op: "delete_rule_source_group_port" });
-            } else if (groupType.includes("mac")) {
-              operations.push({ op: "delete_rule_source_group_mac" });
-            } else if (groupType.includes("domain")) {
-              operations.push({ op: "delete_rule_source_group_domain" });
+          // If the new config has no group at all, delete the entire group node to avoid empty container error
+          if (!config.source?.group) {
+            operations.push({ op: "delete_rule_source_group" });
+          } else {
+            for (const [groupType] of Object.entries(currentRule.source.group)) {
+              if (groupType.includes("address")) {
+                operations.push({ op: "delete_rule_source_group_address" });
+              } else if (groupType.includes("network")) {
+                operations.push({ op: "delete_rule_source_group_network" });
+              } else if (groupType.includes("port")) {
+                operations.push({ op: "delete_rule_source_group_port" });
+              } else if (groupType.includes("mac")) {
+                operations.push({ op: "delete_rule_source_group_mac" });
+              } else if (groupType.includes("domain")) {
+                operations.push({ op: "delete_rule_source_group_domain" });
+              } else if (groupType.includes("remote")) {
+                operations.push({ op: "delete_rule_source_group_remote" });
+              }
             }
           }
         }
@@ -544,6 +554,8 @@ class FirewallIPv4Service {
               operations.push({ op: "set_rule_source_group_mac", value: groupName });
             } else if (groupType.includes("domain")) {
               operations.push({ op: "set_rule_source_group_domain", value: groupName });
+            } else if (groupType.includes("remote")) {
+              operations.push({ op: "set_rule_source_group_remote", value: groupName });
             }
           }
         }
@@ -571,18 +583,24 @@ class FirewallIPv4Service {
           operations.push({ op: "delete_rule_destination_geoip" });
         }
         if (currentRule.destination?.group) {
-          // Delete ALL existing groups (address, network, port, etc.)
-          for (const [groupType] of Object.entries(currentRule.destination.group)) {
-            if (groupType.includes("address")) {
-              operations.push({ op: "delete_rule_destination_group_address" });
-            } else if (groupType.includes("network")) {
-              operations.push({ op: "delete_rule_destination_group_network" });
-            } else if (groupType.includes("port")) {
-              operations.push({ op: "delete_rule_destination_group_port" });
-            } else if (groupType.includes("mac")) {
-              operations.push({ op: "delete_rule_destination_group_mac" });
-            } else if (groupType.includes("domain")) {
-              operations.push({ op: "delete_rule_destination_group_domain" });
+          // If the new config has no group at all, delete the entire group node to avoid empty container error
+          if (!config.destination?.group) {
+            operations.push({ op: "delete_rule_destination_group" });
+          } else {
+            for (const [groupType] of Object.entries(currentRule.destination.group)) {
+              if (groupType.includes("address")) {
+                operations.push({ op: "delete_rule_destination_group_address" });
+              } else if (groupType.includes("network")) {
+                operations.push({ op: "delete_rule_destination_group_network" });
+              } else if (groupType.includes("port")) {
+                operations.push({ op: "delete_rule_destination_group_port" });
+              } else if (groupType.includes("mac")) {
+                operations.push({ op: "delete_rule_destination_group_mac" });
+              } else if (groupType.includes("domain")) {
+                operations.push({ op: "delete_rule_destination_group_domain" });
+              } else if (groupType.includes("remote")) {
+                operations.push({ op: "delete_rule_destination_group_remote" });
+              }
             }
           }
         }
@@ -609,6 +627,8 @@ class FirewallIPv4Service {
               operations.push({ op: "set_rule_destination_group_mac", value: groupName });
             } else if (groupType.includes("domain")) {
               operations.push({ op: "set_rule_destination_group_domain", value: groupName });
+            } else if (groupType.includes("remote")) {
+              operations.push({ op: "set_rule_destination_group_remote", value: groupName });
             }
           }
         }

--- a/frontend/src/lib/api/firewall-ipv6.ts
+++ b/frontend/src/lib/api/firewall-ipv6.ts
@@ -293,6 +293,8 @@ class FirewallIPv6Service {
             operations.push({ op: "set_rule_source_group_mac", value: groupName });
           } else if (groupType.includes("domain")) {
             operations.push({ op: "set_rule_source_group_domain", value: groupName });
+          } else if (groupType.includes("remote")) {
+            operations.push({ op: "set_rule_source_group_remote", value: groupName });
           }
         }
       }
@@ -330,6 +332,8 @@ class FirewallIPv6Service {
             operations.push({ op: "set_rule_destination_group_mac", value: groupName });
           } else if (groupType.includes("domain")) {
             operations.push({ op: "set_rule_destination_group_domain", value: groupName });
+          } else if (groupType.includes("remote")) {
+            operations.push({ op: "set_rule_destination_group_remote", value: groupName });
           }
         }
       }
@@ -495,18 +499,24 @@ class FirewallIPv6Service {
           operations.push({ op: "delete_rule_source_geoip" });
         }
         if (currentRule.source?.group) {
-          // Delete ALL existing groups (address, network, port, etc.)
-          for (const [groupType] of Object.entries(currentRule.source.group)) {
-            if (groupType.includes("address")) {
-              operations.push({ op: "delete_rule_source_group_address" });
-            } else if (groupType.includes("network")) {
-              operations.push({ op: "delete_rule_source_group_network" });
-            } else if (groupType.includes("port")) {
-              operations.push({ op: "delete_rule_source_group_port" });
-            } else if (groupType.includes("mac")) {
-              operations.push({ op: "delete_rule_source_group_mac" });
-            } else if (groupType.includes("domain")) {
-              operations.push({ op: "delete_rule_source_group_domain" });
+          // If the new config has no group at all, delete the entire group node to avoid empty container error
+          if (!config.source?.group) {
+            operations.push({ op: "delete_rule_source_group" });
+          } else {
+            for (const [groupType] of Object.entries(currentRule.source.group)) {
+              if (groupType.includes("address")) {
+                operations.push({ op: "delete_rule_source_group_address" });
+              } else if (groupType.includes("network")) {
+                operations.push({ op: "delete_rule_source_group_network" });
+              } else if (groupType.includes("port")) {
+                operations.push({ op: "delete_rule_source_group_port" });
+              } else if (groupType.includes("mac")) {
+                operations.push({ op: "delete_rule_source_group_mac" });
+              } else if (groupType.includes("domain")) {
+                operations.push({ op: "delete_rule_source_group_domain" });
+              } else if (groupType.includes("remote")) {
+                operations.push({ op: "delete_rule_source_group_remote" });
+              }
             }
           }
         }
@@ -547,6 +557,8 @@ class FirewallIPv6Service {
               operations.push({ op: "set_rule_source_group_mac", value: groupName });
             } else if (groupType.includes("domain")) {
               operations.push({ op: "set_rule_source_group_domain", value: groupName });
+            } else if (groupType.includes("remote")) {
+              operations.push({ op: "set_rule_source_group_remote", value: groupName });
             }
           }
         }
@@ -574,18 +586,24 @@ class FirewallIPv6Service {
           operations.push({ op: "delete_rule_destination_geoip" });
         }
         if (currentRule.destination?.group) {
-          // Delete ALL existing groups (address, network, port, etc.)
-          for (const [groupType] of Object.entries(currentRule.destination.group)) {
-            if (groupType.includes("address")) {
-              operations.push({ op: "delete_rule_destination_group_address" });
-            } else if (groupType.includes("network")) {
-              operations.push({ op: "delete_rule_destination_group_network" });
-            } else if (groupType.includes("port")) {
-              operations.push({ op: "delete_rule_destination_group_port" });
-            } else if (groupType.includes("mac")) {
-              operations.push({ op: "delete_rule_destination_group_mac" });
-            } else if (groupType.includes("domain")) {
-              operations.push({ op: "delete_rule_destination_group_domain" });
+          // If the new config has no group at all, delete the entire group node to avoid empty container error
+          if (!config.destination?.group) {
+            operations.push({ op: "delete_rule_destination_group" });
+          } else {
+            for (const [groupType] of Object.entries(currentRule.destination.group)) {
+              if (groupType.includes("address")) {
+                operations.push({ op: "delete_rule_destination_group_address" });
+              } else if (groupType.includes("network")) {
+                operations.push({ op: "delete_rule_destination_group_network" });
+              } else if (groupType.includes("port")) {
+                operations.push({ op: "delete_rule_destination_group_port" });
+              } else if (groupType.includes("mac")) {
+                operations.push({ op: "delete_rule_destination_group_mac" });
+              } else if (groupType.includes("domain")) {
+                operations.push({ op: "delete_rule_destination_group_domain" });
+              } else if (groupType.includes("remote")) {
+                operations.push({ op: "delete_rule_destination_group_remote" });
+              }
             }
           }
         }
@@ -623,6 +641,8 @@ class FirewallIPv6Service {
               operations.push({ op: "set_rule_destination_group_mac", value: groupName });
             } else if (groupType.includes("domain")) {
               operations.push({ op: "set_rule_destination_group_domain", value: groupName });
+            } else if (groupType.includes("remote")) {
+              operations.push({ op: "set_rule_destination_group_remote", value: groupName });
             }
           }
         }


### PR DESCRIPTION
  - Convert ZoneRulePanel from tab layout to stacked scrollable sections
  - Replace disabled rule lock icon with ban icon
  - Remove interface matching section (not applicable for zone-based firewalls)
  - Remove "Will create rule #N" text from create panel
  - Gate remote group option on VyOS 1.5+ capabilities
  - Fix port group appearing in source match instead of source port section
  - Fix edit panel incorrectly showing group mode when rule has address + port group
  - Fix "source/destination group may not be empty" error when clearing groups by adding delete_rule_source_group and delete_rule_destination_group operations to IPv4/IPv6 builders and mappers
  - Fix setting source/destination address back to any not working
  - Load real firewall capabilities and pass to ZoneRulePanel
  - Add rich source/destination rendering in policy table with GeoIP badges, group badges with member tooltips, and port group badges