### PR TITLE
fix(system): support multiple inet addresses in static host mapping

### DIFF
--- a/backend/routers/system.py
+++ b/backend/routers/system.py
@@ -132,7 +132,7 @@ class ConfigManagement(BaseModel):
 
 class StaticHostEntry(BaseModel):
     hostname: str
-    inet: Optional[str] = None
+    inet: List[str] = Field(default_factory=list)
     aliases: List[str] = Field(default_factory=list)
 
 
@@ -412,7 +412,9 @@ def _parse_static_host_mapping(system_config: dict) -> List[StaticHostEntry]:
         for hostname, host_cfg in hosts_raw.items():
             if host_cfg is None:
                 host_cfg = {}
-            inet = host_cfg.get("inet")
+            inet = host_cfg.get("inet") or []
+            if isinstance(inet, str):
+                inet = [inet]
             aliases_raw = host_cfg.get("alias", [])
             if isinstance(aliases_raw, str):
                 aliases_raw = [aliases_raw]

--- a/frontend/src/components/system/settings/HostMappingModal.tsx
+++ b/frontend/src/components/system/settings/HostMappingModal.tsx
@@ -23,7 +23,8 @@ interface Props {
 
 export function HostMappingModal({ open, onOpenChange, onSuccess }: Props) {
   const [hostname, setHostname] = useState("");
-  const [inet, setInet] = useState("");
+  const [inetList, setInetList] = useState<string[]>([]);
+  const [inetInput, setInetInput] = useState("");
   const [aliases, setAliases] = useState<string[]>([]);
   const [aliasInput, setAliasInput] = useState("");
   const [loading, setLoading] = useState(false);
@@ -32,7 +33,8 @@ export function HostMappingModal({ open, onOpenChange, onSuccess }: Props) {
   useEffect(() => {
     if (open) {
       setHostname("");
-      setInet("");
+      setInetList([]);
+      setInetInput("");
       setAliases([]);
       setAliasInput("");
       setError(null);
@@ -42,6 +44,18 @@ export function HostMappingModal({ open, onOpenChange, onSuccess }: Props) {
   const handleClose = () => {
     setError(null);
     onOpenChange(false);
+  };
+
+  const addInet = () => {
+    const ip = inetInput.trim();
+    if (ip && !inetList.includes(ip)) {
+      setInetList((prev) => [...prev, ip]);
+    }
+    setInetInput("");
+  };
+
+  const removeInet = (ip: string) => {
+    setInetList((prev) => prev.filter((i) => i !== ip));
   };
 
   const addAlias = () => {
@@ -64,8 +78,8 @@ export function HostMappingModal({ open, onOpenChange, onSuccess }: Props) {
       setError("Hostname is required.");
       return;
     }
-    if (!inet.trim()) {
-      setError("IP address is required.");
+    if (inetList.length === 0) {
+      setError("At least one IP address is required.");
       return;
     }
 
@@ -73,7 +87,7 @@ export function HostMappingModal({ open, onOpenChange, onSuccess }: Props) {
     try {
       const result = await systemSettingsService.createStaticHost(
         hostname.trim(),
-        inet.trim(),
+        inetList,
         aliases,
       );
 
@@ -127,28 +141,40 @@ export function HostMappingModal({ open, onOpenChange, onSuccess }: Props) {
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="inet">IP Address</Label>
-            <Input
-              id="inet"
-              value={inet}
-              onChange={(e) => setInet(e.target.value)}
-              placeholder="192.168.1.100"
-            />
+            <Label>IP Address(es)</Label>
+            <div className="flex gap-2">
+              <Input
+                value={inetInput}
+                onChange={(e) => setInetInput(e.target.value)}
+                placeholder="192.168.1.100"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    addInet();
+                  }
+                }}
+              />
+              <Button type="button" variant="outline" size="sm" onClick={addInet}>
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+            {inetList.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {inetList.map((ip) => (
+                  <Badge key={ip} variant="secondary" className="flex items-center gap-1 font-mono">
+                    {ip}
+                    <button type="button" onClick={() => removeInet(ip)}>
+                      <X className="h-3 w-3 ml-1" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+            )}
           </div>
 
           {/* Aliases */}
           <div className="space-y-2">
             <Label>Aliases (optional)</Label>
-            <div className="flex flex-wrap gap-2 min-h-[2rem]">
-              {aliases.map((a) => (
-                <Badge key={a} variant="secondary" className="flex items-center gap-1">
-                  {a}
-                  <button type="button" onClick={() => removeAlias(a)}>
-                    <X className="h-3 w-3 ml-1" />
-                  </button>
-                </Badge>
-              ))}
-            </div>
             <div className="flex gap-2">
               <Input
                 value={aliasInput}
@@ -165,6 +191,18 @@ export function HostMappingModal({ open, onOpenChange, onSuccess }: Props) {
                 <Plus className="h-4 w-4" />
               </Button>
             </div>
+            {aliases.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {aliases.map((a) => (
+                  <Badge key={a} variant="secondary" className="flex items-center gap-1">
+                    {a}
+                    <button type="button" onClick={() => removeAlias(a)}>
+                      <X className="h-3 w-3 ml-1" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+            )}
           </div>
 
           <div className="flex justify-end gap-2 pt-2">

--- a/frontend/src/components/system/settings/HostMappingPanel.tsx
+++ b/frontend/src/components/system/settings/HostMappingPanel.tsx
@@ -112,8 +112,16 @@ export function HostMappingPanel({ config, isReadOnly, onRefresh }: Props) {
               config.static_host_mapping.map((entry) => (
                 <TableRow key={entry.hostname}>
                   <TableCell className="font-mono">{entry.hostname}</TableCell>
-                  <TableCell className="font-mono">
-                    {entry.inet ?? <span className="text-muted-foreground">—</span>}
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {entry.inet.length > 0 ? entry.inet.map((ip) => (
+                        <Badge key={ip} variant="outline" className="font-mono text-xs">
+                          {ip}
+                        </Badge>
+                      )) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </div>
                   </TableCell>
                   <TableCell>
                     <div className="flex flex-wrap gap-1">

--- a/frontend/src/lib/api/system-settings.ts
+++ b/frontend/src/lib/api/system-settings.ts
@@ -127,7 +127,7 @@ export interface ConfigManagement {
 
 export interface StaticHostEntry {
   hostname: string;
-  inet: string | null;
+  inet: string[];
   aliases: string[];
 }
 
@@ -400,10 +400,13 @@ class SystemSettingsService {
 
   async createStaticHost(
     hostname: string,
-    inet: string,
+    inet: string[],
     aliases?: string[],
   ): Promise<VyOSResponse> {
-    const ops: BatchOp[] = [{ op: "set_static_host", value: inet }];
+    const ops: BatchOp[] = [];
+    for (const ip of inet) {
+      ops.push({ op: "set_static_host", value: ip });
+    }
     for (const alias of aliases ?? []) {
       ops.push({ op: "add_static_host_alias", value: alias });
     }


### PR DESCRIPTION
VyOS returns `inet` as a list when multiple IPs are configured for a host mapping, causing a Pydantic validation error and 500 on the /vyos/system/config endpoint. Changed `StaticHostEntry.inet` from a single optional string to a list, normalizing both string and list values from VyOS during parsing. Updated the frontend type, API service, panel table, and add modal to support adding and displaying multiple IPs per host entry.

Closes #189