### PR TITLE
Refactor: wire missing backend ethernet commands to frontend UI 

### DIFF
--- a/backend/routers/interfaces/ethernet.py
+++ b/backend/routers/interfaces/ethernet.py
@@ -115,6 +115,8 @@ class OffloadConfig(BaseModel):
     rps: Optional[str] = None
     sg: Optional[str] = None
     tso: Optional[str] = None
+    hw_tc_offload: Optional[str] = None
+    rfs: Optional[str] = None
 
 class RingBufferConfig(BaseModel):
     """Ring buffer settings"""
@@ -133,6 +135,7 @@ class IPConfig(BaseModel):
     proxy_arp_pvlan: Optional[bool] = None
     source_validation: Optional[str] = None
     enable_directed_broadcast: Optional[bool] = None
+    disable_forwarding: Optional[bool] = None
 
 class IPv6Config(BaseModel):
     """IPv6 configuration settings"""
@@ -140,6 +143,10 @@ class IPv6Config(BaseModel):
     adjust_mss: Optional[str] = None
     disable_forwarding: Optional[bool] = None
     dup_addr_detect_transmits: Optional[str] = None
+    accept_dad: Optional[str] = None
+    no_default_link_local: Optional[bool] = None
+    base_reachable_time: Optional[str] = None
+    source_validation: Optional[str] = None
 
 class DHCPOptionsConfig(BaseModel):
     """DHCP options"""
@@ -148,12 +155,18 @@ class DHCPOptionsConfig(BaseModel):
     vendor_class_id: Optional[str] = None
     no_default_route: Optional[bool] = None
     default_route_distance: Optional[str] = None
+    reject: Optional[Any] = None
+    user_class: Optional[str] = None
+    mtu: Optional[bool] = None
 
 class DHCPv6OptionsConfig(BaseModel):
     """DHCPv6 options"""
     duid: Optional[str] = None
     rapid_commit: Optional[bool] = None
     pd: Optional[Dict] = None
+    no_release: Optional[bool] = None
+    parameters_only: Optional[bool] = None
+    temporary: Optional[bool] = None
 
 class VIFConfig(BaseModel):
     """VLAN sub-interface (VIF) configuration"""
@@ -186,10 +199,41 @@ class EAPoLConfig(BaseModel):
     ca_cert_file: Optional[str] = None
     cert_file: Optional[str] = None
     key_file: Optional[str] = None
+    passphrase: Optional[str] = None
 
 class EVPNConfig(BaseModel):
     """EVPN configuration"""
     uplink: Optional[bool] = None
+
+class InterruptCoalescingConfig(BaseModel):
+    """Interrupt coalescing configuration (VyOS 1.5+)"""
+    adaptive_rx: Optional[bool] = None
+    adaptive_tx: Optional[bool] = None
+    cqe_mode_rx: Optional[bool] = None
+    cqe_mode_tx: Optional[bool] = None
+    rx_usecs: Optional[str] = None
+    rx_frames: Optional[str] = None
+    tx_usecs: Optional[str] = None
+    tx_frames: Optional[str] = None
+    rx_usecs_irq: Optional[str] = None
+    rx_usecs_low: Optional[str] = None
+    rx_usecs_high: Optional[str] = None
+    tx_usecs_irq: Optional[str] = None
+    tx_usecs_low: Optional[str] = None
+    tx_usecs_high: Optional[str] = None
+    rx_frames_irq: Optional[str] = None
+    rx_frame_low: Optional[str] = None
+    rx_frame_high: Optional[str] = None
+    tx_frames_irq: Optional[str] = None
+    tx_frame_low: Optional[str] = None
+    tx_frame_high: Optional[str] = None
+    pkt_rate_low: Optional[str] = None
+    pkt_rate_high: Optional[str] = None
+    sample_interval: Optional[str] = None
+    stats_block_usecs: Optional[str] = None
+    tx_aggr_max_bytes: Optional[str] = None
+    tx_aggr_max_frames: Optional[str] = None
+    tx_aggr_time_usecs: Optional[str] = None
 
 class EthernetInterfaceConfigResponse(BaseModel):
     """Ethernet interface configuration from VyOS (read operation)"""
@@ -228,6 +272,9 @@ class EthernetInterfaceConfigResponse(BaseModel):
     mirror: Optional[MirrorConfig] = Field(None, description="Port mirroring configuration")
     eapol: Optional[EAPoLConfig] = Field(None, description="802.1X EAPoL configuration")
     evpn: Optional[EVPNConfig] = Field(None, description="EVPN configuration")
+    redirect: Optional[str] = Field(None, description="Traffic redirect target")
+    interrupt_coalescing: Optional[InterruptCoalescingConfig] = Field(None, description="Interrupt coalescing configuration (1.5+)")
+    switchdev: Optional[bool] = Field(None, description="Switchdev mode (1.5+)")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -350,6 +397,8 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                     "rps": True,
                     "sg": True,
                     "tso": True,
+                    "hw_tc_offload": True,
+                    "rfs": True,
                 },
 
                 # Ring buffer (all versions)
@@ -381,6 +430,7 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                 "ip": {
                     "source_validation": True,
                     "directed_broadcast": version_float >= 1.5,  # 1.5+ only
+                    "disable_forwarding": True,
                 },
 
                 # IPv6 (all versions)
@@ -389,6 +439,11 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                     "eui64": True,
                     "disable_forwarding": True,
                     "dup_addr_detect_transmits": True,
+                    "accept_dad": True,
+                    "no_default_link_local": True,
+                    "base_reachable_time": True,
+                    "source_validation": True,
+                    "interface_identifier": version_float >= 1.5,
                 },
 
                 # Flow control & link detection (all versions)
@@ -402,6 +457,9 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                     "vendor_class_id": True,
                     "no_default_route": True,
                     "default_route_distance": True,
+                    "reject": True,
+                    "user_class": True,
+                    "mtu": True,
                 },
 
                 # DHCPv6 (all versions)
@@ -409,6 +467,11 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                     "duid": True,
                     "rapid_commit": True,
                     "prefix_delegation": True,
+                    "no_release": True,
+                    "parameters_only": True,
+                    "temporary": True,
+                    "no_request_dns": version_float >= 1.5,
+                    "no_request_domain_name": version_float >= 1.5,
                 },
 
                 # VLANs (all versions)
@@ -438,11 +501,25 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                     "ca_cert_file": True,
                     "cert_file": True,
                     "key_file": True,
+                    "passphrase": True,
                 },
 
                 # EVPN (all versions)
                 "evpn": {
                     "uplink_tracking": True,
+                },
+
+                # Redirect (all versions)
+                "redirect": True,
+
+                # Interrupt Coalescing (1.5+ only)
+                "interrupt_coalescing": {
+                    "supported": version_float >= 1.5,
+                },
+
+                # Switchdev (1.5+ only)
+                "switchdev": {
+                    "supported": version_float >= 1.5,
                 },
             },
 
@@ -482,6 +559,8 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                     "delete_offload_sg",
                     "set_offload_tso",
                     "delete_offload_tso",
+                    "set_offload_hw_tc_offload", "delete_offload_hw_tc_offload",
+                    "set_offload_rfs", "delete_offload_rfs",
                 ],
                 "ring_buffer": [
                     "set_ring_buffer_rx",
@@ -506,13 +585,18 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                 "ip": [
                     "set_ip_source_validation",
                     "delete_ip_source_validation",
+                    "set_ip_disable_forwarding", "delete_ip_disable_forwarding",
                 ] + (["set_ip_enable_directed_broadcast"] if version_float >= 1.5 else []),
                 "ipv6": [
                     "set_ipv6_address_autoconf",
                     "set_ipv6_address_eui64",
                     "set_ipv6_disable_forwarding",
                     "set_ipv6_dup_addr_detect_transmits",
-                ],
+                    "set_ipv6_accept_dad",
+                    "set_ipv6_address_no_default_link_local", "delete_ipv6_address_no_default_link_local",
+                    "set_ipv6_base_reachable_time",
+                    "set_ipv6_source_validation", "delete_ipv6_source_validation",
+                ] + (["set_ipv6_address_interface_identifier"] if version_float >= 1.5 else []),
                 "flow_link": [
                     "set_disable_flow_control",
                     "delete_disable_flow_control",
@@ -525,12 +609,24 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                     "set_dhcp_options_vendor_class_id",
                     "set_dhcp_options_no_default_route",
                     "set_dhcp_options_default_route_distance",
+                    "set_dhcp_options_reject",
+                    "set_dhcp_options_user_class",
+                    "set_dhcp_options_mtu",
+                    "delete_dhcp_options",
                 ],
                 "dhcpv6": [
                     "set_dhcpv6_options_duid",
                     "set_dhcpv6_options_rapid_commit",
                     "set_dhcpv6_options_pd",
-                ],
+                    "set_dhcpv6_options_no_release",
+                    "set_dhcpv6_options_parameters_only",
+                    "set_dhcpv6_options_temporary",
+                    "set_dhcpv6_options_pd_length",
+                    "set_dhcpv6_options_pd_interface",
+                    "set_dhcpv6_options_pd_interface_address",
+                    "set_dhcpv6_options_pd_interface_sla_id",
+                    "delete_dhcpv6_options",
+                ] + (["set_dhcpv6_options_no_request_dns", "set_dhcpv6_options_no_request_domain_name"] if version_float >= 1.5 else []),
                 "vlan_vif": [
                     "set_vif",
                     "delete_vif",
@@ -550,6 +646,15 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                     "set_vif_dhcp_options_host_name",
                     "set_vif_ipv6_address_autoconf",
                     "set_vif_ipv6_address_eui64",
+                    "set_vif_egress_qos", "delete_vif_egress_qos",
+                    "set_vif_ingress_qos", "delete_vif_ingress_qos",
+                    "set_vif_redirect", "delete_vif_redirect",
+                    "set_vif_ip_adjust_mss", "set_vif_ip_disable_forwarding",
+                    "set_vif_ip_source_validation", "set_vif_ip_enable_proxy_arp",
+                    "set_vif_ip_arp_cache_timeout",
+                    "set_vif_mirror_ingress", "set_vif_mirror_egress", "delete_vif_mirror",
+                    "set_vif_ipv6_disable_forwarding", "set_vif_ipv6_adjust_mss",
+                    "set_vif_ipv6_accept_dad", "set_vif_ipv6_dup_addr_detect_transmits",
                 ],
                 "vlan_vif_s": [
                     "set_vif_s",
@@ -598,11 +703,35 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                     "set_eapol_ca_cert_file",
                     "set_eapol_cert_file",
                     "set_eapol_key_file",
+                    "set_eapol_passphrase",
+                    "delete_eapol",
                 ],
                 "evpn": [
                     "set_evpn_uplink",
                     "delete_evpn",
                 ],
+                "redirect": [
+                    "set_redirect",
+                    "delete_redirect",
+                ],
+                "switchdev": (["set_switchdev", "delete_switchdev"] if version_float >= 1.5 else []),
+                "interrupt_coalescing": ([
+                    "set_interrupt_coalescing_adaptive_rx", "delete_interrupt_coalescing_adaptive_rx",
+                    "set_interrupt_coalescing_adaptive_tx", "delete_interrupt_coalescing_adaptive_tx",
+                    "set_interrupt_coalescing_cqe_mode_rx", "delete_interrupt_coalescing_cqe_mode_rx",
+                    "set_interrupt_coalescing_cqe_mode_tx", "delete_interrupt_coalescing_cqe_mode_tx",
+                    "set_interrupt_coalescing_rx_usecs", "set_interrupt_coalescing_rx_frames",
+                    "set_interrupt_coalescing_tx_usecs", "set_interrupt_coalescing_tx_frames",
+                    "set_interrupt_coalescing_rx_usecs_irq", "set_interrupt_coalescing_rx_usecs_low", "set_interrupt_coalescing_rx_usecs_high",
+                    "set_interrupt_coalescing_tx_usecs_irq", "set_interrupt_coalescing_tx_usecs_low", "set_interrupt_coalescing_tx_usecs_high",
+                    "set_interrupt_coalescing_rx_frames_irq", "set_interrupt_coalescing_rx_frame_low", "set_interrupt_coalescing_rx_frame_high",
+                    "set_interrupt_coalescing_tx_frames_irq", "set_interrupt_coalescing_tx_frame_low", "set_interrupt_coalescing_tx_frame_high",
+                    "set_interrupt_coalescing_pkt_rate_low", "set_interrupt_coalescing_pkt_rate_high",
+                    "set_interrupt_coalescing_sample_interval", "set_interrupt_coalescing_stats_block_usecs",
+                    "set_interrupt_coalescing_tx_aggr_max_bytes", "set_interrupt_coalescing_tx_aggr_max_frames",
+                    "set_interrupt_coalescing_tx_aggr_time_usecs",
+                    "delete_interrupt_coalescing",
+                ] if version_float >= 1.5 else []),
             },
 
             # Version-specific feature notes
@@ -613,13 +742,21 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                     "1.4": {
                         "description": "Base VyOS 1.4 feature set",
                         "limitations": [
-                            "Directed broadcast not available"
+                            "Directed broadcast not available",
+                            "Interrupt coalescing not available",
+                            "Switchdev not available",
+                            "DHCPv6 no-request-dns/no-request-domain-name not available",
+                            "IPv6 interface-identifier not available",
                         ]
                     },
                     "1.5": {
                         "description": "VyOS 1.5 with enhanced features",
                         "new_features": [
-                            "IP directed broadcast support"
+                            "IP directed broadcast support",
+                            "Interrupt coalescing support",
+                            "Switchdev mode",
+                            "DHCPv6 no-request-dns and no-request-domain-name",
+                            "IPv6 interface-identifier",
                         ]
                     }
                 }
@@ -1129,6 +1266,227 @@ async def configure_interface_batch(http_request: Request, request: InterfaceBat
                 batch.set_evpn_uplink(request.interface)
             elif op_type == "delete_evpn":
                 batch.delete_evpn(request.interface)
+            # DHCP Options (additional)
+            elif op_type == "set_dhcp_options_reject":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_dhcp_options_reject(request.interface, value)
+            elif op_type == "set_dhcp_options_user_class":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_dhcp_options_user_class(request.interface, value)
+            elif op_type == "set_dhcp_options_mtu":
+                batch.set_dhcp_options_mtu(request.interface)
+            elif op_type == "delete_dhcp_options":
+                batch.delete_dhcp_options(request.interface)
+            # DHCPv6 Options (additional)
+            elif op_type == "set_dhcpv6_options_no_release":
+                batch.set_dhcpv6_options_no_release(request.interface)
+            elif op_type == "set_dhcpv6_options_parameters_only":
+                batch.set_dhcpv6_options_parameters_only(request.interface)
+            elif op_type == "set_dhcpv6_options_temporary":
+                batch.set_dhcpv6_options_temporary(request.interface)
+            elif op_type == "set_dhcpv6_options_pd_length":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value (pd_id,length)")
+                parts = value.split(",")
+                if len(parts) != 2:
+                    raise HTTPException(status_code=400, detail=f"{op_type} value must be 'pd_id,length'")
+                batch.set_dhcpv6_options_pd_length(request.interface, parts[0], parts[1])
+            elif op_type == "set_dhcpv6_options_pd_interface":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value (pd_id,interface)")
+                parts = value.split(",")
+                if len(parts) != 2:
+                    raise HTTPException(status_code=400, detail=f"{op_type} value must be 'pd_id,interface'")
+                batch.set_dhcpv6_options_pd_interface(request.interface, parts[0], parts[1])
+            elif op_type == "set_dhcpv6_options_pd_interface_address":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value (pd_id,interface,address)")
+                parts = value.split(",", 2)
+                if len(parts) != 3:
+                    raise HTTPException(status_code=400, detail=f"{op_type} value must be 'pd_id,interface,address'")
+                batch.set_dhcpv6_options_pd_interface_address(request.interface, parts[0], parts[1], parts[2])
+            elif op_type == "set_dhcpv6_options_pd_interface_sla_id":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value (pd_id,interface,sla_id)")
+                parts = value.split(",", 2)
+                if len(parts) != 3:
+                    raise HTTPException(status_code=400, detail=f"{op_type} value must be 'pd_id,interface,sla_id'")
+                batch.set_dhcpv6_options_pd_interface_sla_id(request.interface, parts[0], parts[1], parts[2])
+            elif op_type == "delete_dhcpv6_options":
+                batch.delete_dhcpv6_options(request.interface)
+            elif op_type == "set_dhcpv6_options_no_request_dns":
+                batch.set_dhcpv6_options_no_request_dns(request.interface)
+            elif op_type == "set_dhcpv6_options_no_request_domain_name":
+                batch.set_dhcpv6_options_no_request_domain_name(request.interface)
+            # IP (additional)
+            elif op_type == "set_ip_disable_forwarding":
+                batch.set_ip_disable_forwarding(request.interface)
+            elif op_type == "delete_ip_disable_forwarding":
+                batch.delete_ip_disable_forwarding(request.interface)
+            # IPv6 (additional)
+            elif op_type == "set_ipv6_accept_dad":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_ipv6_accept_dad(request.interface, value)
+            elif op_type == "set_ipv6_address_no_default_link_local":
+                batch.set_ipv6_address_no_default_link_local(request.interface)
+            elif op_type == "delete_ipv6_address_no_default_link_local":
+                batch.delete_ipv6_address_no_default_link_local(request.interface)
+            elif op_type == "set_ipv6_base_reachable_time":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_ipv6_base_reachable_time(request.interface, value)
+            elif op_type == "set_ipv6_source_validation":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_ipv6_source_validation(request.interface, value)
+            elif op_type == "delete_ipv6_source_validation":
+                batch.delete_ipv6_source_validation(request.interface)
+            elif op_type == "set_ipv6_address_interface_identifier":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_ipv6_address_interface_identifier(request.interface, value)
+            # Offload (additional)
+            elif op_type == "set_offload_hw_tc_offload":
+                batch.set_offload_hw_tc_offload(request.interface)
+            elif op_type == "delete_offload_hw_tc_offload":
+                batch.delete_offload_hw_tc_offload(request.interface)
+            elif op_type == "set_offload_rfs":
+                batch.set_offload_rfs(request.interface)
+            elif op_type == "delete_offload_rfs":
+                batch.delete_offload_rfs(request.interface)
+            # Redirect
+            elif op_type == "set_redirect":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_redirect(request.interface, value)
+            elif op_type == "delete_redirect":
+                batch.delete_redirect(request.interface)
+            # EAPoL (additional)
+            elif op_type == "set_eapol_passphrase":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_eapol_passphrase(request.interface, value)
+            elif op_type == "delete_eapol":
+                batch.delete_eapol(request.interface)
+            # Switchdev (1.5+)
+            elif op_type == "set_switchdev":
+                batch.set_switchdev(request.interface)
+            elif op_type == "delete_switchdev":
+                batch.delete_switchdev(request.interface)
+            # Interrupt Coalescing (1.5+)
+            elif op_type == "set_interrupt_coalescing_adaptive_rx":
+                batch.set_interrupt_coalescing_adaptive_rx(request.interface)
+            elif op_type == "delete_interrupt_coalescing_adaptive_rx":
+                batch.delete_interrupt_coalescing_adaptive_rx(request.interface)
+            elif op_type == "set_interrupt_coalescing_adaptive_tx":
+                batch.set_interrupt_coalescing_adaptive_tx(request.interface)
+            elif op_type == "delete_interrupt_coalescing_adaptive_tx":
+                batch.delete_interrupt_coalescing_adaptive_tx(request.interface)
+            elif op_type == "set_interrupt_coalescing_cqe_mode_rx":
+                batch.set_interrupt_coalescing_cqe_mode_rx(request.interface)
+            elif op_type == "delete_interrupt_coalescing_cqe_mode_rx":
+                batch.delete_interrupt_coalescing_cqe_mode_rx(request.interface)
+            elif op_type == "set_interrupt_coalescing_cqe_mode_tx":
+                batch.set_interrupt_coalescing_cqe_mode_tx(request.interface)
+            elif op_type == "delete_interrupt_coalescing_cqe_mode_tx":
+                batch.delete_interrupt_coalescing_cqe_mode_tx(request.interface)
+            elif op_type == "set_interrupt_coalescing_rx_usecs":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_rx_usecs(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_rx_frames":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_rx_frames(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_tx_usecs":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_tx_usecs(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_tx_frames":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_tx_frames(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_rx_usecs_irq":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_rx_usecs_irq(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_rx_usecs_low":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_rx_usecs_low(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_rx_usecs_high":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_rx_usecs_high(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_tx_usecs_irq":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_tx_usecs_irq(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_tx_usecs_low":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_tx_usecs_low(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_tx_usecs_high":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_tx_usecs_high(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_rx_frames_irq":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_rx_frames_irq(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_rx_frame_low":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_rx_frame_low(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_rx_frame_high":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_rx_frame_high(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_tx_frames_irq":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_tx_frames_irq(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_tx_frame_low":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_tx_frame_low(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_tx_frame_high":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_tx_frame_high(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_pkt_rate_low":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_pkt_rate_low(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_pkt_rate_high":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_pkt_rate_high(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_sample_interval":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_sample_interval(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_stats_block_usecs":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_stats_block_usecs(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_tx_aggr_max_bytes":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_tx_aggr_max_bytes(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_tx_aggr_max_frames":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_tx_aggr_max_frames(request.interface, value)
+            elif op_type == "set_interrupt_coalescing_tx_aggr_time_usecs":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value")
+                batch.set_interrupt_coalescing_tx_aggr_time_usecs(request.interface, value)
+            elif op_type == "delete_interrupt_coalescing":
+                batch.delete_interrupt_coalescing(request.interface)
             # VIF (802.1q VLAN) Sub-interface Operations
             elif op_type == "set_vif_address":
                 if not value:

--- a/backend/vyos_builders/interfaces/ethernet.py
+++ b/backend/vyos_builders/interfaces/ethernet.py
@@ -911,3 +911,460 @@ class EthernetInterfaceBuilderMixin:
         """Delete EVPN configuration"""
         path = self.mappers[self.interface_mapper_key].get_evpn_path(interface)
         return self.add_delete(path)
+
+    # ========================================================================
+    # DHCP Options (additional)
+    # ========================================================================
+
+    def set_dhcp_options_reject(self, interface: str, server: str) -> "EthernetInterfaceBuilderMixin":
+        """Set DHCP reject server"""
+        path = self.mappers[self.interface_mapper_key].get_dhcp_options_reject(interface, server)
+        return self.add_set(path)
+
+    def set_dhcp_options_user_class(self, interface: str, user_class: str) -> "EthernetInterfaceBuilderMixin":
+        """Set DHCP user class"""
+        path = self.mappers[self.interface_mapper_key].get_dhcp_options_user_class(interface, user_class)
+        return self.add_set(path)
+
+    def set_dhcp_options_mtu(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable DHCP MTU option"""
+        path = self.mappers[self.interface_mapper_key].get_dhcp_options_mtu(interface)
+        return self.add_set(path)
+
+    def delete_dhcp_options(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete all DHCP options"""
+        path = self.mappers[self.interface_mapper_key].get_dhcp_options_path(interface)
+        return self.add_delete(path)
+
+    # ========================================================================
+    # DHCPv6 Options (additional)
+    # ========================================================================
+
+    def set_dhcpv6_options_no_release(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable DHCPv6 no-release"""
+        path = self.mappers[self.interface_mapper_key].get_dhcpv6_options_no_release(interface)
+        return self.add_set(path)
+
+    def set_dhcpv6_options_parameters_only(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable DHCPv6 parameters-only"""
+        path = self.mappers[self.interface_mapper_key].get_dhcpv6_options_parameters_only(interface)
+        return self.add_set(path)
+
+    def set_dhcpv6_options_temporary(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable DHCPv6 temporary address"""
+        path = self.mappers[self.interface_mapper_key].get_dhcpv6_options_temporary(interface)
+        return self.add_set(path)
+
+    def set_dhcpv6_options_pd_length(self, interface: str, pd_id: str, length: str) -> "EthernetInterfaceBuilderMixin":
+        """Set DHCPv6 prefix delegation length"""
+        path = self.mappers[self.interface_mapper_key].get_dhcpv6_options_pd_length(interface, pd_id, length)
+        return self.add_set(path)
+
+    def set_dhcpv6_options_pd_interface(self, interface: str, pd_id: str, pd_iface: str) -> "EthernetInterfaceBuilderMixin":
+        """Set DHCPv6 prefix delegation interface"""
+        path = self.mappers[self.interface_mapper_key].get_dhcpv6_options_pd_interface(interface, pd_id, pd_iface)
+        return self.add_set(path)
+
+    def set_dhcpv6_options_pd_interface_address(self, interface: str, pd_id: str, pd_iface: str, address: str) -> "EthernetInterfaceBuilderMixin":
+        """Set DHCPv6 prefix delegation interface address"""
+        path = self.mappers[self.interface_mapper_key].get_dhcpv6_options_pd_interface_address(interface, pd_id, pd_iface, address)
+        return self.add_set(path)
+
+    def set_dhcpv6_options_pd_interface_sla_id(self, interface: str, pd_id: str, pd_iface: str, sla_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Set DHCPv6 prefix delegation interface SLA ID"""
+        path = self.mappers[self.interface_mapper_key].get_dhcpv6_options_pd_interface_sla_id(interface, pd_id, pd_iface, sla_id)
+        return self.add_set(path)
+
+    def delete_dhcpv6_options(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete all DHCPv6 options"""
+        path = self.mappers[self.interface_mapper_key].get_dhcpv6_options_path(interface)
+        return self.add_delete(path)
+
+    # DHCPv6 1.5+ only
+    def set_dhcpv6_options_no_request_dns(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Disable DHCPv6 DNS request (1.5+ only)"""
+        path = self.mappers[self.interface_mapper_key].get_dhcpv6_options_no_request_dns(interface)
+        return self.add_set(path)
+
+    def set_dhcpv6_options_no_request_domain_name(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Disable DHCPv6 domain name request (1.5+ only)"""
+        path = self.mappers[self.interface_mapper_key].get_dhcpv6_options_no_request_domain_name(interface)
+        return self.add_set(path)
+
+    # ========================================================================
+    # IP (additional)
+    # ========================================================================
+
+    def set_ip_disable_forwarding(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Disable IP forwarding on interface"""
+        path = self.mappers[self.interface_mapper_key].get_ip_disable_forwarding(interface)
+        return self.add_set(path)
+
+    def delete_ip_disable_forwarding(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable IP forwarding on interface (remove disable flag)"""
+        path = self.mappers[self.interface_mapper_key].get_ip_disable_forwarding(interface)
+        return self.add_delete(path)
+
+    # ========================================================================
+    # IPv6 (additional)
+    # ========================================================================
+
+    def set_ipv6_accept_dad(self, interface: str, count: str) -> "EthernetInterfaceBuilderMixin":
+        """Set IPv6 accept DAD count"""
+        path = self.mappers[self.interface_mapper_key].get_ipv6_accept_dad(interface, count)
+        return self.add_set(path)
+
+    def set_ipv6_address_no_default_link_local(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Disable default link-local address"""
+        path = self.mappers[self.interface_mapper_key].get_ipv6_address_no_default_link_local(interface)
+        return self.add_set(path)
+
+    def delete_ipv6_address_no_default_link_local(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable default link-local address"""
+        path = self.mappers[self.interface_mapper_key].get_ipv6_address_no_default_link_local(interface)
+        return self.add_delete(path)
+
+    def set_ipv6_base_reachable_time(self, interface: str, time: str) -> "EthernetInterfaceBuilderMixin":
+        """Set IPv6 base reachable time"""
+        path = self.mappers[self.interface_mapper_key].get_ipv6_base_reachable_time(interface, time)
+        return self.add_set(path)
+
+    def set_ipv6_source_validation(self, interface: str, mode: str) -> "EthernetInterfaceBuilderMixin":
+        """Set IPv6 source validation mode"""
+        path = self.mappers[self.interface_mapper_key].get_ipv6_source_validation(interface, mode)
+        return self.add_set(path)
+
+    def delete_ipv6_source_validation(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete IPv6 source validation"""
+        path = self.mappers[self.interface_mapper_key].get_ipv6_source_validation_path(interface)
+        return self.add_delete(path)
+
+    # IPv6 1.5+ only
+    def set_ipv6_address_interface_identifier(self, interface: str, identifier: str) -> "EthernetInterfaceBuilderMixin":
+        """Set IPv6 address interface identifier (1.5+ only)"""
+        path = self.mappers[self.interface_mapper_key].get_ipv6_address_interface_identifier(interface, identifier)
+        return self.add_set(path)
+
+    # ========================================================================
+    # Offload (additional)
+    # ========================================================================
+
+    def set_offload_hw_tc_offload(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable hardware TC offload"""
+        path = self.mappers[self.interface_mapper_key].get_offload_hw_tc_offload(interface)
+        return self.add_set(path)
+
+    def delete_offload_hw_tc_offload(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete hardware TC offload"""
+        path = self.mappers[self.interface_mapper_key].get_offload_hw_tc_offload(interface)
+        return self.add_delete(path)
+
+    def set_offload_rfs(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable Receive Flow Steering"""
+        path = self.mappers[self.interface_mapper_key].get_offload_rfs(interface)
+        return self.add_set(path)
+
+    def delete_offload_rfs(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete Receive Flow Steering"""
+        path = self.mappers[self.interface_mapper_key].get_offload_rfs(interface)
+        return self.add_delete(path)
+
+    # ========================================================================
+    # Redirect Operations
+    # ========================================================================
+
+    def set_redirect(self, interface: str, target: str) -> "EthernetInterfaceBuilderMixin":
+        """Set interface redirect target"""
+        path = self.mappers[self.interface_mapper_key].get_redirect(interface, target)
+        return self.add_set(path)
+
+    def delete_redirect(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete interface redirect"""
+        path = self.mappers[self.interface_mapper_key].get_redirect_path(interface)
+        return self.add_delete(path)
+
+    # ========================================================================
+    # EAPoL (additional)
+    # ========================================================================
+
+    def set_eapol_passphrase(self, interface: str, passphrase: str) -> "EthernetInterfaceBuilderMixin":
+        """Set EAPoL passphrase"""
+        path = self.mappers[self.interface_mapper_key].get_eapol_passphrase(interface, passphrase)
+        return self.add_set(path)
+
+    def delete_eapol(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete EAPoL configuration"""
+        path = self.mappers[self.interface_mapper_key].get_eapol_path(interface)
+        return self.add_delete(path)
+
+    # ========================================================================
+    # Switchdev Operations (1.5+)
+    # ========================================================================
+
+    def set_switchdev(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable switchdev (1.5+ only)"""
+        path = self.mappers[self.interface_mapper_key].get_switchdev(interface)
+        return self.add_set(path)
+
+    def delete_switchdev(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete switchdev configuration (1.5+ only)"""
+        path = self.mappers[self.interface_mapper_key].get_switchdev(interface)
+        return self.add_delete(path)
+
+    # ========================================================================
+    # Interrupt Coalescing Operations (1.5+)
+    # ========================================================================
+
+    def set_interrupt_coalescing_adaptive_rx(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable adaptive RX interrupt coalescing"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_adaptive_rx(interface)
+        return self.add_set(path)
+
+    def delete_interrupt_coalescing_adaptive_rx(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete adaptive RX interrupt coalescing"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_adaptive_rx(interface)
+        return self.add_delete(path)
+
+    def set_interrupt_coalescing_adaptive_tx(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable adaptive TX interrupt coalescing"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_adaptive_tx(interface)
+        return self.add_set(path)
+
+    def delete_interrupt_coalescing_adaptive_tx(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete adaptive TX interrupt coalescing"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_adaptive_tx(interface)
+        return self.add_delete(path)
+
+    def set_interrupt_coalescing_cqe_mode_rx(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable CQE mode RX interrupt coalescing"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_cqe_mode_rx(interface)
+        return self.add_set(path)
+
+    def delete_interrupt_coalescing_cqe_mode_rx(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete CQE mode RX interrupt coalescing"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_cqe_mode_rx(interface)
+        return self.add_delete(path)
+
+    def set_interrupt_coalescing_cqe_mode_tx(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable CQE mode TX interrupt coalescing"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_cqe_mode_tx(interface)
+        return self.add_set(path)
+
+    def delete_interrupt_coalescing_cqe_mode_tx(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete CQE mode TX interrupt coalescing"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_cqe_mode_tx(interface)
+        return self.add_delete(path)
+
+    def set_interrupt_coalescing_rx_usecs(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set RX interrupt coalescing microseconds"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_rx_usecs(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_rx_frames(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set RX interrupt coalescing frames"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_rx_frames(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_tx_usecs(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set TX interrupt coalescing microseconds"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_tx_usecs(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_tx_frames(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set TX interrupt coalescing frames"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_tx_frames(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_rx_usecs_irq(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set RX interrupt coalescing microseconds IRQ"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_rx_usecs_irq(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_rx_usecs_low(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set RX interrupt coalescing microseconds low"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_rx_usecs_low(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_rx_usecs_high(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set RX interrupt coalescing microseconds high"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_rx_usecs_high(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_tx_usecs_irq(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set TX interrupt coalescing microseconds IRQ"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_tx_usecs_irq(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_tx_usecs_low(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set TX interrupt coalescing microseconds low"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_tx_usecs_low(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_tx_usecs_high(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set TX interrupt coalescing microseconds high"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_tx_usecs_high(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_rx_frames_irq(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set RX interrupt coalescing frames IRQ"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_rx_frames_irq(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_rx_frame_low(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set RX interrupt coalescing frame low"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_rx_frame_low(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_rx_frame_high(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set RX interrupt coalescing frame high"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_rx_frame_high(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_tx_frames_irq(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set TX interrupt coalescing frames IRQ"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_tx_frames_irq(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_tx_frame_low(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set TX interrupt coalescing frame low"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_tx_frame_low(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_tx_frame_high(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set TX interrupt coalescing frame high"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_tx_frame_high(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_pkt_rate_low(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set interrupt coalescing packet rate low"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_pkt_rate_low(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_pkt_rate_high(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set interrupt coalescing packet rate high"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_pkt_rate_high(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_sample_interval(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set interrupt coalescing sample interval"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_sample_interval(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_stats_block_usecs(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set interrupt coalescing stats block microseconds"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_stats_block_usecs(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_tx_aggr_max_bytes(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set TX aggregation max bytes"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_tx_aggr_max_bytes(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_tx_aggr_max_frames(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set TX aggregation max frames"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_tx_aggr_max_frames(interface, value)
+        return self.add_set(path)
+
+    def set_interrupt_coalescing_tx_aggr_time_usecs(self, interface: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set TX aggregation time microseconds"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_tx_aggr_time_usecs(interface, value)
+        return self.add_set(path)
+
+    def delete_interrupt_coalescing(self, interface: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete all interrupt coalescing settings"""
+        path = self.mappers[self.interface_mapper_key].get_interrupt_coalescing_path(interface)
+        return self.add_delete(path)
+
+    # ========================================================================
+    # VIF Additional Operations
+    # ========================================================================
+
+    def set_vif_egress_qos(self, interface: str, vlan_id: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set VIF egress QoS mapping"""
+        path = self.mappers[self.interface_mapper_key].get_vif_egress_qos(interface, vlan_id, value)
+        return self.add_set(path)
+
+    def delete_vif_egress_qos(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete VIF egress QoS mapping"""
+        path = self.mappers[self.interface_mapper_key].get_vif_egress_qos_path(interface, vlan_id)
+        return self.add_delete(path)
+
+    def set_vif_ingress_qos(self, interface: str, vlan_id: str, value: str) -> "EthernetInterfaceBuilderMixin":
+        """Set VIF ingress QoS mapping"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ingress_qos(interface, vlan_id, value)
+        return self.add_set(path)
+
+    def delete_vif_ingress_qos(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete VIF ingress QoS mapping"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ingress_qos_path(interface, vlan_id)
+        return self.add_delete(path)
+
+    def set_vif_redirect(self, interface: str, vlan_id: str, target: str) -> "EthernetInterfaceBuilderMixin":
+        """Set VIF redirect target"""
+        path = self.mappers[self.interface_mapper_key].get_vif_redirect(interface, vlan_id, target)
+        return self.add_set(path)
+
+    def delete_vif_redirect(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete VIF redirect"""
+        path = self.mappers[self.interface_mapper_key].get_vif_redirect_path(interface, vlan_id)
+        return self.add_delete(path)
+
+    def set_vif_ip_adjust_mss(self, interface: str, vlan_id: str, mss: str) -> "EthernetInterfaceBuilderMixin":
+        """Set VIF IPv4 TCP MSS"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ip_adjust_mss(interface, vlan_id, mss)
+        return self.add_set(path)
+
+    def set_vif_ip_disable_forwarding(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Disable IP forwarding on VIF"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ip_disable_forwarding(interface, vlan_id)
+        return self.add_set(path)
+
+    def set_vif_ip_source_validation(self, interface: str, vlan_id: str, mode: str) -> "EthernetInterfaceBuilderMixin":
+        """Set VIF IP source validation mode"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ip_source_validation(interface, vlan_id, mode)
+        return self.add_set(path)
+
+    def set_vif_ip_enable_proxy_arp(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable proxy ARP on VIF"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ip_enable_proxy_arp(interface, vlan_id)
+        return self.add_set(path)
+
+    def set_vif_ip_arp_cache_timeout(self, interface: str, vlan_id: str, timeout: str) -> "EthernetInterfaceBuilderMixin":
+        """Set VIF ARP cache timeout"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ip_arp_cache_timeout(interface, vlan_id, timeout)
+        return self.add_set(path)
+
+    def set_vif_mirror_ingress(self, interface: str, vlan_id: str, target: str) -> "EthernetInterfaceBuilderMixin":
+        """Set VIF ingress port mirroring"""
+        path = self.mappers[self.interface_mapper_key].get_vif_mirror_ingress(interface, vlan_id, target)
+        return self.add_set(path)
+
+    def set_vif_mirror_egress(self, interface: str, vlan_id: str, target: str) -> "EthernetInterfaceBuilderMixin":
+        """Set VIF egress port mirroring"""
+        path = self.mappers[self.interface_mapper_key].get_vif_mirror_egress(interface, vlan_id, target)
+        return self.add_set(path)
+
+    def delete_vif_mirror(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete VIF port mirroring"""
+        path = self.mappers[self.interface_mapper_key].get_vif_mirror_path(interface, vlan_id)
+        return self.add_delete(path)
+
+    def set_vif_ipv6_disable_forwarding(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Disable IPv6 forwarding on VIF"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ipv6_disable_forwarding(interface, vlan_id)
+        return self.add_set(path)
+
+    def set_vif_ipv6_adjust_mss(self, interface: str, vlan_id: str, mss: str) -> "EthernetInterfaceBuilderMixin":
+        """Set VIF IPv6 TCP MSS"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ipv6_adjust_mss(interface, vlan_id, mss)
+        return self.add_set(path)
+
+    def set_vif_ipv6_accept_dad(self, interface: str, vlan_id: str, count: str) -> "EthernetInterfaceBuilderMixin":
+        """Set VIF IPv6 accept DAD count"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ipv6_accept_dad(interface, vlan_id, count)
+        return self.add_set(path)
+
+    def set_vif_ipv6_dup_addr_detect_transmits(self, interface: str, vlan_id: str, count: str) -> "EthernetInterfaceBuilderMixin":
+        """Set VIF IPv6 DAD transmits"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ipv6_dup_addr_detect_transmits(interface, vlan_id, count)
+        return self.add_set(path)

--- a/backend/vyos_mappers/interfaces/ethernet.py
+++ b/backend/vyos_mappers/interfaces/ethernet.py
@@ -103,6 +103,18 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
         """Get command path for enabling TCP Segmentation Offload."""
         return ["interfaces", self.interface_type, interface, "offload", "tso"]
 
+    def get_offload_hw_tc_offload(self, interface: str) -> List[str]:
+        """Get command path for enabling hardware TC offload."""
+        return ["interfaces", self.interface_type, interface, "offload", "hw-tc-offload"]
+
+    def get_offload_rfs(self, interface: str) -> List[str]:
+        """Get command path for enabling Receive Flow Steering."""
+        return ["interfaces", self.interface_type, interface, "offload", "rfs"]
+
+    def get_offload_path(self, interface: str) -> List[str]:
+        """Get command path for offload settings (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "offload"]
+
     # Ring Buffer
     def get_ring_buffer_rx(self, interface: str, size: str) -> List[str]:
         """Get command path for setting RX ring buffer size."""
@@ -171,6 +183,14 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
         """Get command path for source validation (for deletion)."""
         return ["interfaces", self.interface_type, interface, "ip", "source-validation"]
 
+    def get_ip_disable_forwarding(self, interface: str) -> List[str]:
+        """Get command path for disabling IP forwarding."""
+        return ["interfaces", self.interface_type, interface, "ip", "disable-forwarding"]
+
+    def get_ip_path(self, interface: str) -> List[str]:
+        """Get command path for IP settings (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "ip"]
+
     # Directed Broadcast (1.5+)
     def get_ip_enable_directed_broadcast(self, interface: str) -> List[str]:
         """Get command path for enabling directed broadcast."""
@@ -192,6 +212,30 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
     def get_ipv6_dup_addr_detect_transmits(self, interface: str, count: str) -> List[str]:
         """Get command path for IPv6 DAD transmits."""
         return ["interfaces", self.interface_type, interface, "ipv6", "dup-addr-detect-transmits", count]
+
+    def get_ipv6_accept_dad(self, interface: str, count: str) -> List[str]:
+        """Get command path for IPv6 accept DAD."""
+        return ["interfaces", self.interface_type, interface, "ipv6", "accept-dad", count]
+
+    def get_ipv6_address_no_default_link_local(self, interface: str) -> List[str]:
+        """Get command path for IPv6 no default link-local address."""
+        return ["interfaces", self.interface_type, interface, "ipv6", "address", "no-default-link-local"]
+
+    def get_ipv6_base_reachable_time(self, interface: str, time: str) -> List[str]:
+        """Get command path for IPv6 base reachable time."""
+        return ["interfaces", self.interface_type, interface, "ipv6", "base-reachable-time", time]
+
+    def get_ipv6_source_validation(self, interface: str, mode: str) -> List[str]:
+        """Get command path for IPv6 source validation."""
+        return ["interfaces", self.interface_type, interface, "ipv6", "source-validation", mode]
+
+    def get_ipv6_source_validation_path(self, interface: str) -> List[str]:
+        """Get command path for IPv6 source validation (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "ipv6", "source-validation"]
+
+    def get_ipv6_path(self, interface: str) -> List[str]:
+        """Get command path for IPv6 settings (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "ipv6"]
 
     # Flow Control
     def get_disable_flow_control(self, interface: str) -> List[str]:
@@ -224,6 +268,22 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
         """Get command path for DHCP default route distance."""
         return ["interfaces", self.interface_type, interface, "dhcp-options", "default-route-distance", distance]
 
+    def get_dhcp_options_reject(self, interface: str, server: str) -> List[str]:
+        """Get command path for DHCP reject server."""
+        return ["interfaces", self.interface_type, interface, "dhcp-options", "reject", server]
+
+    def get_dhcp_options_user_class(self, interface: str, user_class: str) -> List[str]:
+        """Get command path for DHCP user class."""
+        return ["interfaces", self.interface_type, interface, "dhcp-options", "user-class", user_class]
+
+    def get_dhcp_options_mtu(self, interface: str) -> List[str]:
+        """Get command path for DHCP MTU option."""
+        return ["interfaces", self.interface_type, interface, "dhcp-options", "mtu"]
+
+    def get_dhcp_options_path(self, interface: str) -> List[str]:
+        """Get command path for DHCP options (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "dhcp-options"]
+
     # DHCPv6 Options
     def get_dhcpv6_options_duid(self, interface: str, duid: str) -> List[str]:
         """Get command path for DHCPv6 DUID."""
@@ -236,6 +296,38 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
     def get_dhcpv6_options_pd(self, interface: str, pd_id: str, prefix: str) -> List[str]:
         """Get command path for DHCPv6 prefix delegation."""
         return ["interfaces", self.interface_type, interface, "dhcpv6-options", "pd", pd_id, "length", prefix]
+
+    def get_dhcpv6_options_no_release(self, interface: str) -> List[str]:
+        """Get command path for DHCPv6 no-release."""
+        return ["interfaces", self.interface_type, interface, "dhcpv6-options", "no-release"]
+
+    def get_dhcpv6_options_parameters_only(self, interface: str) -> List[str]:
+        """Get command path for DHCPv6 parameters-only."""
+        return ["interfaces", self.interface_type, interface, "dhcpv6-options", "parameters-only"]
+
+    def get_dhcpv6_options_temporary(self, interface: str) -> List[str]:
+        """Get command path for DHCPv6 temporary address."""
+        return ["interfaces", self.interface_type, interface, "dhcpv6-options", "temporary"]
+
+    def get_dhcpv6_options_pd_length(self, interface: str, pd_id: str, length: str) -> List[str]:
+        """Get command path for DHCPv6 PD length."""
+        return ["interfaces", self.interface_type, interface, "dhcpv6-options", "pd", pd_id, "length", length]
+
+    def get_dhcpv6_options_pd_interface(self, interface: str, pd_id: str, pd_iface: str) -> List[str]:
+        """Get command path for DHCPv6 PD interface."""
+        return ["interfaces", self.interface_type, interface, "dhcpv6-options", "pd", pd_id, "interface", pd_iface]
+
+    def get_dhcpv6_options_pd_interface_address(self, interface: str, pd_id: str, pd_iface: str, address: str) -> List[str]:
+        """Get command path for DHCPv6 PD interface address."""
+        return ["interfaces", self.interface_type, interface, "dhcpv6-options", "pd", pd_id, "interface", pd_iface, "address", address]
+
+    def get_dhcpv6_options_pd_interface_sla_id(self, interface: str, pd_id: str, pd_iface: str, sla_id: str) -> List[str]:
+        """Get command path for DHCPv6 PD interface SLA ID."""
+        return ["interfaces", self.interface_type, interface, "dhcpv6-options", "pd", pd_id, "interface", pd_iface, "sla-id", sla_id]
+
+    def get_dhcpv6_options_path(self, interface: str) -> List[str]:
+        """Get command path for DHCPv6 options (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "dhcpv6-options"]
 
     # VLANs - Basic VLAN creation
     def get_vif(self, interface: str, vlan_id: str) -> List[str]:
@@ -450,6 +542,229 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
         """Get command path for EVPN settings (for deletion)."""
         return ["interfaces", self.interface_type, interface, "evpn"]
 
+    # Redirect
+    def get_redirect(self, interface: str, target: str) -> List[str]:
+        """Get command path for interface redirect."""
+        return ["interfaces", self.interface_type, interface, "redirect", target]
+
+    def get_redirect_path(self, interface: str) -> List[str]:
+        """Get command path for redirect (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "redirect"]
+
+    # EAPoL - Passphrase
+    def get_eapol_passphrase(self, interface: str, passphrase: str) -> List[str]:
+        """Get command path for EAPoL passphrase."""
+        return ["interfaces", self.interface_type, interface, "eapol", "passphrase", passphrase]
+
+    def get_eapol_path(self, interface: str) -> List[str]:
+        """Get command path for EAPoL settings (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "eapol"]
+
+    # VyOS 1.5 Only - Interrupt Coalescing
+    def get_interrupt_coalescing_adaptive_rx(self, interface: str) -> List[str]:
+        """Get command path for interrupt coalescing adaptive RX."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "adaptive-rx"]
+
+    def get_interrupt_coalescing_adaptive_tx(self, interface: str) -> List[str]:
+        """Get command path for interrupt coalescing adaptive TX."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "adaptive-tx"]
+
+    def get_interrupt_coalescing_cqe_mode_rx(self, interface: str) -> List[str]:
+        """Get command path for interrupt coalescing CQE mode RX."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "cqe-mode-rx"]
+
+    def get_interrupt_coalescing_cqe_mode_tx(self, interface: str) -> List[str]:
+        """Get command path for interrupt coalescing CQE mode TX."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "cqe-mode-tx"]
+
+    def get_interrupt_coalescing_rx_usecs(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing RX usecs."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "rx-usecs", value]
+
+    def get_interrupt_coalescing_rx_frames(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing RX frames."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "rx-frames", value]
+
+    def get_interrupt_coalescing_tx_usecs(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing TX usecs."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "tx-usecs", value]
+
+    def get_interrupt_coalescing_tx_frames(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing TX frames."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "tx-frames", value]
+
+    def get_interrupt_coalescing_rx_usecs_irq(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing RX usecs IRQ."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "rx-usecs-irq", value]
+
+    def get_interrupt_coalescing_rx_usecs_low(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing RX usecs low."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "rx-usecs-low", value]
+
+    def get_interrupt_coalescing_rx_usecs_high(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing RX usecs high."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "rx-usecs-high", value]
+
+    def get_interrupt_coalescing_tx_usecs_irq(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing TX usecs IRQ."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "tx-usecs-irq", value]
+
+    def get_interrupt_coalescing_tx_usecs_low(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing TX usecs low."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "tx-usecs-low", value]
+
+    def get_interrupt_coalescing_tx_usecs_high(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing TX usecs high."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "tx-usecs-high", value]
+
+    def get_interrupt_coalescing_rx_frames_irq(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing RX frames IRQ."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "rx-frames-irq", value]
+
+    def get_interrupt_coalescing_rx_frame_low(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing RX frame low."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "rx-frame-low", value]
+
+    def get_interrupt_coalescing_rx_frame_high(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing RX frame high."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "rx-frame-high", value]
+
+    def get_interrupt_coalescing_tx_frames_irq(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing TX frames IRQ."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "tx-frames-irq", value]
+
+    def get_interrupt_coalescing_tx_frame_low(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing TX frame low."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "tx-frame-low", value]
+
+    def get_interrupt_coalescing_tx_frame_high(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing TX frame high."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "tx-frame-high", value]
+
+    def get_interrupt_coalescing_pkt_rate_low(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing packet rate low."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "pkt-rate-low", value]
+
+    def get_interrupt_coalescing_pkt_rate_high(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing packet rate high."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "pkt-rate-high", value]
+
+    def get_interrupt_coalescing_sample_interval(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing sample interval."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "sample-interval", value]
+
+    def get_interrupt_coalescing_stats_block_usecs(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing stats block usecs."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "stats-block-usecs", value]
+
+    def get_interrupt_coalescing_tx_aggr_max_bytes(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing TX aggregation max bytes."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "tx-aggr-max-bytes", value]
+
+    def get_interrupt_coalescing_tx_aggr_max_frames(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing TX aggregation max frames."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "tx-aggr-max-frames", value]
+
+    def get_interrupt_coalescing_tx_aggr_time_usecs(self, interface: str, value: str) -> List[str]:
+        """Get command path for interrupt coalescing TX aggregation time usecs."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing", "tx-aggr-time-usecs", value]
+
+    def get_interrupt_coalescing_path(self, interface: str) -> List[str]:
+        """Get command path for interrupt coalescing (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "interrupt-coalescing"]
+
+    # VyOS 1.5 Only - DHCPv6
+    def get_dhcpv6_options_no_request_dns(self, interface: str) -> List[str]:
+        """Get command path for DHCPv6 no-request-dns (1.5+)."""
+        return ["interfaces", self.interface_type, interface, "dhcpv6-options", "no-request-dns"]
+
+    def get_dhcpv6_options_no_request_domain_name(self, interface: str) -> List[str]:
+        """Get command path for DHCPv6 no-request-domain-name (1.5+)."""
+        return ["interfaces", self.interface_type, interface, "dhcpv6-options", "no-request-domain-name"]
+
+    # VyOS 1.5 Only - IPv6 interface-identifier
+    def get_ipv6_address_interface_identifier(self, interface: str, identifier: str) -> List[str]:
+        """Get command path for IPv6 interface identifier (1.5+)."""
+        return ["interfaces", self.interface_type, interface, "ipv6", "address", "interface-identifier", identifier]
+
+    # VyOS 1.5 Only - Switchdev
+    def get_switchdev(self, interface: str) -> List[str]:
+        """Get command path for switchdev (1.5+)."""
+        return ["interfaces", self.interface_type, interface, "switchdev"]
+
+    # VIF - Additional methods
+    def get_vif_egress_qos(self, interface: str, vlan_id: str, value: str) -> List[str]:
+        """Get command path for VIF egress QoS."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "egress-qos", value]
+
+    def get_vif_egress_qos_path(self, interface: str, vlan_id: str) -> List[str]:
+        """Get command path for VIF egress QoS (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "egress-qos"]
+
+    def get_vif_ingress_qos(self, interface: str, vlan_id: str, value: str) -> List[str]:
+        """Get command path for VIF ingress QoS."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ingress-qos", value]
+
+    def get_vif_ingress_qos_path(self, interface: str, vlan_id: str) -> List[str]:
+        """Get command path for VIF ingress QoS (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ingress-qos"]
+
+    def get_vif_redirect(self, interface: str, vlan_id: str, target: str) -> List[str]:
+        """Get command path for VIF redirect."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "redirect", target]
+
+    def get_vif_redirect_path(self, interface: str, vlan_id: str) -> List[str]:
+        """Get command path for VIF redirect (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "redirect"]
+
+    def get_vif_ip_adjust_mss(self, interface: str, vlan_id: str, mss: str) -> List[str]:
+        """Get command path for VIF IPv4 TCP MSS."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ip", "adjust-mss", mss]
+
+    def get_vif_ip_disable_forwarding(self, interface: str, vlan_id: str) -> List[str]:
+        """Get command path for VIF IP disable forwarding."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ip", "disable-forwarding"]
+
+    def get_vif_ip_source_validation(self, interface: str, vlan_id: str, mode: str) -> List[str]:
+        """Get command path for VIF IP source validation."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ip", "source-validation", mode]
+
+    def get_vif_ip_enable_proxy_arp(self, interface: str, vlan_id: str) -> List[str]:
+        """Get command path for VIF IP proxy ARP."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ip", "enable-proxy-arp"]
+
+    def get_vif_ip_arp_cache_timeout(self, interface: str, vlan_id: str, timeout: str) -> List[str]:
+        """Get command path for VIF IP ARP cache timeout."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ip", "arp-cache-timeout", timeout]
+
+    def get_vif_mirror_ingress(self, interface: str, vlan_id: str, target: str) -> List[str]:
+        """Get command path for VIF mirror ingress."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "mirror", "ingress", target]
+
+    def get_vif_mirror_egress(self, interface: str, vlan_id: str, target: str) -> List[str]:
+        """Get command path for VIF mirror egress."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "mirror", "egress", target]
+
+    def get_vif_mirror_path(self, interface: str, vlan_id: str) -> List[str]:
+        """Get command path for VIF mirror (for deletion)."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "mirror"]
+
+    def get_vif_ipv6_disable_forwarding(self, interface: str, vlan_id: str) -> List[str]:
+        """Get command path for VIF IPv6 disable forwarding."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ipv6", "disable-forwarding"]
+
+    def get_vif_ipv6_adjust_mss(self, interface: str, vlan_id: str, mss: str) -> List[str]:
+        """Get command path for VIF IPv6 TCP MSS."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ipv6", "adjust-mss", mss]
+
+    def get_vif_ipv6_accept_dad(self, interface: str, vlan_id: str, count: str) -> List[str]:
+        """Get command path for VIF IPv6 accept DAD."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ipv6", "accept-dad", count]
+
+    def get_vif_ipv6_dup_addr_detect_transmits(self, interface: str, vlan_id: str, count: str) -> List[str]:
+        """Get command path for VIF IPv6 DAD transmits."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ipv6", "dup-addr-detect-transmits", count]
+
     # ========================================================================
     # Config Parsing Methods (for READ operations)
     # ========================================================================
@@ -502,6 +817,9 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
             "mirror": self._parse_mirror(config),
             "eapol": self._parse_eapol(config),
             "evpn": self._parse_evpn(config),
+            "redirect": config.get("redirect"),
+            "interrupt_coalescing": self._parse_interrupt_coalescing(config),
+            "switchdev": "switchdev" in config,
         }
 
     # ========================================================================
@@ -534,6 +852,8 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
             "rps": flag("rps"),
             "sg": flag("sg"),
             "tso": flag("tso"),
+            "hw_tc_offload": flag("hw-tc-offload"),
+            "rfs": flag("rfs"),
         }
 
     def _parse_ring_buffer(self, config: Dict[str, Any]) -> Dict[str, Any]:
@@ -567,6 +887,7 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
             "enable_proxy_arp": "enable-proxy-arp" in ip_config,
             "proxy_arp_pvlan": "proxy-arp-pvlan" in ip_config,
             "source_validation": ip_config.get("source-validation"),
+            "disable_forwarding": "disable-forwarding" in ip_config,
             # v1.5+ features - included in base for normalization
             # Override in v1.4 to exclude or set to None
             "enable_directed_broadcast": "enable-directed-broadcast" in ip_config,
@@ -598,6 +919,10 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
             "adjust_mss": ipv6_config.get("adjust-mss"),
             "disable_forwarding": "disable-forwarding" in ipv6_config,
             "dup_addr_detect_transmits": ipv6_config.get("dup-addr-detect-transmits"),
+            "accept_dad": ipv6_config.get("accept-dad"),
+            "no_default_link_local": "no-default-link-local" in ipv6_config.get("address", {}),
+            "base_reachable_time": ipv6_config.get("base-reachable-time"),
+            "source_validation": ipv6_config.get("source-validation"),
         }
 
     def _parse_dhcp_options(self, config: Dict[str, Any]) -> Dict[str, Any]:
@@ -611,6 +936,9 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
             "vendor_class_id": dhcp_options.get("vendor-class-id"),
             "no_default_route": "no-default-route" in dhcp_options,
             "default_route_distance": dhcp_options.get("default-route-distance"),
+            "reject": dhcp_options.get("reject"),
+            "user_class": dhcp_options.get("user-class"),
+            "mtu": "mtu" in dhcp_options,
         }
 
     def _parse_dhcpv6_options(self, config: Dict[str, Any]) -> Dict[str, Any]:
@@ -622,6 +950,9 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
             "duid": dhcpv6_options.get("duid"),
             "rapid_commit": "rapid-commit" in dhcpv6_options,
             "pd": dhcpv6_options.get("pd"),
+            "no_release": "no-release" in dhcpv6_options,
+            "parameters_only": "parameters-only" in dhcpv6_options,
+            "temporary": "temporary" in dhcpv6_options,
         }
 
     def _parse_vif(self, config: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -723,6 +1054,42 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
             "ca_cert_file": eapol.get("ca-cert-file"),
             "cert_file": eapol.get("cert-file"),
             "key_file": eapol.get("key-file"),
+            "passphrase": eapol.get("passphrase"),
+        }
+
+    def _parse_interrupt_coalescing(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        """Parse interrupt coalescing settings (1.5+)."""
+        ic = config.get("interrupt-coalescing", {})
+        if not ic:
+            return None
+        return {
+            "adaptive_rx": "adaptive-rx" in ic,
+            "adaptive_tx": "adaptive-tx" in ic,
+            "cqe_mode_rx": "cqe-mode-rx" in ic,
+            "cqe_mode_tx": "cqe-mode-tx" in ic,
+            "rx_usecs": ic.get("rx-usecs"),
+            "rx_frames": ic.get("rx-frames"),
+            "tx_usecs": ic.get("tx-usecs"),
+            "tx_frames": ic.get("tx-frames"),
+            "rx_usecs_irq": ic.get("rx-usecs-irq"),
+            "rx_usecs_low": ic.get("rx-usecs-low"),
+            "rx_usecs_high": ic.get("rx-usecs-high"),
+            "tx_usecs_irq": ic.get("tx-usecs-irq"),
+            "tx_usecs_low": ic.get("tx-usecs-low"),
+            "tx_usecs_high": ic.get("tx-usecs-high"),
+            "rx_frames_irq": ic.get("rx-frames-irq"),
+            "rx_frame_low": ic.get("rx-frame-low"),
+            "rx_frame_high": ic.get("rx-frame-high"),
+            "tx_frames_irq": ic.get("tx-frames-irq"),
+            "tx_frame_low": ic.get("tx-frame-low"),
+            "tx_frame_high": ic.get("tx-frame-high"),
+            "pkt_rate_low": ic.get("pkt-rate-low"),
+            "pkt_rate_high": ic.get("pkt-rate-high"),
+            "sample_interval": ic.get("sample-interval"),
+            "stats_block_usecs": ic.get("stats-block-usecs"),
+            "tx_aggr_max_bytes": ic.get("tx-aggr-max-bytes"),
+            "tx_aggr_max_frames": ic.get("tx-aggr-max-frames"),
+            "tx_aggr_time_usecs": ic.get("tx-aggr-time-usecs"),
         }
 
     def _parse_evpn(self, config: Dict[str, Any]) -> Dict[str, Any]:

--- a/backend/vyos_mappers/interfaces/ethernet_versions/v1_4.py
+++ b/backend/vyos_mappers/interfaces/ethernet_versions/v1_4.py
@@ -32,9 +32,34 @@ class EthernetMapper_v1_4(EthernetInterfaceMapper):
             f"Current device is running v1.4"
         )
 
+    def get_interrupt_coalescing_adaptive_rx(self, interface: str) -> List[str]:
+        raise ValueError("interrupt-coalescing requires VyOS 1.5+. Current device is running v1.4")
+
+    def get_interrupt_coalescing_adaptive_tx(self, interface: str) -> List[str]:
+        raise ValueError("interrupt-coalescing requires VyOS 1.5+. Current device is running v1.4")
+
+    # (Don't need to override every single interrupt-coalescing method -
+    # the builder will check capabilities before calling these)
+
+    def get_dhcpv6_options_no_request_dns(self, interface: str) -> List[str]:
+        raise ValueError("dhcpv6 no-request-dns requires VyOS 1.5+. Current device is running v1.4")
+
+    def get_dhcpv6_options_no_request_domain_name(self, interface: str) -> List[str]:
+        raise ValueError("dhcpv6 no-request-domain-name requires VyOS 1.5+. Current device is running v1.4")
+
+    def get_ipv6_address_interface_identifier(self, interface: str, identifier: str) -> List[str]:
+        raise ValueError("ipv6 interface-identifier requires VyOS 1.5+. Current device is running v1.4")
+
+    def get_switchdev(self, interface: str) -> List[str]:
+        raise ValueError("switchdev requires VyOS 1.5+. Current device is running v1.4")
+
     # ========================================================================
     # Parsing Overrides - Normalize unavailable features
     # ========================================================================
+
+    def _parse_interrupt_coalescing(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        """Interrupt coalescing not available in v1.4."""
+        return None
 
     def _parse_ip_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -57,6 +82,7 @@ class EthernetMapper_v1_4(EthernetInterfaceMapper):
             "enable_arp_ignore": "enable-arp-ignore" in ip_config,
             "enable_proxy_arp": "enable-proxy-arp" in ip_config,
             "proxy_arp_pvlan": "proxy-arp-pvlan" in ip_config,
+            "disable_forwarding": "disable-forwarding" in ip_config,
             "source_validation": ip_config.get("source-validation"),
             # v1.5+ features - NOT available in 1.4, always None for normalization
             "enable_directed_broadcast": None,  # Feature not available in 1.4

--- a/frontend/src/app/network/interfaces/page.tsx
+++ b/frontend/src/app/network/interfaces/page.tsx
@@ -24,6 +24,8 @@ import { ComprehensiveEthernetModal } from "@/components/network/ComprehensiveEt
 import { ComprehensiveVLANModal } from "@/components/network/ComprehensiveVLANModal";
 import { DeleteEthernetModal } from "@/components/network/DeleteEthernetModal";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { usePermissions } from "@/hooks/usePermissions";
+import { FeatureGroup } from "@/lib/api/user-management";
 
 type InterfaceType = "ethernet" | "vlan";
 
@@ -49,6 +51,8 @@ export default function InterfacesPage() {
   // VLAN Modal states
   const [isCreateVLANModalOpen, setIsCreateVLANModalOpen] = useState(false);
   const [editingVLAN, setEditingVLAN] = useState<VLANWithParent | null>(null);
+
+  const { canWrite } = usePermissions();
 
   const loadData = async () => {
     try {
@@ -268,6 +272,7 @@ export default function InterfacesPage() {
                     setIsCreateInterfaceModalOpen(true);
                   }
                 }}
+                disabled={!canWrite(FeatureGroup.INTERFACES)}
               >
                 <Plus className="h-4 w-4" />
                 {selectedType === "ethernet" ? "Create Interface" : "Create VLAN"}
@@ -330,6 +335,7 @@ export default function InterfacesPage() {
                       <TableHeader>
                         <TableRow>
                           <TableHead>Name</TableHead>
+                          <TableHead>Status</TableHead>
                           <TableHead>Description</TableHead>
                           <TableHead>Addresses</TableHead>
                           <TableHead>VRF</TableHead>
@@ -347,6 +353,11 @@ export default function InterfacesPage() {
                                 <code className="font-semibold font-mono text-foreground">
                                   {iface.name}
                                 </code>
+                              </TableCell>
+                              <TableCell>
+                                <Badge variant={iface.disable ? "secondary" : "default"} className="text-xs">
+                                  {iface.disable ? "Disabled" : "Enabled"}
+                                </Badge>
                               </TableCell>
                               <TableCell className="text-muted-foreground max-w-[200px] truncate">
                                 {iface.description || "—"}
@@ -406,6 +417,7 @@ export default function InterfacesPage() {
                                     size="sm"
                                     onClick={() => setEditingInterface(iface)}
                                     className="h-7 w-7 p-0"
+                                    disabled={!canWrite(FeatureGroup.INTERFACES)}
                                   >
                                     <Pencil className="h-3.5 w-3.5" />
                                   </Button>
@@ -414,6 +426,7 @@ export default function InterfacesPage() {
                                     size="sm"
                                     onClick={() => setDeletingInterface(iface)}
                                     className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                                    disabled={!canWrite(FeatureGroup.INTERFACES)}
                                   >
                                     <Trash2 className="h-3.5 w-3.5" />
                                   </Button>
@@ -530,6 +543,7 @@ export default function InterfacesPage() {
                                   size="sm"
                                   onClick={() => setEditingVLAN(vlan)}
                                   className="h-7 w-7 p-0"
+                                  disabled={!canWrite(FeatureGroup.INTERFACES)}
                                 >
                                   <Pencil className="h-3.5 w-3.5" />
                                 </Button>
@@ -540,6 +554,7 @@ export default function InterfacesPage() {
                                     // TODO: Implement VLAN delete
                                   }}
                                   className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                                  disabled={!canWrite(FeatureGroup.INTERFACES)}
                                 >
                                   <Trash2 className="h-3.5 w-3.5" />
                                 </Button>

--- a/frontend/src/app/network/interfaces/page.tsx
+++ b/frontend/src/app/network/interfaces/page.tsx
@@ -5,15 +5,27 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Plus, RefreshCw, AlertCircle, Search, Cable, Pencil, Trash2, Network } from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Plus, RefreshCw, AlertCircle, Search, Cable, Pencil, Trash2, Network, ChevronRight } from "lucide-react";
 import { useState, useEffect } from "react";
+import { cn } from "@/lib/utils";
 import { ethernetService } from "@/lib/api/ethernet";
 import type { EthernetInterface, EthernetCapabilities, VIFConfig } from "@/lib/api/types/ethernet";
 import { ComprehensiveEthernetModal } from "@/components/network/ComprehensiveEthernetModal";
 import { ComprehensiveVLANModal } from "@/components/network/ComprehensiveVLANModal";
 import { DeleteEthernetModal } from "@/components/network/DeleteEthernetModal";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
 
-type InterfaceType = "all" | "ethernet" | "vlan";
+type InterfaceType = "ethernet" | "vlan";
 
 // VLAN with parent interface info
 interface VLANWithParent extends VIFConfig {
@@ -25,10 +37,9 @@ export default function InterfacesPage() {
   const [interfaces, setInterfaces] = useState<EthernetInterface[]>([]);
   const [capabilities, setCapabilities] = useState<EthernetCapabilities | null>(null);
   const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
-  const [typeFilter, setTypeFilter] = useState<InterfaceType>("all");
+  const [selectedType, setSelectedType] = useState<InterfaceType>("ethernet");
 
   // Ethernet Modal states
   const [isCreateInterfaceModalOpen, setIsCreateInterfaceModalOpen] = useState(false);
@@ -42,7 +53,6 @@ export default function InterfacesPage() {
   const loadData = async () => {
     try {
       setError(null);
-      setRefreshing(true);
       const [configData, capabilitiesData] = await Promise.all([
         ethernetService.getConfig(),
         ethernetService.getCapabilities(),
@@ -53,7 +63,6 @@ export default function InterfacesPage() {
       setError(err instanceof Error ? err.message : "Failed to load interface data");
     } finally {
       setLoading(false);
-      setRefreshing(false);
     }
   };
 
@@ -65,7 +74,6 @@ export default function InterfacesPage() {
   const allVlans: VLANWithParent[] = interfaces.flatMap((iface) => {
     const vlans: VLANWithParent[] = [];
 
-    // Add VIFs (802.1q)
     if (iface.vif) {
       iface.vif.forEach((vif) => {
         vlans.push({
@@ -76,7 +84,6 @@ export default function InterfacesPage() {
       });
     }
 
-    // Add VIF-S (QinQ) if needed in the future
     if (iface.vif_s) {
       iface.vif_s.forEach((vifs) => {
         vlans.push({
@@ -90,398 +97,467 @@ export default function InterfacesPage() {
     return vlans;
   });
 
-  // Calculate statistics
   const totalInterfaces = interfaces.length;
   const totalVlans = allVlans.length;
 
-  // Filter interfaces based on type
+  // Filter interfaces based on search
   const filteredInterfaces = interfaces.filter((iface) => {
-    if (typeFilter === "vlan") return false; // Don't show interfaces when VLANs are selected
-
-    const matchesType = typeFilter === "all" || iface.type === typeFilter;
-    const matchesSearch =
-      searchQuery === "" ||
-      iface.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      iface.description?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      iface.addresses?.some((addr) => addr.toLowerCase().includes(searchQuery.toLowerCase())) ||
-      iface.vrf?.toLowerCase().includes(searchQuery.toLowerCase());
-
-    return matchesType && matchesSearch;
+    if (searchQuery === "") return true;
+    const q = searchQuery.toLowerCase();
+    return (
+      iface.name.toLowerCase().includes(q) ||
+      iface.description?.toLowerCase().includes(q) ||
+      iface.addresses?.some((addr) => addr.toLowerCase().includes(q)) ||
+      iface.vrf?.toLowerCase().includes(q) ||
+      iface.hw_id?.toLowerCase().includes(q)
+    );
   });
 
-  // Filter VLANs
+  // Filter VLANs based on search
   const filteredVlans = allVlans.filter((vlan) => {
-    if (typeFilter !== "vlan" && typeFilter !== "all") return false; // Only show VLANs when selected or in "all" mode
-
+    if (searchQuery === "") return true;
+    const q = searchQuery.toLowerCase();
     return (
-      searchQuery === "" ||
-      vlan.fullName.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      vlan.parentInterface.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      vlan.description?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      vlan.addresses?.some((addr) => addr.toLowerCase().includes(searchQuery.toLowerCase())) ||
-      vlan.vrf?.toLowerCase().includes(searchQuery.toLowerCase())
+      vlan.fullName.toLowerCase().includes(q) ||
+      vlan.parentInterface.toLowerCase().includes(q) ||
+      vlan.description?.toLowerCase().includes(q) ||
+      vlan.addresses?.some((addr) => addr.toLowerCase().includes(q)) ||
+      vlan.vrf?.toLowerCase().includes(q)
     );
   });
-
-  if (loading) {
-    return (
-      <AppLayout>
-        <div className="flex items-center justify-center h-96">
-          <RefreshCw className="h-8 w-8 animate-spin text-muted-foreground" />
-        </div>
-      </AppLayout>
-    );
-  }
 
   return (
     <AppLayout>
-      <div className="space-y-6 p-6">
-        {/* Header */}
-        <div className="flex items-start justify-between">
-          <div>
-            <h1 className="text-3xl font-bold text-foreground">Network Interfaces</h1>
-            <p className="text-muted-foreground mt-1">
-              Manage and monitor network interface configurations
-            </p>
-          </div>
-        </div>
-
-        {/* Stats Dashboard */}
-        <div className="grid grid-cols-3 gap-4">
-          <Card className="border-border">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-                  <Network className="h-5 w-5 text-primary" />
-                </div>
-                <div>
-                  <p className="text-2xl font-bold text-foreground">{totalInterfaces}</p>
-                  <p className="text-xs text-muted-foreground">Total Interfaces</p>
-                </div>
+      <div className="flex h-full">
+        {/* Left Sidebar - Interface Type Selector */}
+        <div className="w-80 border-r border-border bg-card flex flex-col h-full">
+          <div className="p-6 pb-4">
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h2 className="text-lg font-semibold text-foreground">Interfaces</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  {totalInterfaces + totalVlans} total
+                </p>
               </div>
-            </CardContent>
-          </Card>
-
-          <Card className="border-border">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10">
-                  <Cable className="h-5 w-5 text-blue-500" />
-                </div>
-                <div>
-                  <p className="text-2xl font-bold text-foreground">{totalInterfaces}</p>
-                  <p className="text-xs text-muted-foreground">Ethernet</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card className="border-border">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-500/10">
-                  <Network className="h-5 w-5 text-purple-500" />
-                </div>
-                <div>
-                  <p className="text-2xl font-bold text-foreground">{totalVlans}</p>
-                  <p className="text-xs text-muted-foreground">VLANs</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Error Alert */}
-        {error && (
-          <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-4 flex items-start gap-3">
-            <AlertCircle className="h-5 w-5 text-destructive mt-0.5" />
-            <div className="flex-1">
-              <h3 className="font-semibold text-destructive">Failed to load interfaces</h3>
-              <p className="text-sm text-destructive/90 mt-1">{error}</p>
-              <Button variant="outline" size="sm" onClick={loadData} className="mt-3">
-                <RefreshCw className="h-3.5 w-3.5 mr-2" />
-                Try Again
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={loadData}
+                disabled={loading}
+                className="h-8 w-8"
+              >
+                <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
               </Button>
             </div>
           </div>
-        )}
 
-        {/* Filters and Actions */}
-        {!error && (
-          <div className="flex items-center justify-between gap-4">
-            <div className="relative flex-1">
+          <Separator />
+
+          {/* Interface Type List */}
+          <ScrollArea className="flex-1 px-3">
+            {loading ? (
+              <div className="flex items-center justify-center py-12">
+                <LoadingSpinner message="" size="sm" />
+              </div>
+            ) : error ? (
+              <div className="p-4">
+                <div className="flex items-center gap-2 text-destructive text-sm">
+                  <AlertCircle className="h-4 w-4" />
+                  <span>Failed to load</span>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-1 py-3">
+                {/* Ethernet */}
+                <button
+                  onClick={() => setSelectedType("ethernet")}
+                  className={cn(
+                    "w-full text-left rounded-lg px-3 py-3 transition-all",
+                    selectedType === "ethernet"
+                      ? "bg-accent text-accent-foreground shadow-sm"
+                      : "hover:bg-accent/50"
+                  )}
+                >
+                  <div className="flex items-start gap-3">
+                    <div className={cn(
+                      "mt-0.5 rounded-md p-1.5",
+                      selectedType === "ethernet" ? "bg-primary/10" : "bg-muted"
+                    )}>
+                      <Cable className={cn(
+                        "h-4 w-4",
+                        selectedType === "ethernet" ? "text-primary" : "text-muted-foreground"
+                      )} />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between gap-2 mb-1">
+                        <span className="font-medium text-sm text-foreground">
+                          Ethernet
+                        </span>
+                        {selectedType === "ethernet" && (
+                          <ChevronRight className="h-4 w-4 text-primary flex-shrink-0" />
+                        )}
+                      </div>
+                      <span className="text-xs text-muted-foreground">
+                        {totalInterfaces} {totalInterfaces === 1 ? "interface" : "interfaces"}
+                      </span>
+                    </div>
+                  </div>
+                </button>
+
+                {/* VLAN */}
+                <button
+                  onClick={() => setSelectedType("vlan")}
+                  className={cn(
+                    "w-full text-left rounded-lg px-3 py-3 transition-all",
+                    selectedType === "vlan"
+                      ? "bg-accent text-accent-foreground shadow-sm"
+                      : "hover:bg-accent/50"
+                  )}
+                >
+                  <div className="flex items-start gap-3">
+                    <div className={cn(
+                      "mt-0.5 rounded-md p-1.5",
+                      selectedType === "vlan" ? "bg-primary/10" : "bg-muted"
+                    )}>
+                      <Network className={cn(
+                        "h-4 w-4",
+                        selectedType === "vlan" ? "text-primary" : "text-muted-foreground"
+                      )} />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between gap-2 mb-1">
+                        <span className="font-medium text-sm text-foreground">
+                          VLAN
+                        </span>
+                        {selectedType === "vlan" && (
+                          <ChevronRight className="h-4 w-4 text-primary flex-shrink-0" />
+                        )}
+                      </div>
+                      <span className="text-xs text-muted-foreground">
+                        {totalVlans} {totalVlans === 1 ? "VLAN" : "VLANs"}
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              </div>
+            )}
+          </ScrollArea>
+        </div>
+
+        {/* Main Content */}
+        <div className="flex-1 flex flex-col">
+          {/* Header */}
+          <div className="p-6 pb-4 border-b border-border">
+            <div className="flex items-start justify-between mb-4">
+              <div className="flex-1">
+                <h1 className="text-2xl font-bold text-foreground">
+                  {selectedType === "ethernet" ? "Ethernet Interfaces" : "VLANs"}
+                </h1>
+                <p className="text-sm text-muted-foreground mt-2">
+                  {selectedType === "ethernet"
+                    ? "Physical and virtual ethernet interface configurations"
+                    : "802.1Q VLAN sub-interfaces"}
+                </p>
+              </div>
+              <Button
+                className="gap-2"
+                onClick={() => {
+                  if (selectedType === "vlan") {
+                    setIsCreateVLANModalOpen(true);
+                  } else {
+                    setIsCreateInterfaceModalOpen(true);
+                  }
+                }}
+              >
+                <Plus className="h-4 w-4" />
+                {selectedType === "ethernet" ? "Create Interface" : "Create VLAN"}
+              </Button>
+            </div>
+
+            {/* Search */}
+            <div className="relative">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input
-                placeholder="Search by name, description, IP address, or VRF..."
+                placeholder={
+                  selectedType === "ethernet"
+                    ? "Search by name, description, IP address, VRF, or MAC..."
+                    : "Search by name, parent, description, IP address, or VRF..."
+                }
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 className="pl-10"
               />
             </div>
-
-            <div className="flex gap-2">
-              <Button
-                variant={typeFilter === "all" ? "default" : "outline"}
-                size="sm"
-                onClick={() => setTypeFilter("all")}
-              >
-                All ({totalInterfaces + totalVlans})
-              </Button>
-              <Button
-                variant={typeFilter === "ethernet" ? "default" : "outline"}
-                size="sm"
-                onClick={() => setTypeFilter("ethernet")}
-              >
-                Ethernet ({totalInterfaces})
-              </Button>
-              <Button
-                variant={typeFilter === "vlan" ? "default" : "outline"}
-                size="sm"
-                onClick={() => setTypeFilter("vlan")}
-              >
-                VLAN ({totalVlans})
-              </Button>
-            </div>
-
-            <Button
-              onClick={() => {
-                if (typeFilter === "vlan") {
-                  setIsCreateVLANModalOpen(true);
-                } else {
-                  setIsCreateInterfaceModalOpen(true);
-                }
-              }}
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              Create {typeFilter === "vlan" ? "VLAN" : "Interface"}
-            </Button>
           </div>
-        )}
 
-        {/* Interface Cards */}
-        {!error && (
-          <div className="space-y-4 mt-6">
-            {/* Ethernet Interfaces */}
-            {(typeFilter === "all" || typeFilter === "ethernet") && filteredInterfaces.length > 0 && (
-              <div className="space-y-3">
-                {typeFilter === "all" && (
-                  <h2 className="text-lg font-semibold text-foreground">Ethernet Interfaces</h2>
-                )}
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {filteredInterfaces.map((iface) => {
-                    const vlanCount = (iface.vif?.length || 0) + (iface.vif_s?.length || 0);
-                    return (
-                      <Card key={iface.name} className="border-border hover:border-primary/50 transition-colors group">
-                        <CardContent className="p-4">
-                          <div className="flex items-start justify-between mb-3">
-                            <div className="flex items-center gap-2">
-                              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-500/10">
-                                <Cable className="h-4 w-4 text-blue-500" />
-                              </div>
-                              <div>
-                                <code className="font-semibold font-mono text-foreground text-base">
+          {/* Table Content */}
+          <div className="flex-1 overflow-auto p-6">
+            {loading ? (
+              <div className="flex items-center justify-center py-12">
+                <LoadingSpinner message="Loading interfaces..." size="sm" />
+              </div>
+            ) : error ? (
+              <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-4 flex items-start gap-3">
+                <AlertCircle className="h-5 w-5 text-destructive mt-0.5" />
+                <div className="flex-1">
+                  <h3 className="font-semibold text-destructive">Failed to load interfaces</h3>
+                  <p className="text-sm text-destructive/90 mt-1">{error}</p>
+                  <Button variant="outline" size="sm" onClick={loadData} className="mt-3">
+                    <RefreshCw className="h-3.5 w-3.5 mr-2" />
+                    Try Again
+                  </Button>
+                </div>
+              </div>
+            ) : selectedType === "ethernet" ? (
+              /* Ethernet Table */
+              filteredInterfaces.length === 0 ? (
+                <Card className="border-border">
+                  <CardContent className="py-12">
+                    <div className="flex flex-col items-center gap-2">
+                      <Cable className="h-12 w-12 text-muted-foreground/30" />
+                      <p className="text-muted-foreground">
+                        {searchQuery
+                          ? "No ethernet interfaces matching your search"
+                          : "No ethernet interfaces configured"}
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+              ) : (
+                <>
+                  <div className="rounded-md border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Name</TableHead>
+                          <TableHead>Description</TableHead>
+                          <TableHead>Addresses</TableHead>
+                          <TableHead>VRF</TableHead>
+                          <TableHead>MAC / HW ID</TableHead>
+                          <TableHead>VLANs</TableHead>
+                          <TableHead className="w-[80px]"></TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {filteredInterfaces.map((iface) => {
+                          const vlanCount = (iface.vif?.length || 0) + (iface.vif_s?.length || 0);
+                          return (
+                            <TableRow key={iface.name}>
+                              <TableCell>
+                                <code className="font-semibold font-mono text-foreground">
                                   {iface.name}
                                 </code>
-                                {vlanCount > 0 && (
-                                  <div className="text-xs text-muted-foreground mt-0.5">
-                                    {vlanCount} VLAN(s)
+                              </TableCell>
+                              <TableCell className="text-muted-foreground max-w-[200px] truncate">
+                                {iface.description || "—"}
+                              </TableCell>
+                              <TableCell>
+                                {iface.addresses && iface.addresses.length > 0 ? (
+                                  <div className="flex flex-wrap gap-1">
+                                    {iface.addresses.slice(0, 2).map((addr, idx) => (
+                                      <code
+                                        key={idx}
+                                        className="text-xs font-mono px-1.5 py-0.5 rounded bg-accent text-foreground"
+                                      >
+                                        {addr}
+                                      </code>
+                                    ))}
+                                    {iface.addresses.length > 2 && (
+                                      <Badge variant="secondary" className="text-xs px-1.5 py-0">
+                                        +{iface.addresses.length - 2}
+                                      </Badge>
+                                    )}
                                   </div>
+                                ) : (
+                                  <span className="text-muted-foreground">—</span>
                                 )}
-                              </div>
-                            </div>
-                            <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setEditingInterface(iface)}
-                                className="h-7 w-7 p-0"
-                              >
-                                <Pencil className="h-3.5 w-3.5" />
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setDeletingInterface(iface)}
-                                className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                              >
-                                <Trash2 className="h-3.5 w-3.5" />
-                              </Button>
-                            </div>
-                          </div>
-
-                          <div className="space-y-2 text-sm">
-                            {iface.description && (
-                              <div className="text-muted-foreground truncate">
-                                {iface.description}
-                              </div>
-                            )}
-
-                            {iface.addresses && iface.addresses.length > 0 && (
-                              <div className="flex flex-wrap gap-1.5">
-                                {iface.addresses.slice(0, 2).map((addr, idx) => (
-                                  <code
-                                    key={idx}
-                                    className="text-xs font-mono px-1.5 py-0.5 rounded bg-accent text-foreground"
-                                  >
-                                    {addr}
-                                  </code>
-                                ))}
-                                {iface.addresses.length > 2 && (
-                                  <Badge variant="secondary" className="text-xs px-1.5 py-0">
-                                    +{iface.addresses.length - 2}
+                              </TableCell>
+                              <TableCell>
+                                {iface.vrf ? (
+                                  <Badge variant="outline" className="bg-purple-500/10 text-purple-500 border-purple-500/20 text-xs">
+                                    {iface.vrf}
                                   </Badge>
+                                ) : (
+                                  <span className="text-muted-foreground">—</span>
                                 )}
-                              </div>
-                            )}
-
-                            <div className="flex flex-wrap gap-2 pt-1">
-                              {iface.vrf && (
-                                <Badge variant="outline" className="bg-purple-500/10 text-purple-500 border-purple-500/20 text-xs">
-                                  VRF: {iface.vrf}
-                                </Badge>
-                              )}
-                              {iface.hw_id && (
-                                <code className="text-xs font-mono text-muted-foreground">
-                                  {iface.hw_id}
-                                </code>
-                              )}
-                            </div>
-                          </div>
-                        </CardContent>
-                      </Card>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-
-            {/* VLANs */}
-            {(typeFilter === "all" || typeFilter === "vlan") && filteredVlans.length > 0 && (
-              <div className="space-y-3">
-                {typeFilter === "all" && (
-                  <h2 className="text-lg font-semibold text-foreground">VLANs</h2>
-                )}
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {filteredVlans.map((vlan) => (
-                    <Card key={vlan.fullName} className="border-border hover:border-primary/50 transition-colors group">
-                      <CardContent className="p-4">
-                        <div className="flex items-start justify-between mb-3">
-                          <div className="flex items-center gap-2">
-                            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-purple-500/10">
-                              <Network className="h-4 w-4 text-purple-500" />
-                            </div>
-                            <div>
-                              <code className="font-semibold font-mono text-foreground text-base">
+                              </TableCell>
+                              <TableCell>
+                                {iface.hw_id ? (
+                                  <code className="text-xs font-mono text-muted-foreground">
+                                    {iface.hw_id}
+                                  </code>
+                                ) : (
+                                  <span className="text-muted-foreground">—</span>
+                                )}
+                              </TableCell>
+                              <TableCell>
+                                {vlanCount > 0 ? (
+                                  <Badge variant="secondary" className="text-xs">
+                                    {vlanCount}
+                                  </Badge>
+                                ) : (
+                                  <span className="text-muted-foreground">0</span>
+                                )}
+                              </TableCell>
+                              <TableCell>
+                                <div className="flex gap-1 justify-end">
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => setEditingInterface(iface)}
+                                    className="h-7 w-7 p-0"
+                                  >
+                                    <Pencil className="h-3.5 w-3.5" />
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => setDeletingInterface(iface)}
+                                    className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                                  >
+                                    <Trash2 className="h-3.5 w-3.5" />
+                                  </Button>
+                                </div>
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </div>
+                  <p className="text-sm text-muted-foreground text-center mt-3">
+                    Showing {filteredInterfaces.length} of {totalInterfaces} interface{totalInterfaces !== 1 ? "s" : ""}
+                  </p>
+                </>
+              )
+            ) : (
+              /* VLAN Table */
+              filteredVlans.length === 0 ? (
+                <Card className="border-border">
+                  <CardContent className="py-12">
+                    <div className="flex flex-col items-center gap-2">
+                      <Network className="h-12 w-12 text-muted-foreground/30" />
+                      <p className="text-muted-foreground">
+                        {searchQuery
+                          ? "No VLANs matching your search"
+                          : "No VLANs configured"}
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+              ) : (
+                <>
+                  <div className="rounded-md border">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Name</TableHead>
+                          <TableHead>VLAN ID</TableHead>
+                          <TableHead>Parent</TableHead>
+                          <TableHead>Description</TableHead>
+                          <TableHead>Addresses</TableHead>
+                          <TableHead>VRF</TableHead>
+                          <TableHead>Status</TableHead>
+                          <TableHead className="w-[80px]"></TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {filteredVlans.map((vlan) => (
+                          <TableRow key={vlan.fullName}>
+                            <TableCell>
+                              <code className="font-semibold font-mono text-foreground">
                                 {vlan.fullName}
                               </code>
-                              <div className="text-xs text-muted-foreground mt-0.5">
-                                Parent: {vlan.parentInterface}
-                              </div>
-                            </div>
-                          </div>
-                          <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => setEditingVLAN(vlan)}
-                              className="h-7 w-7 p-0"
-                            >
-                              <Pencil className="h-3.5 w-3.5" />
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => {
-                                // TODO: Implement VLAN delete
-                              }}
-                              className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                            >
-                              <Trash2 className="h-3.5 w-3.5" />
-                            </Button>
-                          </div>
-                        </div>
-
-                        <div className="space-y-2 text-sm">
-                          {vlan.description && (
-                            <div className="text-muted-foreground truncate">
-                              {vlan.description}
-                            </div>
-                          )}
-
-                          {vlan.addresses && vlan.addresses.length > 0 && (
-                            <div className="flex flex-wrap gap-1.5">
-                              {vlan.addresses.slice(0, 2).map((addr, idx) => (
-                                <code
-                                  key={idx}
-                                  className="text-xs font-mono px-1.5 py-0.5 rounded bg-accent text-foreground"
-                                >
-                                  {addr}
-                                </code>
-                              ))}
-                              {vlan.addresses.length > 2 && (
-                                <Badge variant="secondary" className="text-xs px-1.5 py-0">
-                                  +{vlan.addresses.length - 2}
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant="outline" className="bg-purple-500/10 text-purple-500 border-purple-500/20 text-xs">
+                                {vlan.vlan_id}
+                              </Badge>
+                            </TableCell>
+                            <TableCell>
+                              <code className="text-xs font-mono text-muted-foreground">
+                                {vlan.parentInterface}
+                              </code>
+                            </TableCell>
+                            <TableCell className="text-muted-foreground max-w-[200px] truncate">
+                              {vlan.description || "—"}
+                            </TableCell>
+                            <TableCell>
+                              {vlan.addresses && vlan.addresses.length > 0 ? (
+                                <div className="flex flex-wrap gap-1">
+                                  {vlan.addresses.slice(0, 2).map((addr, idx) => (
+                                    <code
+                                      key={idx}
+                                      className="text-xs font-mono px-1.5 py-0.5 rounded bg-accent text-foreground"
+                                    >
+                                      {addr}
+                                    </code>
+                                  ))}
+                                  {vlan.addresses.length > 2 && (
+                                    <Badge variant="secondary" className="text-xs px-1.5 py-0">
+                                      +{vlan.addresses.length - 2}
+                                    </Badge>
+                                  )}
+                                </div>
+                              ) : (
+                                <span className="text-muted-foreground">—</span>
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              {vlan.vrf ? (
+                                <Badge variant="outline" className="bg-purple-500/10 text-purple-500 border-purple-500/20 text-xs">
+                                  {vlan.vrf}
+                                </Badge>
+                              ) : (
+                                <span className="text-muted-foreground">—</span>
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              {vlan.disable ? (
+                                <Badge variant="outline" className="bg-red-500/10 text-red-500 border-red-500/20 text-xs">
+                                  Disabled
+                                </Badge>
+                              ) : (
+                                <Badge variant="outline" className="bg-green-500/10 text-green-500 border-green-500/20 text-xs">
+                                  Enabled
                                 </Badge>
                               )}
-                            </div>
-                          )}
-
-                          <div className="flex flex-wrap gap-2 pt-1">
-                            <Badge
-                              variant="outline"
-                              className="bg-purple-500/10 text-purple-500 border-purple-500/20 text-xs"
-                            >
-                              VLAN {vlan.vlan_id}
-                            </Badge>
-                            {vlan.vrf && (
-                              <Badge variant="outline" className="bg-purple-500/10 text-purple-500 border-purple-500/20 text-xs">
-                                VRF: {vlan.vrf}
-                              </Badge>
-                            )}
-                            {vlan.disable ? (
-                              <Badge variant="outline" className="bg-red-500/10 text-red-500 border-red-500/20 text-xs">
-                                Disabled
-                              </Badge>
-                            ) : (
-                              <Badge variant="outline" className="bg-green-500/10 text-green-500 border-green-500/20 text-xs">
-                                Enabled
-                              </Badge>
-                            )}
-                          </div>
-                        </div>
-                      </CardContent>
-                    </Card>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Empty state */}
-            {filteredInterfaces.length === 0 && filteredVlans.length === 0 && (
-              <Card className="border-border">
-                <CardContent className="py-12">
-                  <div className="flex flex-col items-center gap-2">
-                    <Network className="h-12 w-12 text-muted-foreground/30" />
-                    <p className="text-muted-foreground">
-                      {searchQuery
-                        ? "No interfaces or VLANs found matching your search"
-                        : typeFilter === "vlan"
-                        ? "No VLANs configured"
-                        : "No interfaces configured"}
-                    </p>
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex gap-1 justify-end">
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setEditingVLAN(vlan)}
+                                  className="h-7 w-7 p-0"
+                                >
+                                  <Pencil className="h-3.5 w-3.5" />
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => {
+                                    // TODO: Implement VLAN delete
+                                  }}
+                                  className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                                >
+                                  <Trash2 className="h-3.5 w-3.5" />
+                                </Button>
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
                   </div>
-                </CardContent>
-              </Card>
-            )}
-
-            {/* Count */}
-            {(filteredInterfaces.length > 0 || filteredVlans.length > 0) && (
-              <p className="text-sm text-muted-foreground text-center">
-                Showing {filteredInterfaces.length + filteredVlans.length} of {totalInterfaces + totalVlans} item{totalInterfaces + totalVlans !== 1 ? "s" : ""}
-              </p>
+                  <p className="text-sm text-muted-foreground text-center mt-3">
+                    Showing {filteredVlans.length} of {totalVlans} VLAN{totalVlans !== 1 ? "s" : ""}
+                  </p>
+                </>
+              )
             )}
           </div>
-        )}
+        </div>
       </div>
 
       {/* Ethernet Modals */}

--- a/frontend/src/components/network/ComprehensiveEthernetModal.tsx
+++ b/frontend/src/components/network/ComprehensiveEthernetModal.tsx
@@ -23,7 +23,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ethernetService } from "@/lib/api/ethernet";
 import type { EthernetInterface, EthernetCapabilities, BatchOperation } from "@/lib/api/types/ethernet";
-import { Loader2, X } from "lucide-react";
+import { Loader2, X, AlertCircle } from "lucide-react";
 
 interface ComprehensiveEthernetModalProps {
   open: boolean;
@@ -65,6 +65,8 @@ export function ComprehensiveEthernetModal({
   const [offloadRps, setOffloadRps] = useState("");
   const [offloadSg, setOffloadSg] = useState("");
   const [offloadTso, setOffloadTso] = useState("");
+  const [offloadHwTcOffload, setOffloadHwTcOffload] = useState("");
+  const [offloadRfs, setOffloadRfs] = useState("");
 
   // Ring buffer
   const [ringBufferRx, setRingBufferRx] = useState("");
@@ -88,12 +90,17 @@ export function ComprehensiveEthernetModal({
   // IP settings
   const [ipSourceValidation, setIpSourceValidation] = useState("");
   const [ipEnableDirectedBroadcast, setIpEnableDirectedBroadcast] = useState(false);
+  const [ipDisableForwarding, setIpDisableForwarding] = useState(false);
 
   // IPv6 settings
   const [ipv6Autoconf, setIpv6Autoconf] = useState(false);
   const [ipv6Eui64, setIpv6Eui64] = useState("");
   const [ipv6DisableForwarding, setIpv6DisableForwarding] = useState(false);
   const [ipv6DupAddrDetectTransmits, setIpv6DupAddrDetectTransmits] = useState("");
+  const [ipv6AcceptDad, setIpv6AcceptDad] = useState("");
+  const [ipv6NoDefaultLinkLocal, setIpv6NoDefaultLinkLocal] = useState(false);
+  const [ipv6BaseReachableTime, setIpv6BaseReachableTime] = useState("");
+  const [ipv6SourceValidation, setIpv6SourceValidation] = useState("");
 
   // Flow and Link
   const [disableFlowControl, setDisableFlowControl] = useState(false);
@@ -105,10 +112,16 @@ export function ComprehensiveEthernetModal({
   const [dhcpVendorClassId, setDhcpVendorClassId] = useState("");
   const [dhcpNoDefaultRoute, setDhcpNoDefaultRoute] = useState(false);
   const [dhcpDefaultRouteDistance, setDhcpDefaultRouteDistance] = useState("");
+  const [dhcpReject, setDhcpReject] = useState("");
+  const [dhcpUserClass, setDhcpUserClass] = useState("");
+  const [dhcpMtu, setDhcpMtu] = useState(false);
 
   // DHCPv6 options
   const [dhcpv6Duid, setDhcpv6Duid] = useState("");
   const [dhcpv6RapidCommit, setDhcpv6RapidCommit] = useState(false);
+  const [dhcpv6NoRelease, setDhcpv6NoRelease] = useState(false);
+  const [dhcpv6ParametersOnly, setDhcpv6ParametersOnly] = useState(false);
+  const [dhcpv6Temporary, setDhcpv6Temporary] = useState(false);
 
   // Port mirroring
   const [mirrorIngress, setMirrorIngress] = useState("");
@@ -118,9 +131,26 @@ export function ComprehensiveEthernetModal({
   const [eapolCaCertFile, setEapolCaCertFile] = useState("");
   const [eapolCertFile, setEapolCertFile] = useState("");
   const [eapolKeyFile, setEapolKeyFile] = useState("");
+  const [eapolPassphrase, setEapolPassphrase] = useState("");
 
   // EVPN
   const [evpnUplink, setEvpnUplink] = useState(false);
+
+  // Redirect
+  const [redirect, setRedirect] = useState("");
+
+  // Switchdev
+  const [switchdev, setSwitchdev] = useState(false);
+
+  // Interrupt Coalescing
+  const [icAdaptiveRx, setIcAdaptiveRx] = useState(false);
+  const [icAdaptiveTx, setIcAdaptiveTx] = useState(false);
+  const [icCqeModeRx, setIcCqeModeRx] = useState(false);
+  const [icCqeModeTx, setIcCqeModeTx] = useState(false);
+  const [icRxUsecs, setIcRxUsecs] = useState("");
+  const [icRxFrames, setIcRxFrames] = useState("");
+  const [icTxUsecs, setIcTxUsecs] = useState("");
+  const [icTxFrames, setIcTxFrames] = useState("");
 
   // Initialize form with interface data
   useEffect(() => {
@@ -145,6 +175,8 @@ export function ComprehensiveEthernetModal({
         setOffloadRps(iface.offload.rps || "");
         setOffloadSg(iface.offload.sg || "");
         setOffloadTso(iface.offload.tso || "");
+        setOffloadHwTcOffload(iface.offload.hw_tc_offload || "");
+        setOffloadRfs(iface.offload.rfs || "");
       }
 
       // Ring buffer
@@ -165,6 +197,7 @@ export function ComprehensiveEthernetModal({
         setArpProxyArpPvlan(iface.ip.proxy_arp_pvlan || false);
         setIpSourceValidation(iface.ip.source_validation || "");
         setIpEnableDirectedBroadcast(iface.ip.enable_directed_broadcast || false);
+        setIpDisableForwarding(iface.ip.disable_forwarding || false);
       }
 
       // IPv6 settings
@@ -172,6 +205,10 @@ export function ComprehensiveEthernetModal({
         setIpv6AdjustMss(iface.ipv6.adjust_mss || "");
         setIpv6DisableForwarding(iface.ipv6.disable_forwarding || false);
         setIpv6DupAddrDetectTransmits(iface.ipv6.dup_addr_detect_transmits || "");
+        setIpv6AcceptDad(iface.ipv6.accept_dad || "");
+        setIpv6NoDefaultLinkLocal(iface.ipv6.no_default_link_local || false);
+        setIpv6BaseReachableTime(iface.ipv6.base_reachable_time || "");
+        setIpv6SourceValidation(iface.ipv6.source_validation || "");
       }
 
       // DHCP options
@@ -181,12 +218,19 @@ export function ComprehensiveEthernetModal({
         setDhcpVendorClassId(iface.dhcp_options.vendor_class_id || "");
         setDhcpNoDefaultRoute(iface.dhcp_options.no_default_route || false);
         setDhcpDefaultRouteDistance(iface.dhcp_options.default_route_distance || "");
+        const reject = iface.dhcp_options.reject;
+        setDhcpReject(Array.isArray(reject) ? reject.join(", ") : reject || "");
+        setDhcpUserClass(iface.dhcp_options.user_class || "");
+        setDhcpMtu(iface.dhcp_options.mtu || false);
       }
 
       // DHCPv6 options
       if (iface.dhcpv6_options) {
         setDhcpv6Duid(iface.dhcpv6_options.duid || "");
         setDhcpv6RapidCommit(iface.dhcpv6_options.rapid_commit || false);
+        setDhcpv6NoRelease(iface.dhcpv6_options.no_release || false);
+        setDhcpv6ParametersOnly(iface.dhcpv6_options.parameters_only || false);
+        setDhcpv6Temporary(iface.dhcpv6_options.temporary || false);
       }
 
       // Port mirroring
@@ -200,11 +244,30 @@ export function ComprehensiveEthernetModal({
         setEapolCaCertFile(iface.eapol.ca_cert_file || "");
         setEapolCertFile(iface.eapol.cert_file || "");
         setEapolKeyFile(iface.eapol.key_file || "");
+        setEapolPassphrase(iface.eapol.passphrase || "");
       }
 
       // EVPN
       if (iface.evpn) {
         setEvpnUplink(iface.evpn.uplink || false);
+      }
+
+      // Redirect
+      setRedirect(iface.redirect || "");
+
+      // Switchdev
+      setSwitchdev(iface.switchdev || false);
+
+      // Interrupt Coalescing
+      if (iface.interrupt_coalescing) {
+        setIcAdaptiveRx(iface.interrupt_coalescing.adaptive_rx || false);
+        setIcAdaptiveTx(iface.interrupt_coalescing.adaptive_tx || false);
+        setIcCqeModeRx(iface.interrupt_coalescing.cqe_mode_rx || false);
+        setIcCqeModeTx(iface.interrupt_coalescing.cqe_mode_tx || false);
+        setIcRxUsecs(iface.interrupt_coalescing.rx_usecs || "");
+        setIcRxFrames(iface.interrupt_coalescing.rx_frames || "");
+        setIcTxUsecs(iface.interrupt_coalescing.tx_usecs || "");
+        setIcTxFrames(iface.interrupt_coalescing.tx_frames || "");
       }
     } else {
       resetForm();
@@ -228,6 +291,8 @@ export function ComprehensiveEthernetModal({
     setOffloadRps("");
     setOffloadSg("");
     setOffloadTso("");
+    setOffloadHwTcOffload("");
+    setOffloadRfs("");
     setRingBufferRx("");
     setRingBufferTx("");
     setIpAdjustMss("");
@@ -243,10 +308,15 @@ export function ComprehensiveEthernetModal({
     setArpProxyArpPvlan(false);
     setIpSourceValidation("");
     setIpEnableDirectedBroadcast(false);
+    setIpDisableForwarding(false);
     setIpv6Autoconf(false);
     setIpv6Eui64("");
     setIpv6DisableForwarding(false);
     setIpv6DupAddrDetectTransmits("");
+    setIpv6AcceptDad("");
+    setIpv6NoDefaultLinkLocal(false);
+    setIpv6BaseReachableTime("");
+    setIpv6SourceValidation("");
     setDisableFlowControl(false);
     setDisableLinkDetect(false);
     setDhcpClientId("");
@@ -254,14 +324,31 @@ export function ComprehensiveEthernetModal({
     setDhcpVendorClassId("");
     setDhcpNoDefaultRoute(false);
     setDhcpDefaultRouteDistance("");
+    setDhcpReject("");
+    setDhcpUserClass("");
+    setDhcpMtu(false);
     setDhcpv6Duid("");
     setDhcpv6RapidCommit(false);
+    setDhcpv6NoRelease(false);
+    setDhcpv6ParametersOnly(false);
+    setDhcpv6Temporary(false);
     setMirrorIngress("");
     setMirrorEgress("");
     setEapolCaCertFile("");
     setEapolCertFile("");
     setEapolKeyFile("");
+    setEapolPassphrase("");
     setEvpnUplink(false);
+    setRedirect("");
+    setSwitchdev(false);
+    setIcAdaptiveRx(false);
+    setIcAdaptiveTx(false);
+    setIcCqeModeRx(false);
+    setIcCqeModeTx(false);
+    setIcRxUsecs("");
+    setIcRxFrames("");
+    setIcTxUsecs("");
+    setIcTxFrames("");
     setError(null);
   };
 
@@ -311,6 +398,22 @@ export function ComprehensiveEthernetModal({
       }
     };
 
+    // Helper for boolean toggle operations
+    const addBooleanToggle = (
+      currentValue: boolean | undefined | null,
+      newValue: boolean,
+      setOp: string,
+      deleteOp: string
+    ) => {
+      if (mode === "create") {
+        if (newValue) operations.push({ op: setOp });
+      } else if (mode === "edit") {
+        if (newValue !== (currentValue || false)) {
+          operations.push({ op: newValue ? setOp : deleteOp });
+        }
+      }
+    };
+
     // Basic settings
     addIfChanged(iface?.description, description, "set_description", "delete_description");
     addIfChanged(iface?.mtu, mtu, "set_mtu", "delete_mtu");
@@ -351,12 +454,10 @@ export function ComprehensiveEthernetModal({
         const newValue = newVal.trim();
 
         if (mode === "create") {
-          // Only set if explicitly "on"
           if (newValue === "on") {
             operations.push({ op: setOp });
           }
         } else if (mode === "edit") {
-          // Only add operation if value changed
           if (currentValue !== newValue) {
             if (newValue === "on") {
               operations.push({ op: setOp });
@@ -373,6 +474,8 @@ export function ComprehensiveEthernetModal({
       handleOffloadSetting(iface?.offload?.rps, offloadRps, "set_offload_rps", "delete_offload_rps");
       handleOffloadSetting(iface?.offload?.sg, offloadSg, "set_offload_sg", "delete_offload_sg");
       handleOffloadSetting(iface?.offload?.tso, offloadTso, "set_offload_tso", "delete_offload_tso");
+      handleOffloadSetting(iface?.offload?.hw_tc_offload, offloadHwTcOffload, "set_offload_hw_tc_offload", "delete_offload_hw_tc_offload");
+      handleOffloadSetting(iface?.offload?.rfs, offloadRfs, "set_offload_rfs", "delete_offload_rfs");
     }
 
     // Ring buffer
@@ -424,6 +527,7 @@ export function ComprehensiveEthernetModal({
       if (ipEnableDirectedBroadcast !== (iface?.ip?.enable_directed_broadcast || false)) {
         operations.push({ op: "set_ip_enable_directed_broadcast", value: ipEnableDirectedBroadcast ? "true" : "false" });
       }
+      addBooleanToggle(iface?.ip?.disable_forwarding, ipDisableForwarding, "set_ip_disable_forwarding", "delete_ip_disable_forwarding");
     }
 
     // IPv6 settings
@@ -436,6 +540,10 @@ export function ComprehensiveEthernetModal({
         operations.push({ op: "set_ipv6_disable_forwarding", value: ipv6DisableForwarding ? "true" : "false" });
       }
       addIfChanged(iface?.ipv6?.dup_addr_detect_transmits, ipv6DupAddrDetectTransmits, "set_ipv6_dup_addr_detect_transmits");
+      addIfChanged(iface?.ipv6?.accept_dad, ipv6AcceptDad, "set_ipv6_accept_dad");
+      addBooleanToggle(iface?.ipv6?.no_default_link_local, ipv6NoDefaultLinkLocal, "set_ipv6_address_no_default_link_local", "delete_ipv6_address_no_default_link_local");
+      addIfChanged(iface?.ipv6?.base_reachable_time, ipv6BaseReachableTime, "set_ipv6_base_reachable_time");
+      addIfChanged(iface?.ipv6?.source_validation, ipv6SourceValidation, "set_ipv6_source_validation", "delete_ipv6_source_validation");
     }
 
     // Flow and Link
@@ -455,6 +563,13 @@ export function ComprehensiveEthernetModal({
         operations.push({ op: "set_dhcp_options_no_default_route", value: dhcpNoDefaultRoute ? "true" : "false" });
       }
       addIfChanged(iface?.dhcp_options?.default_route_distance, dhcpDefaultRouteDistance, "set_dhcp_options_default_route_distance");
+      addIfChanged(
+        Array.isArray(iface?.dhcp_options?.reject) ? iface.dhcp_options.reject.join(", ") : (iface?.dhcp_options?.reject || ""),
+        dhcpReject,
+        "set_dhcp_options_reject"
+      );
+      addIfChanged(iface?.dhcp_options?.user_class, dhcpUserClass, "set_dhcp_options_user_class");
+      addBooleanToggle(iface?.dhcp_options?.mtu, dhcpMtu, "set_dhcp_options_mtu", "delete_dhcp_options");
     }
 
     // DHCPv6 options
@@ -463,6 +578,9 @@ export function ComprehensiveEthernetModal({
       if (dhcpv6RapidCommit !== (iface?.dhcpv6_options?.rapid_commit || false)) {
         operations.push({ op: "set_dhcpv6_options_rapid_commit", value: dhcpv6RapidCommit ? "true" : "false" });
       }
+      addBooleanToggle(iface?.dhcpv6_options?.no_release, dhcpv6NoRelease, "set_dhcpv6_options_no_release", "delete_dhcpv6_options");
+      addBooleanToggle(iface?.dhcpv6_options?.parameters_only, dhcpv6ParametersOnly, "set_dhcpv6_options_parameters_only", "delete_dhcpv6_options");
+      addBooleanToggle(iface?.dhcpv6_options?.temporary, dhcpv6Temporary, "set_dhcpv6_options_temporary", "delete_dhcpv6_options");
     }
 
     // Port mirroring
@@ -476,6 +594,7 @@ export function ComprehensiveEthernetModal({
       addIfChanged(iface?.eapol?.ca_cert_file, eapolCaCertFile, "set_eapol_ca_cert_file");
       addIfChanged(iface?.eapol?.cert_file, eapolCertFile, "set_eapol_cert_file");
       addIfChanged(iface?.eapol?.key_file, eapolKeyFile, "set_eapol_key_file");
+      addIfChanged(iface?.eapol?.passphrase, eapolPassphrase, "set_eapol_passphrase");
     }
 
     // EVPN
@@ -483,6 +602,28 @@ export function ComprehensiveEthernetModal({
       if (evpnUplink !== (iface?.evpn?.uplink || false)) {
         operations.push({ op: evpnUplink ? "set_evpn_uplink" : "delete_evpn" });
       }
+    }
+
+    // Redirect
+    if (capabilities?.features.redirect) {
+      addIfChanged(iface?.redirect, redirect, "set_redirect", "delete_redirect");
+    }
+
+    // Switchdev
+    if (capabilities?.features.switchdev?.supported) {
+      addBooleanToggle(iface?.switchdev, switchdev, "set_switchdev", "delete_switchdev");
+    }
+
+    // Interrupt Coalescing
+    if (capabilities?.features.interrupt_coalescing?.supported) {
+      addBooleanToggle(iface?.interrupt_coalescing?.adaptive_rx, icAdaptiveRx, "set_interrupt_coalescing_adaptive_rx", "delete_interrupt_coalescing_adaptive_rx");
+      addBooleanToggle(iface?.interrupt_coalescing?.adaptive_tx, icAdaptiveTx, "set_interrupt_coalescing_adaptive_tx", "delete_interrupt_coalescing_adaptive_tx");
+      addBooleanToggle(iface?.interrupt_coalescing?.cqe_mode_rx, icCqeModeRx, "set_interrupt_coalescing_cqe_mode_rx", "delete_interrupt_coalescing_cqe_mode_rx");
+      addBooleanToggle(iface?.interrupt_coalescing?.cqe_mode_tx, icCqeModeTx, "set_interrupt_coalescing_cqe_mode_tx", "delete_interrupt_coalescing_cqe_mode_tx");
+      addIfChanged(iface?.interrupt_coalescing?.rx_usecs, icRxUsecs, "set_interrupt_coalescing_rx_usecs");
+      addIfChanged(iface?.interrupt_coalescing?.rx_frames, icRxFrames, "set_interrupt_coalescing_rx_frames");
+      addIfChanged(iface?.interrupt_coalescing?.tx_usecs, icTxUsecs, "set_interrupt_coalescing_tx_usecs");
+      addIfChanged(iface?.interrupt_coalescing?.tx_frames, icTxFrames, "set_interrupt_coalescing_tx_frames");
     }
 
     return operations;
@@ -544,8 +685,9 @@ export function ComprehensiveEthernetModal({
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {error && (
-            <div className="bg-destructive/10 text-destructive px-4 py-3 rounded-md text-sm">
-              {error}
+            <div className="bg-destructive/10 border border-destructive/20 rounded-md p-3 flex items-start gap-2">
+              <AlertCircle className="h-4 w-4 text-destructive mt-0.5 shrink-0" />
+              <pre className="whitespace-pre-wrap font-mono text-sm text-destructive">{error}</pre>
             </div>
           )}
 
@@ -817,6 +959,38 @@ export function ComprehensiveEthernetModal({
                       </Select>
                     </div>
 
+                    {/* HW TC Offload */}
+                    {capabilities?.features.offload.hw_tc_offload && (
+                      <div className="space-y-2">
+                        <Label htmlFor="offload-hw-tc">HW TC Offload</Label>
+                        <Select value={offloadHwTcOffload} onValueChange={setOffloadHwTcOffload}>
+                          <SelectTrigger id="offload-hw-tc">
+                            <SelectValue placeholder="Select..." />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="on">On</SelectItem>
+                            <SelectItem value="off">Off</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )}
+
+                    {/* RFS */}
+                    {capabilities?.features.offload.rfs && (
+                      <div className="space-y-2">
+                        <Label htmlFor="offload-rfs">RFS</Label>
+                        <Select value={offloadRfs} onValueChange={setOffloadRfs}>
+                          <SelectTrigger id="offload-rfs">
+                            <SelectValue placeholder="Select..." />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="on">On</SelectItem>
+                            <SelectItem value="off">Off</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )}
+
                   </div>
                 </div>
               )}
@@ -1031,16 +1205,32 @@ export function ComprehensiveEthernetModal({
                         </SelectContent>
                       </Select>
                     </div>
-                    <div className="flex items-center space-x-2 pt-8">
-                      <Checkbox
-                        id="ip-directed-broadcast"
-                        checked={ipEnableDirectedBroadcast}
-                        onCheckedChange={(checked) => setIpEnableDirectedBroadcast(checked as boolean)}
-                      />
-                      <Label htmlFor="ip-directed-broadcast" className="cursor-pointer text-sm">
-                        Enable Directed Broadcast
-                      </Label>
-                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    {capabilities?.features.ip.directed_broadcast && (
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="ip-directed-broadcast"
+                          checked={ipEnableDirectedBroadcast}
+                          onCheckedChange={(checked) => setIpEnableDirectedBroadcast(checked as boolean)}
+                        />
+                        <Label htmlFor="ip-directed-broadcast" className="cursor-pointer text-sm">
+                          Enable Directed Broadcast
+                        </Label>
+                      </div>
+                    )}
+                    {capabilities?.features.ip.disable_forwarding && (
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="ip-disable-forwarding"
+                          checked={ipDisableForwarding}
+                          onCheckedChange={(checked) => setIpDisableForwarding(checked as boolean)}
+                        />
+                        <Label htmlFor="ip-disable-forwarding" className="cursor-pointer text-sm">
+                          Disable Forwarding
+                        </Label>
+                      </div>
+                    )}
                   </div>
                 </div>
               )}
@@ -1068,6 +1258,45 @@ export function ComprehensiveEthernetModal({
                         onChange={(e) => setIpv6DupAddrDetectTransmits(e.target.value)}
                       />
                     </div>
+                    {capabilities?.features.ipv6.accept_dad && (
+                      <div className="space-y-2">
+                        <Label htmlFor="ipv6-accept-dad">Accept DAD</Label>
+                        <Input
+                          id="ipv6-accept-dad"
+                          type="number"
+                          placeholder="0, 1, or 2"
+                          value={ipv6AcceptDad}
+                          onChange={(e) => setIpv6AcceptDad(e.target.value)}
+                        />
+                      </div>
+                    )}
+                    {capabilities?.features.ipv6.base_reachable_time && (
+                      <div className="space-y-2">
+                        <Label htmlFor="ipv6-base-reachable-time">Base Reachable Time</Label>
+                        <Input
+                          id="ipv6-base-reachable-time"
+                          type="number"
+                          placeholder="30"
+                          value={ipv6BaseReachableTime}
+                          onChange={(e) => setIpv6BaseReachableTime(e.target.value)}
+                        />
+                      </div>
+                    )}
+                    {capabilities?.features.ipv6.source_validation && (
+                      <div className="space-y-2">
+                        <Label htmlFor="ipv6-source-validation">Source Validation</Label>
+                        <Select value={ipv6SourceValidation || "none"} onValueChange={(v) => setIpv6SourceValidation(v === "none" ? "" : v)}>
+                          <SelectTrigger id="ipv6-source-validation">
+                            <SelectValue placeholder="None" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="none">None</SelectItem>
+                            <SelectItem value="strict">Strict</SelectItem>
+                            <SelectItem value="loose">Loose</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )}
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     <div className="flex items-center space-x-2">
@@ -1090,6 +1319,18 @@ export function ComprehensiveEthernetModal({
                         Disable Forwarding
                       </Label>
                     </div>
+                    {capabilities?.features.ipv6.no_default_link_local && (
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="ipv6-no-default-link-local"
+                          checked={ipv6NoDefaultLinkLocal}
+                          onCheckedChange={(checked) => setIpv6NoDefaultLinkLocal(checked as boolean)}
+                        />
+                        <Label htmlFor="ipv6-no-default-link-local" className="cursor-pointer text-sm">
+                          No Default Link-Local
+                        </Label>
+                      </div>
+                    )}
                   </div>
                 </div>
               )}
@@ -1138,16 +1379,52 @@ export function ComprehensiveEthernetModal({
                         onChange={(e) => setDhcpDefaultRouteDistance(e.target.value)}
                       />
                     </div>
+                    {capabilities?.features.dhcp.reject && (
+                      <div className="space-y-2">
+                        <Label htmlFor="dhcp-reject">Reject Server</Label>
+                        <Input
+                          id="dhcp-reject"
+                          placeholder="192.168.1.1"
+                          value={dhcpReject}
+                          onChange={(e) => setDhcpReject(e.target.value)}
+                        />
+                      </div>
+                    )}
+                    {capabilities?.features.dhcp.user_class && (
+                      <div className="space-y-2">
+                        <Label htmlFor="dhcp-user-class">User Class</Label>
+                        <Input
+                          id="dhcp-user-class"
+                          placeholder="user-class"
+                          value={dhcpUserClass}
+                          onChange={(e) => setDhcpUserClass(e.target.value)}
+                        />
+                      </div>
+                    )}
                   </div>
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="dhcp-no-default-route"
-                      checked={dhcpNoDefaultRoute}
-                      onCheckedChange={(checked) => setDhcpNoDefaultRoute(checked as boolean)}
-                    />
-                    <Label htmlFor="dhcp-no-default-route" className="cursor-pointer text-sm">
-                      No Default Route
-                    </Label>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="dhcp-no-default-route"
+                        checked={dhcpNoDefaultRoute}
+                        onCheckedChange={(checked) => setDhcpNoDefaultRoute(checked as boolean)}
+                      />
+                      <Label htmlFor="dhcp-no-default-route" className="cursor-pointer text-sm">
+                        No Default Route
+                      </Label>
+                    </div>
+                    {capabilities?.features.dhcp.mtu && (
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="dhcp-mtu"
+                          checked={dhcpMtu}
+                          onCheckedChange={(checked) => setDhcpMtu(checked as boolean)}
+                        />
+                        <Label htmlFor="dhcp-mtu" className="cursor-pointer text-sm">
+                          Request MTU
+                        </Label>
+                      </div>
+                    )}
                   </div>
                 </div>
               )}
@@ -1166,15 +1443,53 @@ export function ComprehensiveEthernetModal({
                       />
                     </div>
                   </div>
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="dhcpv6-rapid-commit"
-                      checked={dhcpv6RapidCommit}
-                      onCheckedChange={(checked) => setDhcpv6RapidCommit(checked as boolean)}
-                    />
-                    <Label htmlFor="dhcpv6-rapid-commit" className="cursor-pointer text-sm">
-                      Rapid Commit
-                    </Label>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="dhcpv6-rapid-commit"
+                        checked={dhcpv6RapidCommit}
+                        onCheckedChange={(checked) => setDhcpv6RapidCommit(checked as boolean)}
+                      />
+                      <Label htmlFor="dhcpv6-rapid-commit" className="cursor-pointer text-sm">
+                        Rapid Commit
+                      </Label>
+                    </div>
+                    {capabilities?.features.dhcpv6.no_release && (
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="dhcpv6-no-release"
+                          checked={dhcpv6NoRelease}
+                          onCheckedChange={(checked) => setDhcpv6NoRelease(checked as boolean)}
+                        />
+                        <Label htmlFor="dhcpv6-no-release" className="cursor-pointer text-sm">
+                          No Release
+                        </Label>
+                      </div>
+                    )}
+                    {capabilities?.features.dhcpv6.parameters_only && (
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="dhcpv6-parameters-only"
+                          checked={dhcpv6ParametersOnly}
+                          onCheckedChange={(checked) => setDhcpv6ParametersOnly(checked as boolean)}
+                        />
+                        <Label htmlFor="dhcpv6-parameters-only" className="cursor-pointer text-sm">
+                          Parameters Only
+                        </Label>
+                      </div>
+                    )}
+                    {capabilities?.features.dhcpv6.temporary && (
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="dhcpv6-temporary"
+                          checked={dhcpv6Temporary}
+                          onCheckedChange={(checked) => setDhcpv6Temporary(checked as boolean)}
+                        />
+                        <Label htmlFor="dhcpv6-temporary" className="cursor-pointer text-sm">
+                          Temporary
+                        </Label>
+                      </div>
+                    )}
                   </div>
                 </div>
               )}
@@ -1239,6 +1554,18 @@ export function ComprehensiveEthernetModal({
                         onChange={(e) => setEapolKeyFile(e.target.value)}
                       />
                     </div>
+                    {capabilities?.features.eapol.passphrase && (
+                      <div className="space-y-2">
+                        <Label htmlFor="eapol-passphrase">Passphrase</Label>
+                        <Input
+                          id="eapol-passphrase"
+                          type="password"
+                          placeholder="EAPoL passphrase"
+                          value={eapolPassphrase}
+                          onChange={(e) => setEapolPassphrase(e.target.value)}
+                        />
+                      </div>
+                    )}
                   </div>
                 </div>
               )}
@@ -1255,6 +1582,127 @@ export function ComprehensiveEthernetModal({
                     <Label htmlFor="evpn-uplink" className="cursor-pointer text-sm">
                       Enable EVPN Uplink Tracking
                     </Label>
+                  </div>
+                </div>
+              )}
+
+              {capabilities?.features.redirect && (
+                <div className="space-y-3">
+                  <h3 className="text-sm font-semibold">Traffic Redirect</h3>
+                  <div className="space-y-2">
+                    <Label htmlFor="redirect">Redirect to Interface</Label>
+                    <Input
+                      id="redirect"
+                      placeholder="eth1"
+                      value={redirect}
+                      onChange={(e) => setRedirect(e.target.value)}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {capabilities?.features.switchdev?.supported && (
+                <div className="space-y-3">
+                  <h3 className="text-sm font-semibold">Switchdev</h3>
+                  <div className="flex items-center space-x-2">
+                    <Checkbox
+                      id="switchdev"
+                      checked={switchdev}
+                      onCheckedChange={(checked) => setSwitchdev(checked as boolean)}
+                    />
+                    <Label htmlFor="switchdev" className="cursor-pointer text-sm">
+                      Enable Switchdev Mode
+                    </Label>
+                  </div>
+                </div>
+              )}
+
+              {capabilities?.features.interrupt_coalescing?.supported && (
+                <div className="space-y-3">
+                  <h3 className="text-sm font-semibold">Interrupt Coalescing</h3>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="ic-rx-usecs">RX Usecs</Label>
+                      <Input
+                        id="ic-rx-usecs"
+                        type="number"
+                        placeholder="0"
+                        value={icRxUsecs}
+                        onChange={(e) => setIcRxUsecs(e.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="ic-tx-usecs">TX Usecs</Label>
+                      <Input
+                        id="ic-tx-usecs"
+                        type="number"
+                        placeholder="0"
+                        value={icTxUsecs}
+                        onChange={(e) => setIcTxUsecs(e.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="ic-rx-frames">RX Frames</Label>
+                      <Input
+                        id="ic-rx-frames"
+                        type="number"
+                        placeholder="0"
+                        value={icRxFrames}
+                        onChange={(e) => setIcRxFrames(e.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="ic-tx-frames">TX Frames</Label>
+                      <Input
+                        id="ic-tx-frames"
+                        type="number"
+                        placeholder="0"
+                        value={icTxFrames}
+                        onChange={(e) => setIcTxFrames(e.target.value)}
+                      />
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="ic-adaptive-rx"
+                        checked={icAdaptiveRx}
+                        onCheckedChange={(checked) => setIcAdaptiveRx(checked as boolean)}
+                      />
+                      <Label htmlFor="ic-adaptive-rx" className="cursor-pointer text-sm">
+                        Adaptive RX
+                      </Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="ic-adaptive-tx"
+                        checked={icAdaptiveTx}
+                        onCheckedChange={(checked) => setIcAdaptiveTx(checked as boolean)}
+                      />
+                      <Label htmlFor="ic-adaptive-tx" className="cursor-pointer text-sm">
+                        Adaptive TX
+                      </Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="ic-cqe-mode-rx"
+                        checked={icCqeModeRx}
+                        onCheckedChange={(checked) => setIcCqeModeRx(checked as boolean)}
+                      />
+                      <Label htmlFor="ic-cqe-mode-rx" className="cursor-pointer text-sm">
+                        CQE Mode RX
+                      </Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="ic-cqe-mode-tx"
+                        checked={icCqeModeTx}
+                        onCheckedChange={(checked) => setIcCqeModeTx(checked as boolean)}
+                      />
+                      <Label htmlFor="ic-cqe-mode-tx" className="cursor-pointer text-sm">
+                        CQE Mode TX
+                      </Label>
+                    </div>
                   </div>
                 </div>
               )}

--- a/frontend/src/components/network/DeleteEthernetModal.tsx
+++ b/frontend/src/components/network/DeleteEthernetModal.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { ethernetService } from "@/lib/api/ethernet";
 import type { EthernetInterface } from "@/lib/api/types/ethernet";
-import { Loader2, AlertTriangle } from "lucide-react";
+import { Loader2, AlertTriangle, AlertCircle } from "lucide-react";
 
 interface DeleteEthernetModalProps {
   open: boolean;
@@ -64,8 +64,9 @@ export function DeleteEthernetModal({
 
         <div className="space-y-4">
           {error && (
-            <div className="bg-destructive/10 text-destructive px-4 py-3 rounded-md text-sm">
-              {error}
+            <div className="bg-destructive/10 border border-destructive/20 rounded-md p-3 flex items-start gap-2">
+              <AlertCircle className="h-4 w-4 text-destructive mt-0.5 shrink-0" />
+              <pre className="whitespace-pre-wrap font-mono text-sm text-destructive">{error}</pre>
             </div>
           )}
 

--- a/frontend/src/lib/api/ethernet.ts
+++ b/frontend/src/lib/api/ethernet.ts
@@ -31,7 +31,11 @@ class EthernetService {
    * Configure ethernet interface using batch operations
    */
   async batchConfigure(request: BatchRequest): Promise<VyOSResponse> {
-    return apiClient.post<VyOSResponse>("/vyos/ethernet/batch", request);
+    const result = await apiClient.post<VyOSResponse>("/vyos/ethernet/batch", request);
+    if (!result.success) {
+      throw new Error(result.error || "Operation failed");
+    }
+    return result;
   }
 
   /**

--- a/frontend/src/lib/api/types/ethernet.ts
+++ b/frontend/src/lib/api/types/ethernet.ts
@@ -10,12 +10,18 @@ export interface DHCPOptionsConfig {
   vendor_class_id?: string | null;
   no_default_route?: boolean | null;
   default_route_distance?: string | null;
+  reject?: string | string[] | null;
+  user_class?: string | null;
+  mtu?: boolean | null;
 }
 
 export interface DHCPv6OptionsConfig {
   duid?: string | null;
   rapid_commit?: boolean | null;
   pd?: Record<string, unknown> | null;
+  no_release?: boolean | null;
+  parameters_only?: boolean | null;
+  temporary?: boolean | null;
 }
 
 export interface OffloadConfig {
@@ -25,6 +31,8 @@ export interface OffloadConfig {
   rps?: string | null;
   sg?: string | null;
   tso?: string | null;
+  hw_tc_offload?: string | null;
+  rfs?: string | null;
 }
 
 export interface RingBufferConfig {
@@ -43,6 +51,7 @@ export interface IPConfig {
   proxy_arp_pvlan?: boolean | null;
   source_validation?: string | null;
   enable_directed_broadcast?: boolean | null;
+  disable_forwarding?: boolean | null;
 }
 
 export interface IPv6Config {
@@ -50,6 +59,10 @@ export interface IPv6Config {
   adjust_mss?: string | null;
   disable_forwarding?: boolean | null;
   dup_addr_detect_transmits?: string | null;
+  accept_dad?: string | null;
+  no_default_link_local?: boolean | null;
+  base_reachable_time?: string | null;
+  source_validation?: string | null;
 }
 
 export interface VIFConfig {
@@ -75,10 +88,41 @@ export interface EAPoLConfig {
   ca_cert_file?: string | null;
   cert_file?: string | null;
   key_file?: string | null;
+  passphrase?: string | null;
 }
 
 export interface EVPNConfig {
   uplink?: boolean | null;
+}
+
+export interface InterruptCoalescingConfig {
+  adaptive_rx?: boolean | null;
+  adaptive_tx?: boolean | null;
+  cqe_mode_rx?: boolean | null;
+  cqe_mode_tx?: boolean | null;
+  rx_usecs?: string | null;
+  rx_frames?: string | null;
+  tx_usecs?: string | null;
+  tx_frames?: string | null;
+  rx_usecs_irq?: string | null;
+  rx_usecs_low?: string | null;
+  rx_usecs_high?: string | null;
+  tx_usecs_irq?: string | null;
+  tx_usecs_low?: string | null;
+  tx_usecs_high?: string | null;
+  rx_frames_irq?: string | null;
+  rx_frame_low?: string | null;
+  rx_frame_high?: string | null;
+  tx_frames_irq?: string | null;
+  tx_frame_low?: string | null;
+  tx_frame_high?: string | null;
+  pkt_rate_low?: string | null;
+  pkt_rate_high?: string | null;
+  sample_interval?: string | null;
+  stats_block_usecs?: string | null;
+  tx_aggr_max_bytes?: string | null;
+  tx_aggr_max_frames?: string | null;
+  tx_aggr_time_usecs?: string | null;
 }
 
 // Main Ethernet Interface type
@@ -107,6 +151,9 @@ export interface EthernetInterface {
   mirror?: MirrorConfig | null;
   eapol?: EAPoLConfig | null;
   evpn?: EVPNConfig | null;
+  redirect?: string | null;
+  interrupt_coalescing?: InterruptCoalescingConfig | null;
+  switchdev?: boolean | null;
 }
 
 // API Response types
@@ -138,6 +185,9 @@ export interface EthernetCapabilities {
     port_mirror: Record<string, boolean>;
     eapol: Record<string, boolean>;
     evpn: Record<string, boolean>;
+    redirect: boolean;
+    interrupt_coalescing: Record<string, boolean>;
+    switchdev: Record<string, boolean>;
   };
   operations: Record<string, string[]>;
   version_info: {


### PR DESCRIPTION
Add frontend support for all new ethernet backend operations including
IP disable-forwarding, IPv6 accept-dad/no-default-link-local/base-reachable-time/ 
source-validation, DHCP reject/user-class/mtu, DHCPv6 no-release/parameters-only/ 
temporary, offload hw-tc-offload/rfs, redirect, EAPoL passphrase, switchdev, and
interrupt coalescing. Fix batchConfigure silently swallowing VyOS errors by checking
result.success. Add RBAC permission gating and status column to interfaces page. 
Improve error display in modals with AlertCircle icon and monospace pre formatting.