### PR TITLE
feat: Add MSS clamping support for interfaces

### DIFF
--- a/backend/routers/interfaces/ethernet.py
+++ b/backend/routers/interfaces/ethernet.py
@@ -177,6 +177,7 @@ class VIFConfig(BaseModel):
     mac: Optional[str] = None
     vrf: Optional[str] = None
     disable: Optional[bool] = None
+    mss_clamping: Optional[bool] = None
 
 class VIFSConfig(BaseModel):
     """QinQ service VLAN (VIF-S) configuration"""
@@ -649,11 +650,11 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
                     "set_vif_egress_qos", "delete_vif_egress_qos",
                     "set_vif_ingress_qos", "delete_vif_ingress_qos",
                     "set_vif_redirect", "delete_vif_redirect",
-                    "set_vif_ip_adjust_mss", "set_vif_ip_disable_forwarding",
+                    "set_vif_ip_adjust_mss", "set_vif_ip_adjust_mss_clamp_to_pmtu", "set_vif_ip_disable_forwarding",
                     "set_vif_ip_source_validation", "set_vif_ip_enable_proxy_arp",
                     "set_vif_ip_arp_cache_timeout",
                     "set_vif_mirror_ingress", "set_vif_mirror_egress", "delete_vif_mirror",
-                    "set_vif_ipv6_disable_forwarding", "set_vif_ipv6_adjust_mss",
+                    "set_vif_ipv6_disable_forwarding", "set_vif_ipv6_adjust_mss", "set_vif_ipv6_adjust_mss_clamp_to_pmtu",
                     "set_vif_ipv6_accept_dad", "set_vif_ipv6_dup_addr_detect_transmits",
                 ],
                 "vlan_vif_s": [
@@ -930,6 +931,10 @@ async def configure_interface_batch(http_request: Request, request: InterfaceBat
     | `set_vif_dhcp_options_host_name` | Yes (vlan_id,hostname) | Set VIF DHCP hostname |
     | `set_vif_ipv6_address_autoconf` | Yes (vlan_id) | Enable VIF IPv6 autoconf |
     | `set_vif_ipv6_address_eui64` | Yes (vlan_id,prefix) | Set VIF IPv6 EUI-64 |
+    | `set_vif_ip_adjust_mss` | Yes (vlan_id,mss) | Set VIF IPv4 TCP MSS |
+    | `set_vif_ip_adjust_mss_clamp_to_pmtu` | Yes (vlan_id) | Enable VIF IPv4 MSS clamping to PMTU |
+    | `set_vif_ipv6_adjust_mss` | Yes (vlan_id,mss) | Set VIF IPv6 TCP MSS |
+    | `set_vif_ipv6_adjust_mss_clamp_to_pmtu` | Yes (vlan_id) | Enable VIF IPv6 MSS clamping to PMTU |
 
     **VLAN Sub-interface Operations (VIF-S - QinQ Service):**
 
@@ -1582,6 +1587,28 @@ async def configure_interface_batch(http_request: Request, request: InterfaceBat
                 if len(parts) != 2:
                     raise HTTPException(status_code=400, detail=f"{op_type} value must be 'vlan_id,prefix'")
                 batch.set_vif_ipv6_address_eui64(request.interface, parts[0], parts[1])
+            elif op_type == "set_vif_ip_adjust_mss":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value (vlan_id,mss)")
+                parts = value.split(",", 1)
+                if len(parts) != 2:
+                    raise HTTPException(status_code=400, detail=f"{op_type} value must be 'vlan_id,mss'")
+                batch.set_vif_ip_adjust_mss(request.interface, parts[0], parts[1])
+            elif op_type == "set_vif_ip_adjust_mss_clamp_to_pmtu":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value (vlan_id)")
+                batch.set_vif_ip_adjust_mss_clamp_to_pmtu(request.interface, value)
+            elif op_type == "set_vif_ipv6_adjust_mss":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value (vlan_id,mss)")
+                parts = value.split(",", 1)
+                if len(parts) != 2:
+                    raise HTTPException(status_code=400, detail=f"{op_type} value must be 'vlan_id,mss'")
+                batch.set_vif_ipv6_adjust_mss(request.interface, parts[0], parts[1])
+            elif op_type == "set_vif_ipv6_adjust_mss_clamp_to_pmtu":
+                if not value:
+                    raise HTTPException(status_code=400, detail=f"{op_type} requires a value (vlan_id)")
+                batch.set_vif_ipv6_adjust_mss_clamp_to_pmtu(request.interface, value)
             # VIF-S (QinQ Service VLAN) Sub-interface Operations
             elif op_type == "set_vif_s_address":
                 if not value:

--- a/backend/routers/wireguard/wireguard.py
+++ b/backend/routers/wireguard/wireguard.py
@@ -196,6 +196,14 @@ async def get_wireguard_config(request: Request, refresh: bool = False):
                 "fwmark": iface_data.get("fwmark"),
                 "per_client_thread": iface_data.get("per_client_thread", False),
                 "disabled": iface_data.get("disabled", False),
+                "mss_clamping": bool(
+                    full_config.get("firewall", {})
+                    .get("options", {})
+                    .get("interface", {})
+                    .get(iface_name, {})
+                    .get("adjust-mss", {})
+                    .get("clamp-mss-to-pmtu")
+                ),
                 "peers": peers,
                 "peer_count": len(peers),
             })
@@ -233,6 +241,12 @@ async def wireguard_interface_batch(request: Request, body: WireGuardInterfaceBa
             method_name = operation.op
             method = getattr(builder, method_name, None)
 
+            if method is None and method_name == "set_interface_mss_clamping":
+                builder.add_set(["firewall", "options", "interface", body.interface, "adjust-mss", "clamp-mss-to-pmtu"])
+                continue
+            if method is None and method_name == "delete_interface_mss_clamping":
+                builder.add_delete(["firewall", "options", "interface", body.interface, "adjust-mss", "clamp-mss-to-pmtu"])
+                continue
             if method is None:
                 raise HTTPException(
                     status_code=400,

--- a/backend/vyos_builders/interfaces/ethernet.py
+++ b/backend/vyos_builders/interfaces/ethernet.py
@@ -1314,6 +1314,21 @@ class EthernetInterfaceBuilderMixin:
         path = self.mappers[self.interface_mapper_key].get_vif_ip_adjust_mss(interface, vlan_id, mss)
         return self.add_set(path)
 
+    def set_vif_ip_adjust_mss_clamp_mss_to_pmtu(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable VIF IPv4 MSS clamping to PMTU"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ip_adjust_mss_clamp_mss_to_pmtu(interface, vlan_id)
+        return self.add_set(path)
+
+    def delete_vif_ip_adjust_mss(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete VIF IPv4 MSS setting"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ip_adjust_mss_path(interface, vlan_id)
+        return self.add_delete(path)
+
+    def delete_vif_ip_adjust_mss_clamp_mss_to_pmtu(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Disable VIF IPv4 MSS clamping"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ip_adjust_mss_path(interface, vlan_id)
+        return self.add_delete(path)
+
     def set_vif_ip_disable_forwarding(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
         """Disable IP forwarding on VIF"""
         path = self.mappers[self.interface_mapper_key].get_vif_ip_disable_forwarding(interface, vlan_id)
@@ -1358,6 +1373,21 @@ class EthernetInterfaceBuilderMixin:
         """Set VIF IPv6 TCP MSS"""
         path = self.mappers[self.interface_mapper_key].get_vif_ipv6_adjust_mss(interface, vlan_id, mss)
         return self.add_set(path)
+
+    def set_vif_ipv6_adjust_mss_clamp_mss_to_pmtu(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Enable VIF IPv6 MSS clamping to PMTU"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ipv6_adjust_mss_clamp_mss_to_pmtu(interface, vlan_id)
+        return self.add_set(path)
+
+    def delete_vif_ipv6_adjust_mss(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Delete VIF IPv6 MSS setting"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ipv6_adjust_mss_path(interface, vlan_id)
+        return self.add_delete(path)
+
+    def delete_vif_ipv6_adjust_mss_clamp_mss_to_pmtu(self, interface: str, vlan_id: str) -> "EthernetInterfaceBuilderMixin":
+        """Disable VIF IPv6 MSS clamping"""
+        path = self.mappers[self.interface_mapper_key].get_vif_ipv6_adjust_mss_path(interface, vlan_id)
+        return self.add_delete(path)
 
     def set_vif_ipv6_accept_dad(self, interface: str, vlan_id: str, count: str) -> "EthernetInterfaceBuilderMixin":
         """Set VIF IPv6 accept DAD count"""

--- a/backend/vyos_builders/wireguard/wireguard.py
+++ b/backend/vyos_builders/wireguard/wireguard.py
@@ -137,6 +137,16 @@ class WireGuardBatchBuilder:
         path = self.mappers[self.mapper_key].get_interface_per_client_thread(interface)
         return self.add_delete(path)
 
+    def set_interface_mss_clamping(self, interface: str) -> "WireGuardBatchBuilder":
+        """Enable MSS clamping for a WireGuard interface."""
+        path = ["firewall", "options", "interface", interface, "adjust-mss", "clamp-mss-to-pmtu"]
+        return self.add_set(path)
+
+    def delete_interface_mss_clamping(self, interface: str) -> "WireGuardBatchBuilder":
+        """Disable MSS clamping for a WireGuard interface."""
+        path = ["firewall", "options", "interface", interface, "adjust-mss", "clamp-mss-to-pmtu"]
+        return self.add_delete(path)
+
     def set_interface_disable(self, interface: str) -> "WireGuardBatchBuilder":
         """Disable interface."""
         path = self.mappers[self.mapper_key].get_interface_disable(interface)

--- a/backend/vyos_mappers/interfaces/ethernet.py
+++ b/backend/vyos_mappers/interfaces/ethernet.py
@@ -721,9 +721,25 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
         """Get command path for VIF IPv4 TCP MSS."""
         return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ip", "adjust-mss", mss]
 
+    def get_vif_ip_adjust_mss_path(self, interface: str, vlan_id: str) -> List[str]:
+        """Get command path for deleting VIF IPv4 TCP MSS."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ip", "adjust-mss"]
+
+    def get_vif_ip_adjust_mss_clamp_mss_to_pmtu(self, interface: str, vlan_id: str) -> List[str]:
+        """Get command path for VIF IPv4 TCP MSS clamping to PMTU."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ip", "adjust-mss", "clamp-mss-to-pmtu"]
+
     def get_vif_ip_disable_forwarding(self, interface: str, vlan_id: str) -> List[str]:
         """Get command path for VIF IP disable forwarding."""
         return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ip", "disable-forwarding"]
+
+    def get_vif_ipv6_adjust_mss_path(self, interface: str, vlan_id: str) -> List[str]:
+        """Get command path for deleting VIF IPv6 TCP MSS."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ipv6", "adjust-mss"]
+
+    def get_vif_ipv6_adjust_mss_clamp_mss_to_pmtu(self, interface: str, vlan_id: str) -> List[str]:
+        """Get command path for VIF IPv6 TCP MSS clamping to PMTU."""
+        return ["interfaces", self.interface_type, interface, "vif", vlan_id, "ipv6", "adjust-mss", "clamp-mss-to-pmtu"]
 
     def get_vif_ip_source_validation(self, interface: str, vlan_id: str, mode: str) -> List[str]:
         """Get command path for VIF IP source validation."""
@@ -979,6 +995,10 @@ class EthernetInterfaceMapper(BaseFeatureMapper):
                         "mac": vif_config.get("mac"),
                         "vrf": vif_config.get("vrf"),
                         "disable": "disable" in vif_config,
+                        "mss_clamping": (
+                            (isinstance(vif_config.get("ip"), dict) and vif_config.get("ip").get("adjust-mss") == "clamp-mss-to-pmtu")
+                            or (isinstance(vif_config.get("ipv6"), dict) and vif_config.get("ipv6").get("adjust-mss") == "clamp-mss-to-pmtu")
+                        ),
                     })
         return vif_parsed if vif_parsed else None
 

--- a/frontend/src/app/network/interfaces/page.tsx
+++ b/frontend/src/app/network/interfaces/page.tsx
@@ -15,11 +15,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Plus, RefreshCw, AlertCircle, Search, Cable, Pencil, Trash2, Network, ChevronRight } from "lucide-react";
+import { Plus, RefreshCw, AlertCircle, Search, Cable, Pencil, Trash2, Network, ChevronRight, Shield } from "lucide-react";
 import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { ethernetService } from "@/lib/api/ethernet";
 import type { EthernetInterface, EthernetCapabilities, VIFConfig } from "@/lib/api/types/ethernet";
+import { wireguardService, type WireGuardInterface } from "@/lib/api/wireguard";
 import { ComprehensiveEthernetModal } from "@/components/network/ComprehensiveEthernetModal";
 import { ComprehensiveVLANModal } from "@/components/network/ComprehensiveVLANModal";
 import { DeleteEthernetModal } from "@/components/network/DeleteEthernetModal";
@@ -27,7 +28,7 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { usePermissions } from "@/hooks/usePermissions";
 import { FeatureGroup } from "@/lib/api/user-management";
 
-type InterfaceType = "ethernet" | "vlan";
+type InterfaceType = "ethernet" | "vlan" | "wireguard";
 
 // VLAN with parent interface info
 interface VLANWithParent extends VIFConfig {
@@ -38,6 +39,7 @@ interface VLANWithParent extends VIFConfig {
 export default function InterfacesPage() {
   const [interfaces, setInterfaces] = useState<EthernetInterface[]>([]);
   const [capabilities, setCapabilities] = useState<EthernetCapabilities | null>(null);
+  const [wireGuardInterfaces, setWireGuardInterfaces] = useState<WireGuardInterface[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -57,12 +59,14 @@ export default function InterfacesPage() {
   const loadData = async () => {
     try {
       setError(null);
-      const [configData, capabilitiesData] = await Promise.all([
+      const [configData, capabilitiesData, wgData] = await Promise.all([
         ethernetService.getConfig(),
         ethernetService.getCapabilities(),
+        wireguardService.getConfig(),
       ]);
       setInterfaces(configData.interfaces);
       setCapabilities(capabilitiesData);
+      setWireGuardInterfaces(wgData.interfaces);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load interface data");
     } finally {
@@ -103,6 +107,7 @@ export default function InterfacesPage() {
 
   const totalInterfaces = interfaces.length;
   const totalVlans = allVlans.length;
+  const totalWireGuard = wireGuardInterfaces.length;
 
   // Filter interfaces based on search
   const filteredInterfaces = interfaces.filter((iface) => {
@@ -130,6 +135,16 @@ export default function InterfacesPage() {
     );
   });
 
+  const filteredWireGuard = wireGuardInterfaces.filter((iface) => {
+    if (searchQuery === "") return true;
+    const q = searchQuery.toLowerCase();
+    return (
+      iface.name.toLowerCase().includes(q) ||
+      iface.description?.toLowerCase().includes(q) ||
+      iface.addresses?.some((addr) => addr.toLowerCase().includes(q))
+    );
+  });
+
   return (
     <AppLayout>
       <div className="flex h-full">
@@ -140,7 +155,7 @@ export default function InterfacesPage() {
               <div>
                 <h2 className="text-lg font-semibold text-foreground">Interfaces</h2>
                 <p className="text-sm text-muted-foreground mt-1">
-                  {totalInterfaces + totalVlans} total
+                  {totalInterfaces + totalVlans + totalWireGuard} total
                 </p>
               </div>
               <Button
@@ -243,6 +258,42 @@ export default function InterfacesPage() {
                     </div>
                   </div>
                 </button>
+
+                {/* WireGuard */}
+                <button
+                  onClick={() => setSelectedType("wireguard")}
+                  className={cn(
+                    "w-full text-left rounded-lg px-3 py-3 transition-all",
+                    selectedType === "wireguard"
+                      ? "bg-accent text-accent-foreground shadow-sm"
+                      : "hover:bg-accent/50"
+                  )}
+                >
+                  <div className="flex items-start gap-3">
+                    <div className={cn(
+                      "mt-0.5 rounded-md p-1.5",
+                      selectedType === "wireguard" ? "bg-primary/10" : "bg-muted"
+                    )}>
+                      <Shield className={cn(
+                        "h-4 w-4",
+                        selectedType === "wireguard" ? "text-primary" : "text-muted-foreground"
+                      )} />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between gap-2 mb-1">
+                        <span className="font-medium text-sm text-foreground">
+                          WireGuard
+                        </span>
+                        {selectedType === "wireguard" && (
+                          <ChevronRight className="h-4 w-4 text-primary flex-shrink-0" />
+                        )}
+                      </div>
+                      <span className="text-xs text-muted-foreground">
+                        {totalWireGuard} {totalWireGuard === 1 ? "tunnel" : "tunnels"}
+                      </span>
+                    </div>
+                  </div>
+                </button>
               </div>
             )}
           </ScrollArea>
@@ -255,12 +306,14 @@ export default function InterfacesPage() {
             <div className="flex items-start justify-between mb-4">
               <div className="flex-1">
                 <h1 className="text-2xl font-bold text-foreground">
-                  {selectedType === "ethernet" ? "Ethernet Interfaces" : "VLANs"}
+                  {selectedType === "ethernet" ? "Ethernet Interfaces" : selectedType === "vlan" ? "VLANs" : "WireGuard Interfaces"}
                 </h1>
                 <p className="text-sm text-muted-foreground mt-2">
                   {selectedType === "ethernet"
                     ? "Physical and virtual ethernet interface configurations"
-                    : "802.1Q VLAN sub-interfaces"}
+                    : selectedType === "vlan"
+                      ? "802.1Q VLAN sub-interfaces"
+                      : "WireGuard tunnel interfaces and status"}
                 </p>
               </div>
               <Button
@@ -268,6 +321,8 @@ export default function InterfacesPage() {
                 onClick={() => {
                   if (selectedType === "vlan") {
                     setIsCreateVLANModalOpen(true);
+                  } else if (selectedType === "wireguard") {
+                    window.location.href = "/vpn/wireguard";
                   } else {
                     setIsCreateInterfaceModalOpen(true);
                   }
@@ -275,7 +330,7 @@ export default function InterfacesPage() {
                 disabled={!canWrite(FeatureGroup.INTERFACES)}
               >
                 <Plus className="h-4 w-4" />
-                {selectedType === "ethernet" ? "Create Interface" : "Create VLAN"}
+                {selectedType === "ethernet" ? "Create Interface" : selectedType === "vlan" ? "Create VLAN" : "Manage WireGuard"}
               </Button>
             </div>
 
@@ -286,7 +341,9 @@ export default function InterfacesPage() {
                 placeholder={
                   selectedType === "ethernet"
                     ? "Search by name, description, IP address, VRF, or MAC..."
-                    : "Search by name, parent, description, IP address, or VRF..."
+                    : selectedType === "vlan"
+                      ? "Search by name, parent, description, IP address, or VRF..."
+                      : "Search by name, description, address..."
                 }
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
@@ -443,7 +500,7 @@ export default function InterfacesPage() {
                   </p>
                 </>
               )
-            ) : (
+            ) : selectedType === "vlan" ? (
               /* VLAN Table */
               filteredVlans.length === 0 ? (
                 <Card className="border-border">
@@ -570,6 +627,60 @@ export default function InterfacesPage() {
                   </p>
                 </>
               )
+            ) : filteredWireGuard.length === 0 ? (
+              <Card className="border-border">
+                <CardContent className="py-12">
+                  <div className="flex flex-col items-center gap-2">
+                    <Shield className="h-12 w-12 text-muted-foreground/30" />
+                    <p className="text-muted-foreground">
+                      {searchQuery ? "No WireGuard interfaces matching your search" : "No WireGuard interfaces configured"}
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            ) : (
+              <>
+                <div className="rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Name</TableHead>
+                        <TableHead>Description</TableHead>
+                        <TableHead>Addresses</TableHead>
+                        <TableHead>Port</TableHead>
+                        <TableHead>Peers</TableHead>
+                        <TableHead>Status</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {filteredWireGuard.map((wg) => (
+                        <TableRow key={wg.name}>
+                          <TableCell><code className="font-semibold font-mono text-foreground">{wg.name}</code></TableCell>
+                          <TableCell className="text-muted-foreground max-w-[220px] truncate">{wg.description || "—"}</TableCell>
+                          <TableCell>
+                            {wg.addresses?.length ? (
+                              <div className="flex flex-wrap gap-1">
+                                {wg.addresses.slice(0, 2).map((addr, idx) => <code key={idx} className="text-xs font-mono px-1.5 py-0.5 rounded bg-accent text-foreground">{addr}</code>)}
+                                {wg.addresses.length > 2 && <Badge variant="secondary" className="text-xs px-1.5 py-0">+{wg.addresses.length - 2}</Badge>}
+                              </div>
+                            ) : <span className="text-muted-foreground">—</span>}
+                          </TableCell>
+                          <TableCell>{wg.port || "Auto"}</TableCell>
+                          <TableCell><Badge variant="secondary" className="text-xs">{wg.peer_count}</Badge></TableCell>
+                          <TableCell>
+                            <Badge variant={wg.disabled ? "secondary" : "default"} className="text-xs">
+                              {wg.disabled ? "Disabled" : "Enabled"}
+                            </Badge>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+                <p className="text-sm text-muted-foreground text-center mt-3">
+                  Showing {filteredWireGuard.length} of {totalWireGuard} tunnel{totalWireGuard !== 1 ? "s" : ""}
+                </p>
+              </>
             )}
           </div>
         </div>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,77 +1,16 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { RebootModal } from "@/components/system/RebootModal";
 import { PoweroffModal } from "@/components/system/PoweroffModal";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Power, PowerOff, Settings as SettingsIcon, Server } from "lucide-react";
-import { systemService, type SystemConfig, type PerformanceOption } from "@/lib/api/system";
-import { useToast } from "@/hooks/useToast";
-
-const DEFAULT_PERFORMANCE_OPTION: PerformanceOption = {
-  value: "default",
-  label: "Default (not set)",
-  description: "No performance tuning",
-};
+import { Power, PowerOff, Settings as SettingsIcon } from "lucide-react";
 
 export default function SettingsPage() {
   const [rebootModalOpen, setRebootModalOpen] = useState(false);
   const [poweroffModalOpen, setPoweroffModalOpen] = useState(false);
-  const [systemConfig, setSystemConfig] = useState<SystemConfig | null>(null);
-  const [systemConfigLoading, setSystemConfigLoading] = useState(true);
-  const [performanceOptions, setPerformanceOptions] = useState<PerformanceOption[]>([DEFAULT_PERFORMANCE_OPTION]);
-  const [performanceSaving, setPerformanceSaving] = useState(false);
-  const { toast } = useToast();
-
-  useEffect(() => {
-    let cancelled = false;
-    Promise.all([systemService.getConfig(true), systemService.getCapabilities()])
-      .then(([config, caps]) => {
-        if (cancelled) return;
-        setSystemConfig(config);
-        if (caps.performance_options?.length) {
-          setPerformanceOptions([DEFAULT_PERFORMANCE_OPTION, ...caps.performance_options]);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setSystemConfig(null);
-      })
-      .finally(() => {
-        if (!cancelled) setSystemConfigLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const handlePerformanceChange = async (value: string) => {
-    const newValue = value === "" ? null : value;
-    setPerformanceSaving(true);
-    try {
-      const result = await systemService.updatePerformance(newValue);
-      if (result.success) {
-        setSystemConfig((prev) => (prev ? { ...prev, performance: newValue } : null));
-        toast.success("Performance option updated", result.message);
-      } else {
-        toast.error("Update failed", result.error ?? result.message);
-      }
-    } catch (err: unknown) {
-      const msg = err && typeof err === "object" && "message" in err ? String((err as { message: string }).message) : "Failed to update performance option";
-      toast.error("Update failed", msg);
-    } finally {
-      setPerformanceSaving(false);
-    }
-  };
 
   const handleRebootSuccess = () => {
     // Modal will close automatically
@@ -95,50 +34,6 @@ export default function SettingsPage() {
           <p className="text-muted-foreground mt-2">
             Manage system power and configuration settings
           </p>
-        </div>
-
-        {/* System Options Section */}
-        <div>
-          <h2 className="text-xl font-semibold mb-4">System</h2>
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Server className="h-5 w-5" />
-                Performance
-              </CardTitle>
-              <CardDescription>
-                Tune system for throughput, latency, power save, or virtualization.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              {systemConfigLoading ? (
-                <p className="text-sm text-muted-foreground">Loading…</p>
-              ) : (
-                <div className="space-y-2">
-                  <Label htmlFor="performance-select">Performance profile</Label>
-                  <Select
-                    value={systemConfig?.performance ?? ""}
-                    onValueChange={handlePerformanceChange}
-                    disabled={performanceSaving}
-                  >
-                    <SelectTrigger id="performance-select" className="w-full max-w-sm">
-                      <SelectValue placeholder="Default (not set)" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {performanceOptions.map((opt) => (
-                        <SelectItem key={opt.value || "default"} value={opt.value} title={opt.description}>
-                          {opt.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    Save config to make the change persistent.
-                  </p>
-                </div>
-              )}
-            </CardContent>
-          </Card>
         </div>
 
         {/* Power Management Section */}

--- a/frontend/src/components/network/ComprehensiveVLANModal.tsx
+++ b/frontend/src/components/network/ComprehensiveVLANModal.tsx
@@ -66,6 +66,9 @@ export function ComprehensiveVLANModal({
   const [dhcpClientId, setDhcpClientId] = useState("");
   const [dhcpHostName, setDhcpHostName] = useState("");
 
+  // TCP MSS settings
+  const [mssClamping, setMssClamping] = useState(false);
+
   // IPv6 settings
   const [ipv6Autoconf, setIpv6Autoconf] = useState(false);
   const [ipv6Eui64, setIpv6Eui64] = useState("");
@@ -81,6 +84,7 @@ export function ComprehensiveVLANModal({
       setMac(vlan.mac || "");
       setVrf(vlan.vrf || "");
       setDisabled(vlan.disable || false);
+      setMssClamping(vlan.mss_clamping || false);
     } else {
       resetForm();
     }
@@ -98,6 +102,7 @@ export function ComprehensiveVLANModal({
     setDisabled(false);
     setDhcpClientId("");
     setDhcpHostName("");
+    setMssClamping(false);
     setIpv6Autoconf(false);
     setIpv6Eui64("");
     setError(null);
@@ -199,6 +204,36 @@ export function ComprehensiveVLANModal({
       operations.push({ op: disabled ? "set_vif_disable" : "delete_vif_disable", value: vid });
     } else if (mode === "create" && disabled) {
       operations.push({ op: "set_vif_disable", value: vid });
+    }
+
+    // TCP MSS clamping
+    if (capabilities?.features.tcp_mss?.clamp_to_pmtu_ipv4 || capabilities?.features.tcp_mss?.clamp_to_pmtu_ipv6) {
+      const currentlyClamping = vlan?.mss_clamping || false;
+
+      if (mode === "create" && mssClamping) {
+        if (capabilities.features.tcp_mss.clamp_to_pmtu_ipv4) {
+          operations.push({ op: "set_vif_ip_adjust_mss_clamp_to_pmtu", value: vid });
+        }
+        if (capabilities.features.tcp_mss.clamp_to_pmtu_ipv6) {
+          operations.push({ op: "set_vif_ipv6_adjust_mss_clamp_to_pmtu", value: vid });
+        }
+      } else if (mode === "edit") {
+        if (mssClamping && !currentlyClamping) {
+          if (capabilities.features.tcp_mss.clamp_to_pmtu_ipv4) {
+            operations.push({ op: "set_vif_ip_adjust_mss_clamp_to_pmtu", value: vid });
+          }
+          if (capabilities.features.tcp_mss.clamp_to_pmtu_ipv6) {
+            operations.push({ op: "set_vif_ipv6_adjust_mss_clamp_to_pmtu", value: vid });
+          }
+        } else if (!mssClamping && currentlyClamping) {
+          if (capabilities.features.tcp_mss.ipv4_adjust || capabilities.features.tcp_mss.clamp_to_pmtu_ipv4) {
+            operations.push({ op: "delete_vif_ip_adjust_mss", value: vid });
+          }
+          if (capabilities.features.tcp_mss.ipv6_adjust || capabilities.features.tcp_mss.clamp_to_pmtu_ipv6) {
+            operations.push({ op: "delete_vif_ipv6_adjust_mss", value: vid });
+          }
+        }
+      }
     }
 
     // DHCP options - require (vlan_id,value)
@@ -489,6 +524,22 @@ export function ComprehensiveVLANModal({
                         onChange={(e) => setDhcpHostName(e.target.value)}
                       />
                     </div>
+                  </div>
+                </div>
+              )}
+
+              {(capabilities?.features.tcp_mss?.clamp_to_pmtu_ipv4 || capabilities?.features.tcp_mss?.clamp_to_pmtu_ipv6) && (
+                <div className="space-y-2">
+                  <h3 className="text-sm font-semibold">TCP MSS</h3>
+                  <div className="flex items-center space-x-2">
+                    <Checkbox
+                      id="mss-clamping"
+                      checked={mssClamping}
+                      onCheckedChange={(checked) => setMssClamping(checked as boolean)}
+                    />
+                    <Label htmlFor="mss-clamping" className="cursor-pointer text-sm">
+                      Enable TCP MSS clamping to PMTU (IPv4+IPv6)
+                    </Label>
                   </div>
                 </div>
               )}

--- a/frontend/src/components/vpn/CreateInterfaceModal.tsx
+++ b/frontend/src/components/vpn/CreateInterfaceModal.tsx
@@ -51,6 +51,7 @@ export function CreateInterfaceModal({
   const [privateKey, setPrivateKey] = useState("");
   const [mtu, setMtu] = useState("");
   const [perClientThread, setPerClientThread] = useState(false);
+  const [mssClamping, setMssClamping] = useState(false);
 
   // UI state
   const [loading, setLoading] = useState(false);
@@ -107,6 +108,7 @@ export function CreateInterfaceModal({
     setPrivateKey("");
     setMtu("");
     setPerClientThread(false);
+    setMssClamping(false);
     setError(null);
     setShowPrivateKey(false);
     setGeneratedPublicKey(null);
@@ -173,6 +175,9 @@ export function CreateInterfaceModal({
 
       if (perClientThread && capabilities?.features.per_client_thread.supported) {
         config.per_client_thread = true;
+      }
+      if (mssClamping) {
+        config.mss_clamping = true;
       }
 
       const result = await wireguardService.createInterface(config);
@@ -394,6 +399,22 @@ export function CreateInterfaceModal({
                 </div>
               </div>
             )}
+
+            <div className="flex items-center space-x-2 rounded-lg border p-3">
+              <Checkbox
+                id="mssClamping"
+                checked={mssClamping}
+                onCheckedChange={(checked) => setMssClamping(checked === true)}
+              />
+              <div className="flex-1">
+                <Label htmlFor="mssClamping" className="cursor-pointer">
+                  MSS Clamping
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Set firewall options interface {name || "wg0"} adjust-mss clamp-mss-to-pmtu.
+                </p>
+              </div>
+            </div>
           </TabsContent>
         </Tabs>
 

--- a/frontend/src/components/vpn/EditInterfaceModal.tsx
+++ b/frontend/src/components/vpn/EditInterfaceModal.tsx
@@ -53,6 +53,7 @@ export function EditInterfaceModal({
   const [privateKey, setPrivateKey] = useState("");
   const [mtu, setMtu] = useState("");
   const [perClientThread, setPerClientThread] = useState(false);
+  const [mssClamping, setMssClamping] = useState(false);
   const [disabled, setDisabled] = useState(false);
 
   // UI state
@@ -72,6 +73,7 @@ export function EditInterfaceModal({
       setPrivateKey(interfaceData.private_key || "");
       setMtu(interfaceData.mtu || "");
       setPerClientThread(interfaceData.per_client_thread);
+      setMssClamping(interfaceData.mss_clamping || false);
       setDisabled(interfaceData.disabled || false);
       setGeneratedPublicKey(null);
     }
@@ -113,6 +115,7 @@ export function EditInterfaceModal({
     setPrivateKey("");
     setMtu("");
     setPerClientThread(false);
+    setMssClamping(false);
     setDisabled(false);
     setError(null);
     setShowPrivateKey(false);
@@ -169,6 +172,11 @@ export function EditInterfaceModal({
       // Per-client thread change
       if (perClientThread !== interfaceData.per_client_thread) {
         newConfig.per_client_thread = perClientThread;
+      }
+
+      // MSS clamping change
+      if (mssClamping !== (interfaceData.mss_clamping || false)) {
+        newConfig.mss_clamping = mssClamping;
       }
 
       // Disabled change
@@ -403,6 +411,22 @@ export function EditInterfaceModal({
                 </div>
               </div>
             )}
+
+            <div className="flex items-center space-x-2 rounded-lg border p-3">
+              <Checkbox
+                id="edit-mss-clamping"
+                checked={mssClamping}
+                onCheckedChange={(checked) => setMssClamping(checked === true)}
+              />
+              <div className="flex-1">
+                <Label htmlFor="edit-mss-clamping" className="cursor-pointer">
+                  TCP MSS Clamping
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Adjusts TCP MSS to match the path MTU to prevent fragmentation issues.
+                </p>
+              </div>
+            </div>
           </TabsContent>
         </Tabs>
 

--- a/frontend/src/lib/api/types/ethernet.ts
+++ b/frontend/src/lib/api/types/ethernet.ts
@@ -73,6 +73,7 @@ export interface VIFConfig {
   mac?: string | null;
   vrf?: string | null;
   disable?: boolean | null;
+  mss_clamping?: boolean | null;
 }
 
 export interface VIFSConfig extends VIFConfig {

--- a/frontend/src/lib/api/wireguard.ts
+++ b/frontend/src/lib/api/wireguard.ts
@@ -26,6 +26,7 @@ export interface WireGuardInterface {
   mtu?: string | null;
   fwmark?: string | null;
   per_client_thread: boolean;
+  mss_clamping?: boolean;
   disabled?: boolean;
   peers: WireGuardPeer[];
   peer_count: number;
@@ -158,6 +159,7 @@ class WireGuardService {
     private_key?: string;
     mtu?: string;
     per_client_thread?: boolean;
+    mss_clamping?: boolean;
   }): Promise<VyOSResponse> {
     const operations: WireGuardBatchOperation[] = [];
 
@@ -185,6 +187,9 @@ class WireGuardService {
     if (config.per_client_thread) {
       operations.push({ op: "set_interface_per_client_thread" });
     }
+    if (config.mss_clamping) {
+      operations.push({ op: "set_interface_mss_clamping" });
+    }
 
     return this.interfaceBatch(config.name, operations);
   }
@@ -202,6 +207,7 @@ class WireGuardService {
       private_key?: string | null;
       mtu?: string | null;
       per_client_thread?: boolean;
+      mss_clamping?: boolean;
       disabled?: boolean;
     }
   ): Promise<VyOSResponse> {
@@ -261,6 +267,15 @@ class WireGuardService {
         operations.push({ op: "set_interface_per_client_thread" });
       } else if (!newConfig.per_client_thread && currentConfig.per_client_thread) {
         operations.push({ op: "delete_interface_per_client_thread" });
+      }
+    }
+
+    // Handle MSS clamping
+    if (newConfig.mss_clamping !== undefined) {
+      if (newConfig.mss_clamping && !currentConfig.mss_clamping) {
+        operations.push({ op: "set_interface_mss_clamping" });
+      } else if (!newConfig.mss_clamping && currentConfig.mss_clamping) {
+        operations.push({ op: "delete_interface_mss_clamping" });
       }
     }
 


### PR DESCRIPTION
Introduce TCP MSS clamping support across Ethernet VLANs and WireGuard interfaces. 

Backend: add mss_clamping to VIF models and capabilities, register new configure ops (adjust_mss_clamp_to_pmtu / delete adjust_mss), implement mapper/builder paths for IPv4/IPv6 MSS clamping and delete operations, and handle WireGuard firewall option adds/deletes in the wireguard router and batch builder. 

Frontend: surface mss_clamping in types, add VLAN TCP MSS toggle in ComprehensiveVLANModal, add MSS clamping option to WireGuard create/edit modals, and list WireGuard interfaces on the Interfaces page with a dedicated tab. 
Also remove the performance profile UI from settings/page.tsx (resolve duplicate).