### PR TITLE
feat(firewall): add group inversion support for firewall rules

### DIFF
--- a/frontend/src/app/firewall/zones/page.tsx
+++ b/frontend/src/app/firewall/zones/page.tsx
@@ -102,7 +102,8 @@ function SortableRuleRow({
   };
 
   function getGroupMembers(name: string): string[] {
-    return groups.find((g) => g.name === name)?.members ?? [];
+    const cleanName = name.startsWith("!") ? name.substring(1) : name;
+    return groups.find((g) => g.name === cleanName)?.members ?? [];
   }
 
   type AddrObj = { address?: string | null; group?: Record<string, string> | null; geoip?: { country_code?: string[] | null; inverse_match?: boolean | null } | null; mac_address?: string | null } | null | undefined;
@@ -122,14 +123,18 @@ function SortableRuleRow({
           <code className="text-xs bg-muted/50 px-1.5 py-0.5 rounded font-mono">{obj.mac_address}</code>
         )}
         {nonPortGroups.map(([, name]) => {
+          const inverted = name.startsWith("!");
+          const displayName = inverted ? name.substring(1) : name;
           const members = getGroupMembers(name);
           return (
             <Tooltip key={name}>
               <TooltipTrigger asChild>
-                <Badge variant="outline" className="text-xs cursor-help w-fit">{name}</Badge>
+                <Badge variant="outline" className={cn("text-xs cursor-help w-fit", inverted && "bg-orange-500/10 text-orange-500 border-orange-500/20")}>
+                  {inverted && "!"}{displayName}
+                </Badge>
               </TooltipTrigger>
               <TooltipContent>
-                <p className="font-semibold text-xs mb-1">{name}</p>
+                <p className="font-semibold text-xs mb-1">{inverted ? `NOT ${displayName}` : displayName}</p>
                 <p className="text-xs">{members.length > 0 ? members.join(", ") : "No members"}</p>
               </TooltipContent>
             </Tooltip>
@@ -169,14 +174,18 @@ function SortableRuleRow({
     if (obj.port) return <span className="font-mono text-xs">{obj.port}</span>;
     if (obj.group?.["port-group"]) {
       const name = obj.group["port-group"];
+      const inverted = name.startsWith("!");
+      const displayName = inverted ? name.substring(1) : name;
       const members = getGroupMembers(name);
       return (
         <Tooltip>
           <TooltipTrigger asChild>
-            <Badge variant="outline" className="text-xs bg-blue-500/10 text-blue-500 border-blue-500/20 cursor-help">{name}</Badge>
+            <Badge variant="outline" className={cn("text-xs cursor-help", inverted ? "bg-orange-500/10 text-orange-500 border-orange-500/20" : "bg-blue-500/10 text-blue-500 border-blue-500/20")}>
+              {inverted && "!"}{displayName}
+            </Badge>
           </TooltipTrigger>
           <TooltipContent>
-            <p className="font-semibold text-xs mb-1">{name}</p>
+            <p className="font-semibold text-xs mb-1">{inverted ? `NOT ${displayName}` : displayName}</p>
             <p className="text-xs">{members.length > 0 ? members.join(", ") : "No ports"}</p>
           </TooltipContent>
         </Tooltip>

--- a/frontend/src/components/firewall/CreateFirewallRuleModal.tsx
+++ b/frontend/src/components/firewall/CreateFirewallRuleModal.tsx
@@ -82,6 +82,7 @@ export function CreateFirewallRuleModal({
   const [sourceGeoipInverse, setSourceGeoipInverse] = useState(false);
   const [sourceGroupType, setSourceGroupType] = useState("");
   const [sourceGroupName, setSourceGroupName] = useState("");
+  const [sourceGroupInvert, setSourceGroupInvert] = useState(false);
 
   // Destination fields
   const [destMode, setDestMode] = useState<"any" | "address" | "group" | "geoip">("any");
@@ -105,6 +106,9 @@ export function CreateFirewallRuleModal({
   }, [sourcePort, destPort, sourcePortGroup, destPortGroup, ruleProtocol]);
   const [destGroupType, setDestGroupType] = useState("");
   const [destGroupName, setDestGroupName] = useState("");
+  const [destGroupInvert, setDestGroupInvert] = useState(false);
+  const [sourcePortGroupInvert, setSourcePortGroupInvert] = useState(false);
+  const [destPortGroupInvert, setDestPortGroupInvert] = useState(false);
 
   // State fields
   const [stateEstablished, setStateEstablished] = useState(false);
@@ -294,16 +298,20 @@ export function CreateFirewallRuleModal({
     setSourceGeoipInverse(false);
     setSourceGroupType("");
     setSourceGroupName("");
+    setSourceGroupInvert(false);
+    setSourcePortGroupInvert(false);
     setDestMode("any");
     setDestAddress("");
     setDestAddressInvert(false);
     setDestPortMode("any");
     setDestPort("");
     setDestPortGroup("");
+    setDestPortGroupInvert(false);
     setDestGeoipCountry([]);
     setDestGeoipInverse(false);
     setDestGroupType("");
     setDestGroupName("");
+    setDestGroupInvert(false);
     setStateEstablished(false);
     setStateNew(false);
     setStateRelated(false);
@@ -427,7 +435,7 @@ export function CreateFirewallRuleModal({
           config.source.address = sourceAddressInvert ? `!${addr}` : addr;
         } else if (sourceMode === "group" && sourceGroupType && sourceGroupName) {
           // Address or network group - mutually exclusive with address, geoip, and mac
-          config.source.group = { [sourceGroupType]: sourceGroupName };
+          config.source.group = { [sourceGroupType]: sourceGroupInvert ? `!${sourceGroupName}` : sourceGroupName };
         } else if (sourceMode === "geoip" && sourceGeoipCountry.length > 0) {
           // GeoIP - mutually exclusive with address, group, and mac
           config.source.geoip = {
@@ -447,7 +455,7 @@ export function CreateFirewallRuleModal({
           if (!config.source.group) {
             config.source.group = {};
           }
-          config.source.group["port-group"] = sourcePortGroup;
+          config.source.group["port-group"] = sourcePortGroupInvert ? `!${sourcePortGroup}` : sourcePortGroup;
         }
       }
 
@@ -468,7 +476,7 @@ export function CreateFirewallRuleModal({
           config.destination.address = destAddressInvert ? `!${addr}` : addr;
         } else if (destMode === "group" && destGroupType && destGroupName) {
           // Address or network group - mutually exclusive with address and geoip
-          config.destination.group = { [destGroupType]: destGroupName };
+          config.destination.group = { [destGroupType]: destGroupInvert ? `!${destGroupName}` : destGroupName };
         } else if (destMode === "geoip" && destGeoipCountry.length > 0) {
           // GeoIP - mutually exclusive with address and group
           config.destination.geoip = {
@@ -485,7 +493,7 @@ export function CreateFirewallRuleModal({
           if (!config.destination.group) {
             config.destination.group = {};
           }
-          config.destination.group["port-group"] = destPortGroup;
+          config.destination.group["port-group"] = destPortGroupInvert ? `!${destPortGroup}` : destPortGroup;
         }
       }
 
@@ -970,6 +978,12 @@ export function CreateFirewallRuleModal({
                       </SelectContent>
                     </Select>
                   </div>
+                  <div className="flex items-center space-x-2">
+                    <Checkbox id="sourceGroupInvert" checked={sourceGroupInvert} onCheckedChange={(c) => setSourceGroupInvert(!!c)} />
+                    <Label htmlFor="sourceGroupInvert" className="cursor-pointer font-normal text-sm">
+                      Invert (match packets NOT in this group)
+                    </Label>
+                  </div>
                 </div>
               </div>
             )}
@@ -1075,7 +1089,7 @@ export function CreateFirewallRuleModal({
               )}
 
               {sourcePortMode === "group" && (
-                <div className="pl-6 border-l-2 border-primary/20">
+                <div className="pl-6 border-l-2 border-primary/20 space-y-2">
                   <Select value={sourcePortGroup} onValueChange={setSourcePortGroup}>
                     <SelectTrigger id="sourcePortGroup">
                       <SelectValue placeholder="Select port group" />
@@ -1088,6 +1102,12 @@ export function CreateFirewallRuleModal({
                       ))}
                     </SelectContent>
                   </Select>
+                  <div className="flex items-center space-x-2">
+                    <Checkbox id="sourcePortGroupInvert" checked={sourcePortGroupInvert} onCheckedChange={(c) => setSourcePortGroupInvert(!!c)} />
+                    <Label htmlFor="sourcePortGroupInvert" className="cursor-pointer font-normal text-sm">
+                      Invert (match packets NOT in this group)
+                    </Label>
+                  </div>
                 </div>
               )}
 
@@ -1241,6 +1261,12 @@ export function CreateFirewallRuleModal({
                       </SelectContent>
                     </Select>
                   </div>
+                  <div className="flex items-center space-x-2">
+                    <Checkbox id="destGroupInvert" checked={destGroupInvert} onCheckedChange={(c) => setDestGroupInvert(!!c)} />
+                    <Label htmlFor="destGroupInvert" className="cursor-pointer font-normal text-sm">
+                      Invert (match packets NOT in this group)
+                    </Label>
+                  </div>
                 </div>
               </div>
             )}
@@ -1317,7 +1343,7 @@ export function CreateFirewallRuleModal({
               )}
 
               {destPortMode === "group" && (
-                <div className="pl-6 border-l-2 border-primary/20">
+                <div className="pl-6 border-l-2 border-primary/20 space-y-2">
                   <Select value={destPortGroup} onValueChange={setDestPortGroup}>
                     <SelectTrigger id="destPortGroup">
                       <SelectValue placeholder="Select port group" />
@@ -1330,6 +1356,12 @@ export function CreateFirewallRuleModal({
                       ))}
                     </SelectContent>
                   </Select>
+                  <div className="flex items-center space-x-2">
+                    <Checkbox id="destPortGroupInvert" checked={destPortGroupInvert} onCheckedChange={(c) => setDestPortGroupInvert(!!c)} />
+                    <Label htmlFor="destPortGroupInvert" className="cursor-pointer font-normal text-sm">
+                      Invert (match packets NOT in this group)
+                    </Label>
+                  </div>
                 </div>
               )}
 

--- a/frontend/src/components/firewall/EditFirewallRuleModal.tsx
+++ b/frontend/src/components/firewall/EditFirewallRuleModal.tsx
@@ -75,6 +75,8 @@ export function EditFirewallRuleModal({
   const [sourceGeoipInverse, setSourceGeoipInverse] = useState(false);
   const [sourceGroupType, setSourceGroupType] = useState("");
   const [sourceGroupName, setSourceGroupName] = useState("");
+  const [sourceGroupInvert, setSourceGroupInvert] = useState(false);
+  const [sourcePortGroupInvert, setSourcePortGroupInvert] = useState(false);
 
   // Destination fields
   const [destMode, setDestMode] = useState<"any" | "address" | "group" | "geoip">("any");
@@ -98,6 +100,8 @@ export function EditFirewallRuleModal({
   }, [sourcePort, destPort, sourcePortGroup, destPortGroup, ruleProtocol]);
   const [destGroupType, setDestGroupType] = useState("");
   const [destGroupName, setDestGroupName] = useState("");
+  const [destGroupInvert, setDestGroupInvert] = useState(false);
+  const [destPortGroupInvert, setDestPortGroupInvert] = useState(false);
 
   // State fields
   const [stateEstablished, setStateEstablished] = useState(false);
@@ -282,9 +286,11 @@ export function EditFirewallRuleModal({
     setSourceAddressInvert(false);
     setSourceGroupType("");
     setSourceGroupName("");
+    setSourceGroupInvert(false);
     setSourcePortMode("any");
     setSourcePort("");
     setSourcePortGroup("");
+    setSourcePortGroupInvert(false);
     setSourceMac("");
     setSourceGeoipCountry([]);
     setSourceGeoipInverse(false);
@@ -319,7 +325,13 @@ export function EditFirewallRuleModal({
           // Address/network/domain/mac group
           setSourceMode("group");
           setSourceGroupType(type);
-          setSourceGroupName(name);
+          if (name.startsWith("!")) {
+            setSourceGroupName(name.substring(1));
+            setSourceGroupInvert(true);
+          } else {
+            setSourceGroupName(name);
+            setSourceGroupInvert(false);
+          }
           hasAddressGroup = true;
           break;
         }
@@ -336,7 +348,14 @@ export function EditFirewallRuleModal({
       setSourcePort(rule.source.port);
     } else if (rule.source?.group && rule.source.group["port-group"]) {
       setSourcePortMode("group");
-      setSourcePortGroup(rule.source.group["port-group"]);
+      const rawPortGroup = rule.source.group["port-group"];
+      if (rawPortGroup.startsWith("!")) {
+        setSourcePortGroup(rawPortGroup.substring(1));
+        setSourcePortGroupInvert(true);
+      } else {
+        setSourcePortGroup(rawPortGroup);
+        setSourcePortGroupInvert(false);
+      }
     } else {
       setSourcePortMode("any");
     }
@@ -348,9 +367,11 @@ export function EditFirewallRuleModal({
     setDestAddressInvert(false);
     setDestGroupType("");
     setDestGroupName("");
+    setDestGroupInvert(false);
     setDestPortMode("any");
     setDestPort("");
     setDestPortGroup("");
+    setDestPortGroupInvert(false);
     setDestGeoipCountry([]);
     setDestGeoipInverse(false);
 
@@ -380,7 +401,13 @@ export function EditFirewallRuleModal({
           // Address/network/domain group
           setDestMode("group");
           setDestGroupType(type);
-          setDestGroupName(name);
+          if (name.startsWith("!")) {
+            setDestGroupName(name.substring(1));
+            setDestGroupInvert(true);
+          } else {
+            setDestGroupName(name);
+            setDestGroupInvert(false);
+          }
           hasAddressGroup = true;
           break;
         }
@@ -397,7 +424,14 @@ export function EditFirewallRuleModal({
       setDestPort(rule.destination.port);
     } else if (rule.destination?.group && rule.destination.group["port-group"]) {
       setDestPortMode("group");
-      setDestPortGroup(rule.destination.group["port-group"]);
+      const rawPortGroup = rule.destination.group["port-group"];
+      if (rawPortGroup.startsWith("!")) {
+        setDestPortGroup(rawPortGroup.substring(1));
+        setDestPortGroupInvert(true);
+      } else {
+        setDestPortGroup(rawPortGroup);
+        setDestPortGroupInvert(false);
+      }
     } else {
       setDestPortMode("any");
     }
@@ -573,7 +607,7 @@ export function EditFirewallRuleModal({
           config.source.address = sourceAddressInvert ? `!${addr}` : addr;
         } else if (sourceMode === "group" && sourceGroupType && sourceGroupType !== "none" && sourceGroupName) {
           // Address or network group - mutually exclusive with address, geoip, and mac
-          config.source.group = { [sourceGroupType]: sourceGroupName };
+          config.source.group = { [sourceGroupType]: sourceGroupInvert ? `!${sourceGroupName}` : sourceGroupName };
         } else if (sourceMode === "geoip" && sourceGeoipCountry.length > 0) {
           // GeoIP - mutually exclusive with address, group, and mac
           config.source.geoip = {
@@ -594,7 +628,7 @@ export function EditFirewallRuleModal({
           if (!config.source.group) {
             config.source.group = {};
           }
-          config.source.group["port-group"] = sourcePortGroup;
+          config.source.group["port-group"] = sourcePortGroupInvert ? `!${sourcePortGroup}` : sourcePortGroup;
         }
       }
 
@@ -626,7 +660,7 @@ export function EditFirewallRuleModal({
           config.destination.address = destAddressInvert ? `!${addr}` : addr;
         } else if (destMode === "group" && destGroupType && destGroupType !== "none" && destGroupName) {
           // Address or network group - mutually exclusive with address and geoip
-          config.destination.group = { [destGroupType]: destGroupName };
+          config.destination.group = { [destGroupType]: destGroupInvert ? `!${destGroupName}` : destGroupName };
         } else if (destMode === "geoip" && destGeoipCountry.length > 0) {
           // GeoIP - mutually exclusive with address and group
           config.destination.geoip = {
@@ -644,7 +678,7 @@ export function EditFirewallRuleModal({
           if (!config.destination.group) {
             config.destination.group = {};
           }
-          config.destination.group["port-group"] = destPortGroup;
+          config.destination.group["port-group"] = destPortGroupInvert ? `!${destPortGroup}` : destPortGroup;
         }
       }
 
@@ -1163,6 +1197,12 @@ export function EditFirewallRuleModal({
                     </Select>
                   </div>
                 </div>
+                <div className="flex items-center space-x-2">
+                  <Checkbox id="sourceGroupInvert" checked={sourceGroupInvert} onCheckedChange={(c) => setSourceGroupInvert(!!c)} />
+                  <Label htmlFor="sourceGroupInvert" className="cursor-pointer font-normal text-sm">
+                    Invert (match packets NOT in this group)
+                  </Label>
+                </div>
               </div>
             )}
 
@@ -1267,7 +1307,7 @@ export function EditFirewallRuleModal({
               )}
 
               {sourcePortMode === "group" && (
-                <div className="pl-6 border-l-2 border-primary/20">
+                <div className="pl-6 border-l-2 border-primary/20 space-y-2">
                   <Select value={sourcePortGroup} onValueChange={setSourcePortGroup}>
                     <SelectTrigger id="sourcePortGroup">
                       <SelectValue placeholder="Select port group" />
@@ -1280,6 +1320,12 @@ export function EditFirewallRuleModal({
                       ))}
                     </SelectContent>
                   </Select>
+                  <div className="flex items-center space-x-2">
+                    <Checkbox id="sourcePortGroupInvert" checked={sourcePortGroupInvert} onCheckedChange={(c) => setSourcePortGroupInvert(!!c)} />
+                    <Label htmlFor="sourcePortGroupInvert" className="cursor-pointer font-normal text-sm">
+                      Invert (match packets NOT in this group)
+                    </Label>
+                  </div>
                 </div>
               )}
 
@@ -1434,6 +1480,12 @@ export function EditFirewallRuleModal({
                     </Select>
                   </div>
                 </div>
+                <div className="flex items-center space-x-2">
+                  <Checkbox id="destGroupInvert" checked={destGroupInvert} onCheckedChange={(c) => setDestGroupInvert(!!c)} />
+                  <Label htmlFor="destGroupInvert" className="cursor-pointer font-normal text-sm">
+                    Invert (match packets NOT in this group)
+                  </Label>
+                </div>
               </div>
             )}
 
@@ -1509,7 +1561,7 @@ export function EditFirewallRuleModal({
               )}
 
               {destPortMode === "group" && (
-                <div className="pl-6 border-l-2 border-primary/20">
+                <div className="pl-6 border-l-2 border-primary/20 space-y-2">
                   <Select value={destPortGroup} onValueChange={setDestPortGroup}>
                     <SelectTrigger id="destPortGroup">
                       <SelectValue placeholder="Select port group" />
@@ -1522,6 +1574,12 @@ export function EditFirewallRuleModal({
                       ))}
                     </SelectContent>
                   </Select>
+                  <div className="flex items-center space-x-2">
+                    <Checkbox id="destPortGroupInvert" checked={destPortGroupInvert} onCheckedChange={(c) => setDestPortGroupInvert(!!c)} />
+                    <Label htmlFor="destPortGroupInvert" className="cursor-pointer font-normal text-sm">
+                      Invert (match packets NOT in this group)
+                    </Label>
+                  </div>
                 </div>
               )}
 

--- a/frontend/src/components/firewall/FirewallRuleRow.tsx
+++ b/frontend/src/components/firewall/FirewallRuleRow.tsx
@@ -27,7 +27,8 @@ interface FirewallRuleRowProps {
 export function FirewallRuleRow({ rule, onEdit, onDelete, isDragging, groups = [] }: FirewallRuleRowProps) {
   // Helper function to find group members for tooltip
   const getGroupMembers = (groupName: string): string[] => {
-    const group = groups.find((g) => g.name === groupName);
+    const cleanName = groupName.startsWith("!") ? groupName.substring(1) : groupName;
+    const group = groups.find((g) => g.name === cleanName);
     return group?.members || [];
   };
 
@@ -131,18 +132,20 @@ export function FirewallRuleRow({ rule, onEdit, onDelete, isDragging, groups = [
             {rule.source.group && Object.entries(rule.source.group)
               .filter(([type]) => type !== "port-group")
               .map(([type, name]) => {
+                const inverted = name.startsWith("!");
+                const displayName = inverted ? name.substring(1) : name;
                 const members = getGroupMembers(name);
                 return (
                   <TooltipProvider key={type}>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <Badge variant="outline" className="text-xs cursor-help">
-                          {name}
+                        <Badge variant="outline" className={cn("text-xs cursor-help", inverted && "bg-orange-500/10 text-orange-500 border-orange-500/20")}>
+                          {inverted && "!"}{displayName}
                         </Badge>
                       </TooltipTrigger>
                       <TooltipContent>
                         <div className="max-w-xs">
-                          <p className="font-semibold text-xs mb-1">{name}</p>
+                          <p className="font-semibold text-xs mb-1">{inverted ? `NOT ${displayName}` : displayName}</p>
                           {members.length > 0 ? (
                             <p className="text-xs">{members.join(", ")}</p>
                           ) : (
@@ -207,18 +210,20 @@ export function FirewallRuleRow({ rule, onEdit, onDelete, isDragging, groups = [
             )}
             {rule.source.group?.["port-group"] && (() => {
               const portGroupName = rule.source.group["port-group"];
+              const inverted = portGroupName.startsWith("!");
+              const displayName = inverted ? portGroupName.substring(1) : portGroupName;
               const members = getGroupMembers(portGroupName);
               return (
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Badge variant="outline" className="text-xs bg-blue-500/10 text-blue-500 border-blue-500/20 cursor-help">
-                        {portGroupName}
+                      <Badge variant="outline" className={cn("text-xs cursor-help", inverted ? "bg-orange-500/10 text-orange-500 border-orange-500/20" : "bg-blue-500/10 text-blue-500 border-blue-500/20")}>
+                        {inverted && "!"}{displayName}
                       </Badge>
                     </TooltipTrigger>
                     <TooltipContent>
                       <div className="max-w-xs">
-                        <p className="font-semibold text-xs mb-1">{portGroupName}</p>
+                        <p className="font-semibold text-xs mb-1">{inverted ? `NOT ${displayName}` : displayName}</p>
                         {members.length > 0 ? (
                           <p className="text-xs">{members.join(", ")}</p>
                         ) : (
@@ -248,18 +253,20 @@ export function FirewallRuleRow({ rule, onEdit, onDelete, isDragging, groups = [
             {rule.destination.group && Object.entries(rule.destination.group)
               .filter(([type]) => type !== "port-group")
               .map(([type, name]) => {
+                const inverted = name.startsWith("!");
+                const displayName = inverted ? name.substring(1) : name;
                 const members = getGroupMembers(name);
                 return (
                   <TooltipProvider key={type}>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <Badge variant="outline" className="text-xs cursor-help">
-                          {name}
+                        <Badge variant="outline" className={cn("text-xs cursor-help", inverted && "bg-orange-500/10 text-orange-500 border-orange-500/20")}>
+                          {inverted && "!"}{displayName}
                         </Badge>
                       </TooltipTrigger>
                       <TooltipContent>
                         <div className="max-w-xs">
-                          <p className="font-semibold text-xs mb-1">{name}</p>
+                          <p className="font-semibold text-xs mb-1">{inverted ? `NOT ${displayName}` : displayName}</p>
                           {members.length > 0 ? (
                             <p className="text-xs">{members.join(", ")}</p>
                           ) : (
@@ -324,18 +331,20 @@ export function FirewallRuleRow({ rule, onEdit, onDelete, isDragging, groups = [
             )}
             {rule.destination.group?.["port-group"] && (() => {
               const portGroupName = rule.destination.group["port-group"];
+              const inverted = portGroupName.startsWith("!");
+              const displayName = inverted ? portGroupName.substring(1) : portGroupName;
               const members = getGroupMembers(portGroupName);
               return (
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Badge variant="outline" className="text-xs bg-blue-500/10 text-blue-500 border-blue-500/20 cursor-help">
-                        {portGroupName}
+                      <Badge variant="outline" className={cn("text-xs cursor-help", inverted ? "bg-orange-500/10 text-orange-500 border-orange-500/20" : "bg-blue-500/10 text-blue-500 border-blue-500/20")}>
+                        {inverted && "!"}{displayName}
                       </Badge>
                     </TooltipTrigger>
                     <TooltipContent>
                       <div className="max-w-xs">
-                        <p className="font-semibold text-xs mb-1">{portGroupName}</p>
+                        <p className="font-semibold text-xs mb-1">{inverted ? `NOT ${displayName}` : displayName}</p>
                         {members.length > 0 ? (
                           <p className="text-xs">{members.join(", ")}</p>
                         ) : (

--- a/frontend/src/components/firewall/zones/ZoneRulePanel.tsx
+++ b/frontend/src/components/firewall/zones/ZoneRulePanel.tsx
@@ -154,6 +154,7 @@ export function ZoneRulePanel({
   const [srcAddressError, setSrcAddressError] = useState<string | null>(null);
   const [srcGroupType, setSrcGroupType] = useState("address-group");
   const [srcGroupName, setSrcGroupName] = useState("");
+  const [srcGroupInvert, setSrcGroupInvert] = useState(false);
   const [srcGeoip, setSrcGeoip] = useState<string[]>([]);
   const [srcGeoipInverse, setSrcGeoipInverse] = useState(false);
   const [srcMac, setSrcMac] = useState("");
@@ -161,6 +162,7 @@ export function ZoneRulePanel({
   const [srcPortMode, setSrcPortMode] = useState<PortMode>("any");
   const [srcPort, setSrcPort] = useState("");
   const [srcPortGroup, setSrcPortGroup] = useState("");
+  const [srcPortGroupInvert, setSrcPortGroupInvert] = useState(false);
   const [srcPortError, setSrcPortError] = useState<string | null>(null);
 
   // ── Destination ───────────────────────────────────────────────────────────
@@ -170,11 +172,13 @@ export function ZoneRulePanel({
   const [dstAddressError, setDstAddressError] = useState<string | null>(null);
   const [dstGroupType, setDstGroupType] = useState("address-group");
   const [dstGroupName, setDstGroupName] = useState("");
+  const [dstGroupInvert, setDstGroupInvert] = useState(false);
   const [dstGeoip, setDstGeoip] = useState<string[]>([]);
   const [dstGeoipInverse, setDstGeoipInverse] = useState(false);
   const [dstPortMode, setDstPortMode] = useState<PortMode>("any");
   const [dstPort, setDstPort] = useState("");
   const [dstPortGroup, setDstPortGroup] = useState("");
+  const [dstPortGroupInvert, setDstPortGroupInvert] = useState(false);
   const [dstPortError, setDstPortError] = useState<string | null>(null);
 
   // ── State matching ────────────────────────────────────────────────────────
@@ -226,6 +230,7 @@ export function ZoneRulePanel({
     setSrcAddressError(null);
     setSrcGroupType("address-group");
     setSrcGroupName("");
+    setSrcGroupInvert(false);
     setSrcGeoip([]);
     setSrcGeoipInverse(false);
     setSrcMac("");
@@ -233,6 +238,7 @@ export function ZoneRulePanel({
     setSrcPortMode("any");
     setSrcPort("");
     setSrcPortGroup("");
+    setSrcPortGroupInvert(false);
     setSrcPortError(null);
     setDstMode("any");
     setDstAddress("");
@@ -240,11 +246,13 @@ export function ZoneRulePanel({
     setDstAddressError(null);
     setDstGroupType("address-group");
     setDstGroupName("");
+    setDstGroupInvert(false);
     setDstGeoip([]);
     setDstGeoipInverse(false);
     setDstPortMode("any");
     setDstPort("");
     setDstPortGroup("");
+    setDstPortGroupInvert(false);
     setDstPortError(null);
     setStateEstablished(false);
     setStateNew(false);
@@ -293,9 +301,15 @@ export function ZoneRulePanel({
       setSrcGeoipInverse(src.geoip.inverse_match ?? false);
     } else if (srcNonPortGroup.length > 0) {
       setSrcMode("group");
-      const [groupType, groupName] = srcNonPortGroup[0];
+      const [groupType, rawGroupName] = srcNonPortGroup[0];
       setSrcGroupType(groupType ?? "address-group");
-      setSrcGroupName(groupName ?? "");
+      if (rawGroupName?.startsWith("!")) {
+        setSrcGroupName(rawGroupName.substring(1));
+        setSrcGroupInvert(true);
+      } else {
+        setSrcGroupName(rawGroupName ?? "");
+        setSrcGroupInvert(false);
+      }
     } else if (src.address) {
       setSrcMode("address");
       const addr = src.address;
@@ -312,7 +326,14 @@ export function ZoneRulePanel({
       setSrcPort(src.port);
     } else if (src?.group?.["port-group"]) {
       setSrcPortMode("group");
-      setSrcPortGroup(src.group["port-group"]);
+      const rawPortGroup = src.group["port-group"];
+      if (rawPortGroup.startsWith("!")) {
+        setSrcPortGroup(rawPortGroup.substring(1));
+        setSrcPortGroupInvert(true);
+      } else {
+        setSrcPortGroup(rawPortGroup);
+        setSrcPortGroupInvert(false);
+      }
     } else {
       setSrcPortMode("any");
     }
@@ -331,9 +352,15 @@ export function ZoneRulePanel({
       setDstGeoipInverse(dst.geoip.inverse_match ?? false);
     } else if (dstNonPortGroup.length > 0) {
       setDstMode("group");
-      const [groupType, groupName] = dstNonPortGroup[0];
+      const [groupType, rawGroupName] = dstNonPortGroup[0];
       setDstGroupType(groupType ?? "address-group");
-      setDstGroupName(groupName ?? "");
+      if (rawGroupName?.startsWith("!")) {
+        setDstGroupName(rawGroupName.substring(1));
+        setDstGroupInvert(true);
+      } else {
+        setDstGroupName(rawGroupName ?? "");
+        setDstGroupInvert(false);
+      }
     } else if (dst.address) {
       setDstMode("address");
       const addr = dst.address;
@@ -350,7 +377,14 @@ export function ZoneRulePanel({
       setDstPort(dst.port);
     } else if (dst?.group?.["port-group"]) {
       setDstPortMode("group");
-      setDstPortGroup(dst.group["port-group"]);
+      const rawPortGroup = dst.group["port-group"];
+      if (rawPortGroup.startsWith("!")) {
+        setDstPortGroup(rawPortGroup.substring(1));
+        setDstPortGroupInvert(true);
+      } else {
+        setDstPortGroup(rawPortGroup);
+        setDstPortGroupInvert(false);
+      }
     } else {
       setDstPortMode("any");
     }
@@ -513,7 +547,7 @@ export function ZoneRulePanel({
         if (srcMode === "address" && srcAddress.trim()) {
           config.source.address = srcAddressInvert ? `!${srcAddress.trim()}` : srcAddress.trim();
         } else if (srcMode === "group" && srcGroupName) {
-          config.source.group = { [srcGroupType]: srcGroupName };
+          config.source.group = { [srcGroupType]: srcGroupInvert ? `!${srcGroupName}` : srcGroupName };
         } else if (srcMode === "geoip" && srcGeoip.length > 0) {
           config.source.geoip = { country_code: srcGeoip, inverse_match: srcGeoipInverse };
         } else if (srcMode === "mac" && srcMac.trim()) {
@@ -522,7 +556,7 @@ export function ZoneRulePanel({
         if (srcPortMode === "port" && srcPort.trim()) {
           config.source.port = srcPort.trim();
         } else if (srcPortMode === "group" && srcPortGroup) {
-          config.source = { ...config.source, group: { ...(config.source.group ?? {}), "port-group": srcPortGroup } };
+          config.source = { ...config.source, group: { ...(config.source.group ?? {}), "port-group": srcPortGroupInvert ? `!${srcPortGroup}` : srcPortGroup } };
         }
       }
 
@@ -534,14 +568,14 @@ export function ZoneRulePanel({
         if (dstMode === "address" && dstAddress.trim()) {
           config.destination.address = dstAddressInvert ? `!${dstAddress.trim()}` : dstAddress.trim();
         } else if (dstMode === "group" && dstGroupName) {
-          config.destination.group = { [dstGroupType]: dstGroupName };
+          config.destination.group = { [dstGroupType]: dstGroupInvert ? `!${dstGroupName}` : dstGroupName };
         } else if (dstMode === "geoip" && dstGeoip.length > 0) {
           config.destination.geoip = { country_code: dstGeoip, inverse_match: dstGeoipInverse };
         }
         if (dstPortMode === "port" && dstPort.trim()) {
           config.destination.port = dstPort.trim();
         } else if (dstPortMode === "group" && dstPortGroup) {
-          config.destination = { ...config.destination, group: { ...(config.destination.group ?? {}), "port-group": dstPortGroup } };
+          config.destination = { ...config.destination, group: { ...(config.destination.group ?? {}), "port-group": dstPortGroupInvert ? `!${dstPortGroup}` : dstPortGroup } };
         }
       }
 
@@ -862,27 +896,33 @@ export function ZoneRulePanel({
                   )}
 
                   {srcMode === "group" && (
-                    <div className="flex gap-2">
-                      <Select value={srcGroupType} onValueChange={(v) => { setSrcGroupType(v); setSrcGroupName(""); }} disabled={!canEdit}>
-                        <SelectTrigger className="h-8 text-xs w-44">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {addrGroupTypeOptions.map((o) => (
-                            <SelectItem key={o.value} value={o.value} className="text-xs">{o.label}</SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <Select value={srcGroupName} onValueChange={setSrcGroupName} disabled={!canEdit}>
-                        <SelectTrigger className="h-8 text-xs flex-1">
-                          <SelectValue placeholder="Select group" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {groupsByType(srcGroupType).map((g) => (
-                            <SelectItem key={g.name} value={g.name} className="text-xs font-mono">{g.name}</SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                    <div className="space-y-1">
+                      <div className="flex gap-2">
+                        <Select value={srcGroupType} onValueChange={(v) => { setSrcGroupType(v); setSrcGroupName(""); }} disabled={!canEdit}>
+                          <SelectTrigger className="h-8 text-xs w-44">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {addrGroupTypeOptions.map((o) => (
+                              <SelectItem key={o.value} value={o.value} className="text-xs">{o.label}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <Select value={srcGroupName} onValueChange={setSrcGroupName} disabled={!canEdit}>
+                          <SelectTrigger className="h-8 text-xs flex-1">
+                            <SelectValue placeholder="Select group" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {groupsByType(srcGroupType).map((g) => (
+                              <SelectItem key={g.name} value={g.name} className="text-xs font-mono">{g.name}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <label className="flex items-center gap-1 text-xs whitespace-nowrap cursor-pointer">
+                        <Checkbox checked={srcGroupInvert} onCheckedChange={(c) => setSrcGroupInvert(!!c)} disabled={!canEdit} className="h-3.5 w-3.5" />
+                        Invert (match packets NOT in this group)
+                      </label>
                     </div>
                   )}
 
@@ -929,16 +969,22 @@ export function ZoneRulePanel({
                     </div>
                   )}
                   {srcPortMode === "group" && (
-                    <Select value={srcPortGroup} onValueChange={setSrcPortGroup} disabled={!canEdit}>
-                      <SelectTrigger className="h-8 text-xs">
-                        <SelectValue placeholder="Select port group" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {portGroups.map((g) => (
-                          <SelectItem key={g.name} value={g.name} className="text-xs font-mono">{g.name}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <div className="space-y-1">
+                      <Select value={srcPortGroup} onValueChange={setSrcPortGroup} disabled={!canEdit}>
+                        <SelectTrigger className="h-8 text-xs">
+                          <SelectValue placeholder="Select port group" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {portGroups.map((g) => (
+                            <SelectItem key={g.name} value={g.name} className="text-xs font-mono">{g.name}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <label className="flex items-center gap-1 text-xs whitespace-nowrap cursor-pointer">
+                        <Checkbox checked={srcPortGroupInvert} onCheckedChange={(c) => setSrcPortGroupInvert(!!c)} disabled={!canEdit} className="h-3.5 w-3.5" />
+                        Invert (match packets NOT in this group)
+                      </label>
+                    </div>
                   )}
                 </div>
               </div>
@@ -980,27 +1026,33 @@ export function ZoneRulePanel({
                   )}
 
                   {dstMode === "group" && (
-                    <div className="flex gap-2">
-                      <Select value={dstGroupType} onValueChange={(v) => { setDstGroupType(v); setDstGroupName(""); }} disabled={!canEdit}>
-                        <SelectTrigger className="h-8 text-xs w-44">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {addrGroupTypeOptions.map((o) => (
-                            <SelectItem key={o.value} value={o.value} className="text-xs">{o.label}</SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <Select value={dstGroupName} onValueChange={setDstGroupName} disabled={!canEdit}>
-                        <SelectTrigger className="h-8 text-xs flex-1">
-                          <SelectValue placeholder="Select group" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {groupsByType(dstGroupType).map((g) => (
-                            <SelectItem key={g.name} value={g.name} className="text-xs font-mono">{g.name}</SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                    <div className="space-y-1">
+                      <div className="flex gap-2">
+                        <Select value={dstGroupType} onValueChange={(v) => { setDstGroupType(v); setDstGroupName(""); }} disabled={!canEdit}>
+                          <SelectTrigger className="h-8 text-xs w-44">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {addrGroupTypeOptions.map((o) => (
+                              <SelectItem key={o.value} value={o.value} className="text-xs">{o.label}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <Select value={dstGroupName} onValueChange={setDstGroupName} disabled={!canEdit}>
+                          <SelectTrigger className="h-8 text-xs flex-1">
+                            <SelectValue placeholder="Select group" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {groupsByType(dstGroupType).map((g) => (
+                              <SelectItem key={g.name} value={g.name} className="text-xs font-mono">{g.name}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <label className="flex items-center gap-1 text-xs whitespace-nowrap cursor-pointer">
+                        <Checkbox checked={dstGroupInvert} onCheckedChange={(c) => setDstGroupInvert(!!c)} disabled={!canEdit} className="h-3.5 w-3.5" />
+                        Invert (match packets NOT in this group)
+                      </label>
                     </div>
                   )}
 
@@ -1034,16 +1086,22 @@ export function ZoneRulePanel({
                     </div>
                   )}
                   {dstPortMode === "group" && (
-                    <Select value={dstPortGroup} onValueChange={setDstPortGroup} disabled={!canEdit}>
-                      <SelectTrigger className="h-8 text-xs">
-                        <SelectValue placeholder="Select port group" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {portGroups.map((g) => (
-                          <SelectItem key={g.name} value={g.name} className="text-xs font-mono">{g.name}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <div className="space-y-1">
+                      <Select value={dstPortGroup} onValueChange={setDstPortGroup} disabled={!canEdit}>
+                        <SelectTrigger className="h-8 text-xs">
+                          <SelectValue placeholder="Select port group" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {portGroups.map((g) => (
+                            <SelectItem key={g.name} value={g.name} className="text-xs font-mono">{g.name}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <label className="flex items-center gap-1 text-xs whitespace-nowrap cursor-pointer">
+                        <Checkbox checked={dstPortGroupInvert} onCheckedChange={(c) => setDstPortGroupInvert(!!c)} disabled={!canEdit} className="h-3.5 w-3.5" />
+                        Invert (match packets NOT in this group)
+                      </label>
+                    </div>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
  Add "Invert" checkbox to all group selectors (source/destination address
  groups and port groups) across zones, create rule, and edit rule modals.
  Inverted groups prepend "!" to the group name per VyOS syntax. Fix group
  member tooltip lookups to strip the "!" prefix so hovering inverted
  groups correctly displays members. Inverted groups render with orange
  badge styling for visual distinction.