### PR TITLE
feat: add custom CA certificate support for Docker containers

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -15,6 +15,7 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     curl \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy backend requirements
@@ -26,8 +27,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy backend application code
 COPY backend/ .
 
+# Copy and set entrypoint script
+COPY backend/docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 # Expose port
 EXPOSE 8000
 
-# Run the FastAPI application with uvicorn
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers"]
+# Use entrypoint script (imports custom CAs, then starts uvicorn)
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ services:
     container_name: vymanager-backend
     ports:
       - "8000:8000"
+    volumes:
+      - ./certs:/usr/local/share/ca-certificates/custom:ro
     env_file:
       - .env
     restart: unless-stopped
@@ -481,12 +483,40 @@ npx prisma studio
 
 ## Troubleshooting
 
+### Custom CA Certificates
+
+If your VyOS instances use certificates signed by a private CA (e.g., FreeIPA, Active Directory CS, internal PKI), you can add your CA certificates so that VyManager trusts them when "Verify SSL" is enabled.
+
+1. Create a `certs` directory next to your `docker-compose.yml`:
+   ```bash
+   mkdir certs
+   ```
+
+2. Copy your CA certificate(s) into it. Files must be PEM-encoded with a `.crt` extension:
+   ```bash
+   cp /path/to/my-ca.crt ./certs/
+   ```
+
+3. Restart the backend container:
+   ```bash
+   docker compose restart backend
+   ```
+
+The backend will automatically import all `.crt` files from the `certs` directory on startup. You can add multiple CA certificates — all of them will be trusted.
+
+> **Note**: The certificate must be in PEM format (starts with `-----BEGIN CERTIFICATE-----`). If you only have the raw base64 data, wrap it with the header and footer:
+> ```
+> -----BEGIN CERTIFICATE-----
+> <your base64 certificate data>
+> -----END CERTIFICATE-----
+> ```
+
 ### Cannot Connect to VyOS Instance
 
 1. **Check API Key**: Verify the API key in VyOS matches your input
 2. **Check Network**: Ensure VyManager can reach the VyOS IP address
 3. **Check Port**: Default is 443, verify it's not blocked by firewall
-4. **Check SSL**: If using self-signed cert, set "Verify SSL" to false
+4. **Check SSL**: If using self-signed cert, set "Verify SSL" to false or add your CA certificate (see [Custom CA Certificates](#custom-ca-certificates))
 
 ### Containers Not Starting
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     curl \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching
@@ -18,8 +19,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
+# Copy and set entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 # Expose port
 EXPOSE 8000
 
-# Run the FastAPI application with uvicorn
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers"]
+# Use entrypoint script (imports custom CAs, then starts uvicorn)
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+# Import custom CA certificates if any are mounted
+CA_DIR="/usr/local/share/ca-certificates/custom"
+if [ -d "$CA_DIR" ] && [ "$(ls -A "$CA_DIR"/*.crt 2>/dev/null)" ]; then
+    echo "Importing custom CA certificates..."
+    update-ca-certificates
+    export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+    export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+    echo "Custom CA certificates imported."
+fi
+
+exec uvicorn app:app --host 0.0.0.0 --port 8000 --proxy-headers


### PR DESCRIPTION
  Users with VyOS instances using certificates signed by private CAs
  (e.g., FreeIPA, internal PKI) can now drop .crt files into a certs/
  directory. The backend container imports them on startup via
  update-ca-certificates, making them trusted for both the requests
  and httpx libraries.

  Closes #108