### PR TITLE
  Fix WireGuard VyOS 1.4 interface creation, GraphQL crash, Layouts

### DIFF
--- a/backend/routers/show.py
+++ b/backend/routers/show.py
@@ -197,7 +197,9 @@ async def _fetch_graphql_fast(service) -> Optional[dict]:
 
 def _gql_result(gql: dict, key: str):
     """Safely extract ``data.result`` from a named GraphQL alias."""
-    return (gql.get(key) or {}).get("data", {}).get("result")
+    entry = gql.get(key) or {}
+    data = entry.get("data") or {}
+    return data.get("result")
 
 
 async def _fetch_gql_wg_status(service, iface_names: List[str]) -> dict:

--- a/backend/routers/wireguard/wireguard.py
+++ b/backend/routers/wireguard/wireguard.py
@@ -35,10 +35,17 @@ class WireGuardBatchOperation(BaseModel):
     value: Optional[str] = Field(None, description="Operation value")
 
 
+class PeerBatchGroup(BaseModel):
+    """A group of operations for a single peer, used for atomic interface+peer creation."""
+    peer: str = Field(..., description="Peer name")
+    operations: List[WireGuardBatchOperation]
+
+
 class WireGuardInterfaceBatchRequest(BaseModel):
     """Model for interface batch configuration."""
     interface: str = Field(..., description="Interface name (e.g., wg0)")
     operations: List[WireGuardBatchOperation]
+    peers: Optional[List[PeerBatchGroup]] = Field(None, description="Optional peer operations to commit atomically with the interface")
 
 
 class WireGuardPeerBatchRequest(BaseModel):
@@ -206,6 +213,32 @@ async def wireguard_interface_batch(request: Request, body: WireGuardInterfaceBa
                 args.append(operation.value)
 
             method(*args)
+
+        # Process optional peer operations (for atomic interface+peer creation on VyOS 1.4)
+        if body.peers:
+            for peer_group in body.peers:
+                for operation in peer_group.operations:
+                    peer_method_name = operation.op
+                    peer_method = getattr(builder, peer_method_name, None)
+
+                    if peer_method is None:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=f"Unknown peer operation: {peer_method_name}"
+                        )
+
+                    sig = inspect.signature(peer_method)
+                    params = list(sig.parameters.keys())
+
+                    args = []
+                    if "interface" in params:
+                        args.append(body.interface)
+                    if "peer" in params:
+                        args.append(peer_group.peer)
+                    if operation.value and len(params) > len(args):
+                        args.append(operation.value)
+
+                    peer_method(*args)
 
         # Execute batch
         response = service.execute_batch(builder)

--- a/backend/vyos_builders/wireguard/wireguard.py
+++ b/backend/vyos_builders/wireguard/wireguard.py
@@ -272,7 +272,7 @@ class WireGuardBatchBuilder:
 
     def get_capabilities(self) -> Dict[str, Any]:
         """Get capabilities for the current VyOS version."""
-        # WireGuard is fully supported on both 1.4 and 1.5
+        is_v14 = "1.4" in self.version and "1.5" not in self.version
         return {
             "version": self.version,
             "features": {
@@ -291,6 +291,10 @@ class WireGuardBatchBuilder:
                 "per_client_thread": {
                     "supported": True,
                     "description": "Per-client threading for performance",
+                },
+                "peer_required_on_create": {
+                    "supported": is_v14,
+                    "description": "VyOS 1.4 requires at least one peer when creating an interface",
                 },
             },
             "version_notes": {

--- a/frontend/src/components/config/UnsavedChangesBanner.tsx
+++ b/frontend/src/components/config/UnsavedChangesBanner.tsx
@@ -127,7 +127,7 @@ export function UnsavedChangesBanner() {
       <>
       <div
         className={cn(
-          "fixed top-0 left-64 right-0 z-50",
+          "shrink-0 z-10",
           "shadow-lg border-b",
           isUrgent
             ? "bg-gradient-to-r from-red-600 to-orange-500 border-red-700/20"
@@ -171,9 +171,6 @@ export function UnsavedChangesBanner() {
           </div>
         </div>
       </div>
-
-      {/* Spacer so content isn't hidden under the fixed banner */}
-      <div className="h-16" />
     </>
   );
   }
@@ -191,7 +188,7 @@ export function UnsavedChangesBanner() {
     <>
       <div
         className={cn(
-          "fixed top-0 left-64 right-0 z-50 bg-gradient-to-r from-blue-600 to-cyan-500",
+          "shrink-0 z-10 bg-gradient-to-r from-blue-600 to-cyan-500",
           "shadow-lg border-b border-blue-700/20"
         )}
       >
@@ -245,9 +242,6 @@ export function UnsavedChangesBanner() {
           </div>
         </div>
       </div>
-
-      {/* Spacer to push content down when banner is visible */}
-      <div className="h-16" />
 
       <ConfigDiffModal
         open={showDiffModal}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -10,7 +10,7 @@ import { useSessionStore } from "@/store/session-store";
 import { Loader2 } from "lucide-react";
 import { UnifiedView } from "../ui/unified-view";
 import { useUnifiedView } from "@/contexts/UnifiedViewContext";
-import { SearchBar } from "../ui/search-bar";
+
 
 export function AppLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -64,19 +64,13 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
     <div className="flex h-screen overflow-hidden bg-background">
       <Sidebar />
       <div className="flex-1 flex flex-col overflow-hidden">
-        {/* Top Header with Search */}
-        <header className="relative z-40 flex h-14 items-center justify-between border-b border-border px-6 bg-card/50 backdrop-blur supports-[backdrop-filter]:bg-card/50">
-          <div className="flex-1" />
-          <div className="flex items-center gap-4">
-            <SearchBar />
-          </div>
-        </header>
-
         {/* Main Content */}
-        <main className="flex-1 overflow-y-auto relative">
+        <main className="flex-1 flex flex-col overflow-hidden relative">
           <PowerActionBanner />
           <UnsavedChangesBanner />
-          {children}
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            {children}
+          </div>
         </main>
       </div>
       <Toaster />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -18,6 +18,7 @@ import { useSessionStore } from "@/store/session-store";
 import { usePermissions } from "@/hooks/usePermissions";
 import { FeatureGroup } from "@/lib/api/user-management";
 import { ThemeSelector } from "@/components/ui/theme-selector";
+import { SearchBar } from "@/components/ui/search-bar";
 
 import { navigation } from "@/lib/navigation";
 
@@ -230,6 +231,11 @@ export function Sidebar() {
             <p className="text-xs text-muted-foreground">VyOS Management</p>
           </div>
         </div>
+      </div>
+
+      {/* Search */}
+      <div className="px-3 pt-3 pb-1 shrink-0">
+        <SearchBar />
       </div>
 
       {/* Navigation */}

--- a/frontend/src/components/ui/search-bar.tsx
+++ b/frontend/src/components/ui/search-bar.tsx
@@ -156,7 +156,7 @@ export function SearchBar() {
   };
 
   return (
-    <div className="relative w-80">
+    <div className="relative w-full">
       <div className="relative">
         <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input

--- a/frontend/src/components/vpn/CreateInterfaceModal.tsx
+++ b/frontend/src/components/vpn/CreateInterfaceModal.tsx
@@ -418,6 +418,16 @@ export function CreateInterfaceModal({
           </TabsContent>
         </Tabs>
 
+        {/* VyOS 1.4 peer requirement notice */}
+        {capabilities?.features.peer_required_on_create?.supported && (
+          <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 p-3">
+            <AlertCircle className="h-5 w-5 text-amber-600 shrink-0 mt-0.5" />
+            <p className="text-sm text-amber-700">
+              VyOS 1.4 requires at least one peer when creating an interface. Please use the <strong>Quick Setup Wizard</strong> instead, which creates an interface and peer together.
+            </p>
+          </div>
+        )}
+
         {/* Error Display */}
         {error && (
           <div className="flex items-start gap-2 rounded-lg bg-destructive/10 border border-destructive/20 p-3">
@@ -430,7 +440,10 @@ export function CreateInterfaceModal({
           <Button variant="outline" onClick={handleClose} disabled={loading}>
             Cancel
           </Button>
-          <Button onClick={handleSubmit} disabled={loading}>
+          <Button
+            onClick={handleSubmit}
+            disabled={loading || capabilities?.features.peer_required_on_create?.supported}
+          >
             {loading ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/frontend/src/components/vpn/QuickSetupWizard.tsx
+++ b/frontend/src/components/vpn/QuickSetupWizard.tsx
@@ -230,6 +230,8 @@ PersistentKeepalive = 25`;
   };
 
   // Run the setup
+  const peerRequiredOnCreate = capabilities?.features.peer_required_on_create?.supported ?? false;
+
   const runSetup = async () => {
     setLoading(true);
     setError(null);
@@ -241,13 +243,35 @@ PersistentKeepalive = 25`;
         throw new Error("Failed to generate server keypair");
       }
 
-      // Step 2: Create interface
-      const interfaceResult = await wireguardService.createInterface({
+      // Step 2: Generate client keypair upfront if creating a client
+      // (needed before interface creation on VyOS 1.4 for atomic commit)
+      let clientKeypair: { private_key?: string | null; public_key?: string | null } | null = null;
+      if (createClient) {
+        clientKeypair = await wireguardService.generateKeypair();
+        if (!clientKeypair.private_key || !clientKeypair.public_key) {
+          throw new Error("Failed to generate client keypair");
+        }
+      }
+
+      // Step 3: Create interface (with peer included for atomic commit on 1.4)
+      const interfaceConfig: Parameters<typeof wireguardService.createInterface>[0] = {
         name: interfaceName.trim(),
         private_key: serverKeypair.private_key,
         addresses: [serverAddress.trim()],
         port: listenPort.trim(),
-      });
+      };
+
+      // Include peer in the same atomic commit when creating a client
+      if (createClient && clientKeypair?.public_key) {
+        interfaceConfig.initial_peers = [{
+          name: clientName.trim(),
+          public_key: clientKeypair.public_key,
+          allowed_ips: [clientAddress.trim()],
+          persistent_keepalive: "25",
+        }];
+      }
+
+      const interfaceResult = await wireguardService.createInterface(interfaceConfig);
 
       if (!interfaceResult.success) {
         throw new Error(interfaceResult.error || "Failed to create interface");
@@ -261,45 +285,22 @@ PersistentKeepalive = 25`;
         serverPrivateKey: serverKeypair.private_key,
       };
 
-      // Step 3: Create client if requested
-      if (createClient) {
-        // Generate client keypair
-        const clientKeypair = await wireguardService.generateKeypair();
-        if (!clientKeypair.private_key || !clientKeypair.public_key) {
-          throw new Error("Failed to generate client keypair");
-        }
-
-        // Create peer on server
-        const peerResult = await wireguardService.createPeer(
-          interfaceName.trim(),
-          {
-            name: clientName.trim(),
-            public_key: clientKeypair.public_key,
-            allowed_ips: [clientAddress.trim()],
-            persistent_keepalive: "25",
-          }
+      // Step 4: Build client config display (peer was already created in the batch)
+      if (createClient && clientKeypair?.private_key && clientKeypair?.public_key) {
+        const clientConfig = buildClientConfig(
+          serverKeypair.public_key,
+          clientKeypair.private_key
         );
 
-        if (!peerResult.success) {
-          // Interface created but peer failed - still show result
-          console.error("Failed to create peer:", peerResult.error);
-        } else {
-          // Build client config
-          const clientConfig = buildClientConfig(
-            serverKeypair.public_key,
-            clientKeypair.private_key
-          );
+        setupResult.clientConfig = clientConfig;
+        setupResult.clientName = clientName.trim();
+        setupResult.clientPublicKey = clientKeypair.public_key;
 
-          setupResult.clientConfig = clientConfig;
-          setupResult.clientName = clientName.trim();
-          setupResult.clientPublicKey = clientKeypair.public_key;
-
-          // Generate QR code
-          const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=${encodeURIComponent(
-            clientConfig
-          )}`;
-          setQrDataUrl(qrUrl);
-        }
+        // Generate QR code
+        const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=${encodeURIComponent(
+          clientConfig
+        )}`;
+        setQrDataUrl(qrUrl);
       }
 
       setResult(setupResult);
@@ -494,13 +495,16 @@ PersistentKeepalive = 25`;
                 id="wizard-create-client"
                 checked={createClient}
                 onCheckedChange={(checked) => setCreateClient(checked === true)}
+                disabled={peerRequiredOnCreate}
               />
               <div className="flex-1">
                 <Label htmlFor="wizard-create-client" className="cursor-pointer">
                   Create a client configuration
                 </Label>
                 <p className="text-xs text-muted-foreground">
-                  Generate a config file and QR code for your first device.
+                  {peerRequiredOnCreate
+                    ? "VyOS 1.4 requires at least one peer when creating an interface."
+                    : "Generate a config file and QR code for your first device."}
                 </p>
               </div>
             </div>

--- a/frontend/src/lib/api/wireguard.ts
+++ b/frontend/src/lib/api/wireguard.ts
@@ -43,6 +43,7 @@ export interface WireGuardCapabilities {
     wireguard: { supported: boolean; description: string };
     key_generation: { supported: boolean; description: string };
     per_client_thread: { supported: boolean; description: string };
+    peer_required_on_create: { supported: boolean; description: string };
   };
   version_notes: {
     full_support: boolean;
@@ -58,6 +59,11 @@ export interface VyOSResponse {
 export interface WireGuardBatchOperation {
   op: string;
   value?: string;
+}
+
+export interface PeerBatchGroup {
+  peer: string;
+  operations: WireGuardBatchOperation[];
 }
 
 export interface KeypairResult {
@@ -138,12 +144,17 @@ class WireGuardService {
    */
   async interfaceBatch(
     interfaceName: string,
-    operations: WireGuardBatchOperation[]
+    operations: WireGuardBatchOperation[],
+    peers?: PeerBatchGroup[]
   ): Promise<VyOSResponse> {
-    const result = await apiClient.post<VyOSResponse>("/vyos/vpn/wireguard/interface/batch", {
+    const payload: Record<string, unknown> = {
       interface: interfaceName,
       operations,
-    });
+    };
+    if (peers && peers.length > 0) {
+      payload.peers = peers;
+    }
+    const result = await apiClient.post<VyOSResponse>("/vyos/vpn/wireguard/interface/batch", payload);
     await this.refreshConfig();
     return result;
   }
@@ -160,6 +171,13 @@ class WireGuardService {
     mtu?: string;
     per_client_thread?: boolean;
     mss_clamping?: boolean;
+    initial_peers?: Array<{
+      name: string;
+      public_key: string;
+      allowed_ips: string[];
+      preshared_key?: string;
+      persistent_keepalive?: string;
+    }>;
   }): Promise<VyOSResponse> {
     const operations: WireGuardBatchOperation[] = [];
 
@@ -191,7 +209,28 @@ class WireGuardService {
       operations.push({ op: "set_interface_mss_clamping" });
     }
 
-    return this.interfaceBatch(config.name, operations);
+    // Build peer batch groups for atomic commit (required on VyOS 1.4)
+    let peerGroups: PeerBatchGroup[] | undefined;
+    if (config.initial_peers && config.initial_peers.length > 0) {
+      peerGroups = config.initial_peers.map((peer) => {
+        const peerOps: WireGuardBatchOperation[] = [
+          { op: "create_peer" },
+          { op: "set_peer_public_key", value: peer.public_key },
+        ];
+        for (const ip of peer.allowed_ips) {
+          peerOps.push({ op: "set_peer_allowed_ips", value: ip });
+        }
+        if (peer.preshared_key) {
+          peerOps.push({ op: "set_peer_preshared_key", value: peer.preshared_key });
+        }
+        if (peer.persistent_keepalive) {
+          peerOps.push({ op: "set_peer_persistent_keepalive", value: peer.persistent_keepalive });
+        }
+        return { peer: peer.name, operations: peerOps };
+      });
+    }
+
+    return this.interfaceBatch(config.name, operations, peerGroups);
   }
 
   /**


### PR DESCRIPTION
  - Fix VyOS 1.4 requiring at least one peer when creating a WireGuard interface by adding atomic interface+peer batch support. The interface batch endpoint now accepts an optional `peers` field so both can be committed in a single transaction.
  - Add `peer_required_on_create` capability flag for VyOS 1.4 so the frontend can enforce the constraint.
  - Quick Setup Wizard now generates both keypairs upfront and sends interface + peer in one batch on all versions.
  - Block standalone interface creation on VyOS 1.4 in CreateInterfaceModal with a notice directing users to the Quick Setup Wizard.
  - Fix _gql_result crash in show.py when GraphQL returns {"data": None} for WireGuardConfig query, causing repeated "wireguard-peers error" in logs.
  - Fix layout gap caused by UnsavedChangesBanner using fixed positioning with spacer divs that overlapped the header. Banners now use normal document flow within a flex column layout.
  - Move search bar from blank header into sidebar to eliminate the empty header bar that appeared as dead space.