### PR TITLE
feat: add configurable API timeout per instance (#110)

### DIFF
--- a/backend/middleware/session.py
+++ b/backend/middleware/session.py
@@ -133,6 +133,7 @@ class SessionMiddleware(BaseHTTPMiddleware):
                             i."verifySsl" as verify_ssl,
                             i."commitConfirmEnabled" as commit_confirm_enabled,
                             i."commitConfirmMinutes" as commit_confirm_minutes,
+                            i.timeout,
                             s.name as site_name,
                             'ADMIN' as user_role
                         FROM active_sessions a
@@ -162,6 +163,7 @@ class SessionMiddleware(BaseHTTPMiddleware):
                             i."verifySsl" as verify_ssl,
                             i."commitConfirmEnabled" as commit_confirm_enabled,
                             i."commitConfirmMinutes" as commit_confirm_minutes,
+                            i.timeout,
                             s.name as site_name,
                             uir.role as user_role
                         FROM active_sessions a
@@ -221,6 +223,7 @@ class SessionMiddleware(BaseHTTPMiddleware):
                         "verify_ssl": session.get("verify_ssl"),
                         "commit_confirm_enabled": session.get("commit_confirm_enabled") or False,
                         "commit_confirm_minutes": session.get("commit_confirm_minutes") or 5,
+                        "timeout": session.get("timeout") or 10,
                     }
                     request.state.site = {
                         "id": session["site_id"],

--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -78,6 +78,7 @@ class InstanceResponse(BaseModel):
     ssh_key_configured: bool = False
     commit_confirm_enabled: bool = False
     commit_confirm_minutes: int = 5
+    timeout: int = 10
     created_at: datetime
     updated_at: datetime
 
@@ -99,6 +100,7 @@ class InstanceCreateRequest(BaseModel):
     ssh_username: Optional[str] = Field(None, description="SSH username for monitoring")
     commit_confirm_enabled: bool = Field(default=False, description="Use commit-confirm for all changes (VyOS 1.5+ only)")
     commit_confirm_minutes: int = Field(default=5, ge=1, le=60, description="Minutes before auto-revert if not confirmed")
+    timeout: int = Field(default=10, ge=1, le=300, description="API request timeout in seconds")
 
 
 class InstanceUpdateRequest(BaseModel):
@@ -118,6 +120,7 @@ class InstanceUpdateRequest(BaseModel):
     ssh_username: Optional[str] = Field(None, description="SSH username for monitoring")
     commit_confirm_enabled: Optional[bool] = Field(None, description="Use commit-confirm for all changes (VyOS 1.5+ only)")
     commit_confirm_minutes: Optional[int] = Field(None, ge=1, le=60, description="Minutes before auto-revert if not confirmed")
+    timeout: Optional[int] = Field(None, ge=1, le=300, description="API request timeout in seconds")
 
 
 class ActiveSessionResponse(BaseModel):
@@ -284,7 +287,7 @@ async def connect_to_instance(request: Request, body: ConnectRequest):
                 instance = await conn.fetchrow(
                     """
                     SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
-                           i."apiKey", i.protocol, i."verifySsl", i."vyosVersion",
+                           i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
                            s.name as site_name,
                            'ADMIN' as role
                     FROM instances i
@@ -298,7 +301,7 @@ async def connect_to_instance(request: Request, body: ConnectRequest):
                 instance = await conn.fetchrow(
                     """
                     SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
-                           i."apiKey", i.protocol, i."verifySsl", i."vyosVersion",
+                           i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
                            s.name as site_name,
                            uir.role as role
                     FROM instances i
@@ -331,7 +334,7 @@ async def connect_to_instance(request: Request, body: ConnectRequest):
                     protocol=instance["protocol"],
                     port=instance["port"],
                     verify=instance["verifySsl"],
-                    timeout=10,
+                    timeout=instance.get("timeout") or 10,
                 )
                 vyos_service = VyOSService(device_config)
 
@@ -589,7 +592,7 @@ async def list_site_instances(request: Request, site_id: str):
                     """
                     SELECT id, "siteId", name, description, host, port, protocol, "verifySsl", "isActive",
                            "vyosVersion", "sshPort", "sshUsername", "sshKeyConfigured",
-                           "commitConfirmEnabled", "commitConfirmMinutes",
+                           "commitConfirmEnabled", "commitConfirmMinutes", timeout,
                            "createdAt", "updatedAt"
                     FROM instances
                     WHERE "siteId" = $1
@@ -603,7 +606,7 @@ async def list_site_instances(request: Request, site_id: str):
                     """
                     SELECT DISTINCT i.id, i."siteId", i.name, i.description, i.host, i.port, i.protocol, i."verifySsl", i."isActive",
                            i."vyosVersion", i."sshPort", i."sshUsername", i."sshKeyConfigured",
-                           i."commitConfirmEnabled", i."commitConfirmMinutes",
+                           i."commitConfirmEnabled", i."commitConfirmMinutes", i.timeout,
                            i."createdAt", i."updatedAt"
                     FROM instances i
                     JOIN user_instance_roles uir ON i.id = uir."instanceId"
@@ -634,6 +637,7 @@ async def list_site_instances(request: Request, site_id: str):
                     ssh_key_configured=inst["sshKeyConfigured"],
                     commit_confirm_enabled=inst.get("commitConfirmEnabled") or False,
                     commit_confirm_minutes=inst.get("commitConfirmMinutes") or 5,
+                    timeout=inst.get("timeout") or 10,
                     created_at=inst["createdAt"],
                     updated_at=inst["updatedAt"],
                 )
@@ -933,13 +937,13 @@ async def create_instance(request: Request, body: InstanceCreateRequest):
                     id, "siteId", name, description, host, port, username, password,
                     "apiKey", "vyosVersion", protocol, "verifySsl", "isActive",
                     "sshPort", "sshUsername",
-                    "commitConfirmEnabled", "commitConfirmMinutes",
+                    "commitConfirmEnabled", "commitConfirmMinutes", timeout,
                     "createdAt", "updatedAt"
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NOW(), NOW())
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, NOW(), NOW())
                 RETURNING id, "siteId", name, description, host, port, protocol, "verifySsl", "vyosVersion",
                           "isActive", "sshPort", "sshUsername", "sshKeyConfigured",
-                          "commitConfirmEnabled", "commitConfirmMinutes",
+                          "commitConfirmEnabled", "commitConfirmMinutes", timeout,
                           "createdAt", "updatedAt"
                 """,
                 instance_id,
@@ -959,6 +963,7 @@ async def create_instance(request: Request, body: InstanceCreateRequest):
                 body.ssh_username,
                 body.commit_confirm_enabled,
                 body.commit_confirm_minutes,
+                body.timeout,
             )
 
             clear_session_cache(instance_id)
@@ -979,6 +984,7 @@ async def create_instance(request: Request, body: InstanceCreateRequest):
                 ssh_key_configured=instance["sshKeyConfigured"],
                 commit_confirm_enabled=instance.get("commitConfirmEnabled") or False,
                 commit_confirm_minutes=instance.get("commitConfirmMinutes") or 5,
+                timeout=instance.get("timeout") or 10,
                 created_at=instance["createdAt"],
                 updated_at=instance["updatedAt"],
             )
@@ -1122,13 +1128,18 @@ async def update_instance(request: Request, instance_id: str, body: InstanceUpda
                 params.append(body.commit_confirm_minutes)
                 param_num += 1
 
+            if body.timeout is not None:
+                updates.append(f'timeout = ${param_num}')
+                params.append(body.timeout)
+                param_num += 1
+
             if not updates:
                 # No fields to update, return current instance
                 instance = await conn.fetchrow(
                     """
                     SELECT id, "siteId", name, description, host, port, protocol, "verifySsl", "vyosVersion",
                            "isActive", "sshPort", "sshUsername", "sshKeyConfigured",
-                           "commitConfirmEnabled", "commitConfirmMinutes",
+                           "commitConfirmEnabled", "commitConfirmMinutes", timeout,
                            "createdAt", "updatedAt"
                     FROM instances WHERE id = $1
                     """,
@@ -1142,7 +1153,7 @@ async def update_instance(request: Request, instance_id: str, body: InstanceUpda
                     WHERE id = $1
                     RETURNING id, "siteId", name, description, host, port, protocol, "verifySsl", "vyosVersion",
                               "isActive", "sshPort", "sshUsername", "sshKeyConfigured",
-                              "commitConfirmEnabled", "commitConfirmMinutes",
+                              "commitConfirmEnabled", "commitConfirmMinutes", timeout,
                               "createdAt", "updatedAt"
                 """
                 instance = await conn.fetchrow(query, *params)
@@ -1169,6 +1180,7 @@ async def update_instance(request: Request, instance_id: str, body: InstanceUpda
                 ssh_key_configured=instance["sshKeyConfigured"],
                 commit_confirm_enabled=instance.get("commitConfirmEnabled") or False,
                 commit_confirm_minutes=instance.get("commitConfirmMinutes") or 5,
+                timeout=instance.get("timeout") or 10,
                 created_at=instance["createdAt"],
                 updated_at=instance["updatedAt"],
             )

--- a/backend/session_vyos_service.py
+++ b/backend/session_vyos_service.py
@@ -89,7 +89,7 @@ def get_session_vyos_service(request: Request) -> VyOSService:
             protocol=protocol,
             port=instance.get("port", 443),
             verify=verify,
-            timeout=30,
+            timeout=instance.get("timeout") or 10,
             commit_confirm_enabled=instance.get("commit_confirm_enabled") or False,
             commit_confirm_minutes=instance.get("commit_confirm_minutes") or 5,
             instance_id=instance_id,

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -23,15 +23,26 @@ if [ -d "prisma/migrations" ] && [ "$(ls -A prisma/migrations)" ]; then
 
   # Try to apply migrations
   if ! npx prisma migrate deploy 2>&1; then
-    # If deploy fails, it might be because the schema exists but migration isn't marked as applied
-    echo "⚠️  Migration deployment failed - checking if schema needs baselining..."
+    echo "⚠️  Migration deployment failed - attempting to resolve..."
 
-    # Get the migration name (first directory in prisma/migrations)
-    MIGRATION_NAME=$(ls prisma/migrations | head -n 1)
+    # Resolve any failed migrations by marking them as rolled back, then re-applying
+    for MIGRATION_DIR in prisma/migrations/*/; do
+      MIGRATION_NAME=$(basename "$MIGRATION_DIR")
+      # Skip the migration_lock.toml entry
+      [ "$MIGRATION_NAME" = "migration_lock.toml" ] && continue
+      echo "📌 Resolving migration: $MIGRATION_NAME"
+      npx prisma migrate resolve --rolled-back "$MIGRATION_NAME" 2>/dev/null || true
+    done
 
-    if [ -n "$MIGRATION_NAME" ]; then
-      echo "📌 Marking migration as already applied: $MIGRATION_NAME"
-      npx prisma migrate resolve --applied "$MIGRATION_NAME" || true
+    # Retry deployment after resolving failed migrations
+    echo "🔄 Retrying migration deployment..."
+    if ! npx prisma migrate deploy 2>&1; then
+      echo "⚠️  Retry failed - marking all migrations as applied..."
+      for MIGRATION_DIR in prisma/migrations/*/; do
+        MIGRATION_NAME=$(basename "$MIGRATION_DIR")
+        [ "$MIGRATION_NAME" = "migration_lock.toml" ] && continue
+        npx prisma migrate resolve --applied "$MIGRATION_NAME" 2>/dev/null || true
+      done
     fi
   fi
 else

--- a/frontend/prisma/migrations/20260225_add_commit_confirm_fields/migration.sql
+++ b/frontend/prisma/migrations/20260225_add_commit_confirm_fields/migration.sql
@@ -1,3 +1,3 @@
 -- AlterTable
-ALTER TABLE "instances" ADD COLUMN "commitConfirmEnabled" BOOLEAN NOT NULL DEFAULT false;
-ALTER TABLE "instances" ADD COLUMN "commitConfirmMinutes" INTEGER NOT NULL DEFAULT 5;
+ALTER TABLE "instances" ADD COLUMN IF NOT EXISTS "commitConfirmEnabled" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "instances" ADD COLUMN IF NOT EXISTS "commitConfirmMinutes" INTEGER NOT NULL DEFAULT 5;

--- a/frontend/prisma/migrations/20260324_add_instance_timeout/migration.sql
+++ b/frontend/prisma/migrations/20260324_add_instance_timeout/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "instances" ADD COLUMN IF NOT EXISTS "timeout" INTEGER NOT NULL DEFAULT 10;

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -179,6 +179,7 @@ model Instance {
   // Commit-confirm settings
   commitConfirmEnabled Boolean @default(false) // Use commit-confirm for all changes
   commitConfirmMinutes Int     @default(5)      // Minutes before auto-revert if not confirmed
+  timeout              Int     @default(10)     // API request timeout in seconds
 
   // SSH / Monitoring fields
   sshPort           Int      @default(22)

--- a/frontend/src/components/sites/CreateInstanceModal.tsx
+++ b/frontend/src/components/sites/CreateInstanceModal.tsx
@@ -52,6 +52,7 @@ export function CreateInstanceModal({
   const [sshUsername, setSshUsername] = useState("");
   const [commitConfirmEnabled, setCommitConfirmEnabled] = useState(false);
   const [commitConfirmMinutes, setCommitConfirmMinutes] = useState("5");
+  const [timeout, setTimeout] = useState("10");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -69,6 +70,7 @@ export function CreateInstanceModal({
     setSshUsername("");
     setCommitConfirmEnabled(false);
     setCommitConfirmMinutes("5");
+    setTimeout("10");
     setError(null);
     onOpenChange(false);
   };
@@ -119,6 +121,7 @@ export function CreateInstanceModal({
         ssh_username: sshUsername.trim() || undefined,
         commit_confirm_enabled: commitConfirmEnabled,
         commit_confirm_minutes: parseInt(commitConfirmMinutes) || 5,
+        timeout: parseInt(timeout) || 10,
       });
 
       handleClose();
@@ -360,6 +363,24 @@ export function CreateInstanceModal({
                 <Label htmlFor="verifySsl" className="cursor-pointer">
                   Verify SSL certificate
                 </Label>
+              </div>
+
+              {/* Timeout */}
+              <div className="space-y-2">
+                <Label htmlFor="timeout">API Timeout (seconds)</Label>
+                <Input
+                  id="timeout"
+                  type="number"
+                  value={timeout}
+                  onChange={(e) => setTimeout(e.target.value)}
+                  placeholder="10"
+                  min="1"
+                  max="300"
+                  disabled={loading}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Timeout for API requests to the VyOS device (1-300 seconds)
+                </p>
               </div>
             </TabsContent>
 

--- a/frontend/src/components/sites/EditInstanceModal.tsx
+++ b/frontend/src/components/sites/EditInstanceModal.tsx
@@ -55,6 +55,7 @@ export function EditInstanceModal({
   const [sshUsername, setSshUsername] = useState("");
   const [commitConfirmEnabled, setCommitConfirmEnabled] = useState(false);
   const [commitConfirmMinutes, setCommitConfirmMinutes] = useState("5");
+  const [timeout, setTimeout] = useState("10");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -71,6 +72,7 @@ export function EditInstanceModal({
       setSshUsername(instance.ssh_username || "");
       setCommitConfirmEnabled(instance.commit_confirm_enabled ?? false);
       setCommitConfirmMinutes((instance.commit_confirm_minutes ?? 5).toString());
+      setTimeout((instance.timeout ?? 10).toString());
       // Don't populate API key for security
       setApiKey("");
       setProtocol(instance.protocol || "https");
@@ -93,6 +95,7 @@ export function EditInstanceModal({
     setSshUsername("");
     setCommitConfirmEnabled(false);
     setCommitConfirmMinutes("5");
+    setTimeout("10");
     setError(null);
     onOpenChange(false);
   };
@@ -140,6 +143,7 @@ export function EditInstanceModal({
         verify_ssl: verifySsl,
         commit_confirm_enabled: commitConfirmEnabled,
         commit_confirm_minutes: parseInt(commitConfirmMinutes) || 5,
+        timeout: parseInt(timeout) || 10,
       };
 
       if (apiKey.trim()) {
@@ -426,6 +430,23 @@ export function EditInstanceModal({
                     Verify SSL certificate
                   </Label>
                 </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="editTimeout">API Timeout (seconds)</Label>
+                <Input
+                  id="editTimeout"
+                  type="number"
+                  value={timeout}
+                  onChange={(e) => setTimeout(e.target.value)}
+                  placeholder="10"
+                  min="1"
+                  max="300"
+                  disabled={loading}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Timeout for API requests to the VyOS device (1-300 seconds)
+                </p>
               </div>
 
               <DialogFooter className="pt-2">

--- a/frontend/src/lib/api/session.ts
+++ b/frontend/src/lib/api/session.ts
@@ -39,6 +39,7 @@ export interface Instance {
   ssh_key_configured: boolean;
   commit_confirm_enabled: boolean;
   commit_confirm_minutes: number;
+  timeout: number;
   created_at: string;
   updated_at: string;
 }
@@ -95,6 +96,7 @@ export interface InstanceCreateRequest {
   ssh_username?: string;
   commit_confirm_enabled?: boolean;
   commit_confirm_minutes?: number;
+  timeout?: number;
 }
 
 export interface InstanceUpdateRequest {
@@ -112,6 +114,7 @@ export interface InstanceUpdateRequest {
   ssh_username?: string;
   commit_confirm_enabled?: boolean;
   commit_confirm_minutes?: number;
+  timeout?: number;
 }
 
 export interface AuthSessionInfo {


### PR DESCRIPTION
   Allow users to set the API request timeout (1-300 seconds) in the
   instance configuration. Previously hardcoded to 10s for connection
   tests and 30s for active sessions, the timeout now flows from the
   database through the middleware to the VyOS service layer.

   Also fixes failed migration recovery in docker-entrypoint.sh by
   resolving failed migrations before retrying, and makes the
   commit-confirm migration idempotent with IF NOT EXISTS.

   Closes #110