### PR TITLE
Replace banner polling with SSE for real-time status updates

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -64,10 +64,13 @@ from routers.vxlan import vxlan as vxlan_router
 from routers.nhrp import nhrp as nhrp_router
 from routers.pim import pim as pim_router
 from routers import version as version_router
+from routers import events as events_router
+from routers.events import start_poller, stop_poller
 
 # Global variables
 db_pool: Optional[asyncpg.Pool] = None
 cleanup_task: Optional[asyncio.Task] = None
+poller_task: Optional[asyncio.Task] = None
 
 # Configuration
 SESSION_INACTIVITY_TIMEOUT = int(os.getenv("SESSION_INACTIVITY_TIMEOUT", "30"))  # Minutes
@@ -145,7 +148,7 @@ async def lifespan(app: FastAPI):
     FastAPI lifespan event handler.
     Manages database connections and application startup/shutdown.
     """
-    global db_pool, cleanup_task
+    global db_pool, cleanup_task, poller_task
 
     # Startup
     print("\n" + "=" * 60)
@@ -182,6 +185,10 @@ async def lifespan(app: FastAPI):
     else:
         print("  ⚠ Session cleanup task not started (no database)")
 
+    # Start SSE banner poller
+    poller_task = start_poller(app.state)
+    print("  ✓ SSE banner poller started")
+
     print("\n" + "=" * 60)
     print("✓ API Ready")
     print("=" * 60)
@@ -193,6 +200,15 @@ async def lifespan(app: FastAPI):
 
     # Shutdown
     print("\n🛑 Shutting down VyManager API...")
+
+    # Stop SSE banner poller
+    stop_poller()
+    if poller_task and not poller_task.done():
+        try:
+            await poller_task
+        except asyncio.CancelledError:
+            pass
+        print("  ✓ SSE banner poller stopped")
 
     # Stop cleanup task
     if cleanup_task and not cleanup_task.done():
@@ -317,6 +333,7 @@ app.include_router(vxlan_router.router)
 app.include_router(nhrp_router.router)
 app.include_router(pim_router.router)
 app.include_router(version_router.router)
+app.include_router(events_router.router)
 
 
 # ============================================================================

--- a/backend/events/event_manager.py
+++ b/backend/events/event_manager.py
@@ -1,0 +1,172 @@
+"""
+SSE Event Manager for Banner Status Updates
+
+Manages per-instance event streams so the frontend receives instant
+updates for config diff, commit-confirm, and power status changes
+instead of polling.
+
+Two update paths:
+  1. Immediate — mutation endpoints call emit() after changes.
+  2. Background — a poller detects external changes (e.g. CLI edits)
+     and emits only when state actually differs from the last push.
+"""
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, AsyncGenerator, Dict, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# Event types
+# ============================================================================
+
+EVENT_CONFIG_DIFF = "config_diff"
+EVENT_COMMIT_CONFIRM = "commit_confirm"
+EVENT_POWER_STATUS = "power_status"
+
+
+# ============================================================================
+# Per-instance subscriber management
+# ============================================================================
+
+@dataclass
+class _InstanceChannel:
+    """Holds the subscribers and last-known state for one VyOS instance."""
+    subscribers: Set[asyncio.Queue] = field(default_factory=set)
+    last_state: Dict[str, Any] = field(default_factory=dict)
+
+
+class EventManager:
+    """
+    Central pub/sub hub for banner SSE events.
+
+    Keyed by instance_id so each VyOS device has its own channel.
+    """
+
+    def __init__(self) -> None:
+        self._channels: Dict[str, _InstanceChannel] = {}
+        self._poller_task: Optional[asyncio.Task] = None
+        self._poll_interval: int = 10  # seconds
+
+    # ------------------------------------------------------------------
+    # Subscribe / unsubscribe
+    # ------------------------------------------------------------------
+
+    def subscribe(self, instance_id: str) -> asyncio.Queue:
+        """Add a new subscriber for an instance, returning its queue."""
+        channel = self._channels.setdefault(instance_id, _InstanceChannel())
+        queue: asyncio.Queue = asyncio.Queue()
+        channel.subscribers.add(queue)
+        logger.info("SSE subscriber added for instance %s (total: %d)",
+                     instance_id, len(channel.subscribers))
+        return queue
+
+    def unsubscribe(self, instance_id: str, queue: asyncio.Queue) -> None:
+        """Remove a subscriber queue."""
+        channel = self._channels.get(instance_id)
+        if channel:
+            channel.subscribers.discard(queue)
+            logger.info("SSE subscriber removed for instance %s (total: %d)",
+                         instance_id, len(channel.subscribers))
+            if not channel.subscribers:
+                del self._channels[instance_id]
+
+    # ------------------------------------------------------------------
+    # Emit events
+    # ------------------------------------------------------------------
+
+    def emit(self, instance_id: str, event_type: str, data: Any) -> None:
+        """
+        Push an event to all subscribers of an instance.
+
+        Called from mutation endpoints for instant updates and from the
+        background poller when external changes are detected.
+        """
+        channel = self._channels.get(instance_id)
+        if not channel or not channel.subscribers:
+            return
+
+        payload = json.dumps({"type": event_type, "data": data})
+
+        dead_queues: list[asyncio.Queue] = []
+        for queue in channel.subscribers:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                dead_queues.append(queue)
+
+        for q in dead_queues:
+            channel.subscribers.discard(q)
+
+    def emit_all_banner_state(
+        self,
+        instance_id: str,
+        config_diff: Any,
+        commit_confirm: Any,
+        power_status: Any,
+    ) -> None:
+        """Emit a combined banner_state event with all three payloads."""
+        channel = self._channels.get(instance_id)
+        if not channel or not channel.subscribers:
+            return
+
+        payload = json.dumps({
+            "type": "banner_state",
+            "data": {
+                "config_diff": config_diff,
+                "commit_confirm": commit_confirm,
+                "power_status": power_status,
+            },
+        })
+
+        dead_queues: list[asyncio.Queue] = []
+        for queue in channel.subscribers:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                dead_queues.append(queue)
+
+        for q in dead_queues:
+            channel.subscribers.discard(q)
+
+    # ------------------------------------------------------------------
+    # Background poller
+    # ------------------------------------------------------------------
+
+    def update_last_state(self, instance_id: str, key: str, value: Any) -> bool:
+        """
+        Update cached state for an instance.
+        Returns True if the value changed (i.e. an event should be emitted).
+        """
+        channel = self._channels.get(instance_id)
+        if not channel:
+            return False
+
+        old = channel.last_state.get(key)
+        serialized_new = json.dumps(value, sort_keys=True, default=str)
+        serialized_old = json.dumps(old, sort_keys=True, default=str) if old is not None else None
+
+        if serialized_new != serialized_old:
+            channel.last_state[key] = value
+            return True
+        return False
+
+    def get_subscribed_instance_ids(self) -> list[str]:
+        """Return instance IDs that have at least one subscriber."""
+        return [iid for iid, ch in self._channels.items() if ch.subscribers]
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def has_subscribers(self, instance_id: str) -> bool:
+        channel = self._channels.get(instance_id)
+        return bool(channel and channel.subscribers)
+
+
+# Singleton
+event_manager = EventManager()

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -48,6 +48,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
         "/vyos/config/snapshots",
         "/session/current",
         "/vyos/power/status",  # Polls for scheduled reboot/poweroff status
+        "/vyos/events/banners",  # SSE stream - long-lived connection
     }
 
     def __init__(self, app):

--- a/backend/routers/config/config.py
+++ b/backend/routers/config/config.py
@@ -15,6 +15,7 @@ from rbac_permissions import FeatureGroup
 import commit_confirm_state
 import json
 import logging
+from events.event_manager import event_manager, EVENT_CONFIG_DIFF, EVENT_COMMIT_CONFIRM
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/config", tags=["config"])
@@ -228,6 +229,9 @@ async def save_config(request: Request, file: Optional[str] = None):
         current_config = await run_in_threadpool(service.get_full_config, refresh=True)
         _saved_config_snapshots[instance_id] = current_config
 
+        # Notify SSE subscribers that diff has changed (now empty after save)
+        event_manager.emit(instance_id, EVENT_CONFIG_DIFF, None)
+
         return SaveConfigResponse(
             success=True,
             message="Configuration saved successfully to disk"
@@ -322,6 +326,10 @@ async def confirm_commit(request: Request):
         # Refresh the config cache so the unsaved-changes banner reflects
         # the new running config, prompting the user to save when ready.
         await run_in_threadpool(service.get_full_config, refresh=True)
+
+        # Notify SSE subscribers
+        event_manager.emit(instance_id, EVENT_COMMIT_CONFIRM, None)
+        event_manager.emit(instance_id, EVENT_CONFIG_DIFF, None)
 
         return SaveConfigResponse(
             success=True,

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -1,0 +1,369 @@
+"""
+SSE Events Router
+
+Provides a Server-Sent Events endpoint that streams banner status updates
+(config diff, commit-confirm, power status) to connected clients in real time.
+
+Replaces frontend polling of /vyos/config/diff, /vyos/config/commit-confirm/status,
+and /vyos/power/status with a single persistent connection.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from starlette.concurrency import run_in_threadpool
+
+from session_vyos_service import get_session_vyos_service, _session_device_registry
+from fastapi_permissions import require_read_permission
+from rbac_permissions import FeatureGroup
+from events.event_manager import (
+    event_manager,
+    EVENT_CONFIG_DIFF,
+    EVENT_COMMIT_CONFIRM,
+    EVENT_POWER_STATUS,
+)
+import commit_confirm_state
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/vyos/events", tags=["events"])
+
+# Background poller task reference
+_poller_task: Optional[asyncio.Task] = None
+POLL_INTERVAL = 10  # seconds
+
+
+# ============================================================================
+# SSE Endpoint
+# ============================================================================
+
+@router.get("/banners")
+async def banner_events(request: Request):
+    """
+    SSE stream for banner status updates.
+
+    Sends events when config diff, commit-confirm, or power status changes.
+    The client receives instant updates from mutations and periodic checks
+    for external changes (e.g. CLI config edits).
+    """
+    await require_read_permission(request, FeatureGroup.CONFIGURATION)
+
+    instance_id = request.state.instance["id"]
+    queue = event_manager.subscribe(instance_id)
+
+    async def event_stream():
+        try:
+            # Send initial state immediately on connect
+            initial = await _gather_banner_state(request)
+            yield _format_sse("banner_state", initial)
+
+            while True:
+                try:
+                    # Wait for events with a timeout for keepalive
+                    payload = await asyncio.wait_for(queue.get(), timeout=30)
+                    yield f"data: {payload}\n\n"
+                except asyncio.TimeoutError:
+                    # Send keepalive comment to prevent connection timeout
+                    yield ": keepalive\n\n"
+                except asyncio.CancelledError:
+                    break
+        except asyncio.CancelledError:
+            pass
+        finally:
+            event_manager.unsubscribe(instance_id, queue)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+def _format_sse(event_type: str, data: Any) -> str:
+    """Format a payload as an SSE data frame."""
+    payload = json.dumps({"type": event_type, "data": data}, default=str)
+    return f"data: {payload}\n\n"
+
+
+# ============================================================================
+# State Gathering (shared by SSE initial push and background poller)
+# ============================================================================
+
+async def _gather_banner_state(request: Request) -> Dict[str, Any]:
+    """Collect current config_diff, commit_confirm, and power_status for an instance."""
+    instance_id = request.state.instance["id"]
+
+    config_diff = await _get_config_diff_state(request)
+    cc_status = _get_commit_confirm_state(instance_id)
+    power = await _get_power_status_state(request)
+
+    return {
+        "config_diff": config_diff,
+        "commit_confirm": cc_status,
+        "power_status": power,
+    }
+
+
+async def _get_config_diff_state(request: Request) -> Dict[str, Any]:
+    """Get config diff state without going through the HTTP endpoint."""
+    from routers.config.config import _saved_config_snapshots, deep_diff
+
+    try:
+        service = get_session_vyos_service(request)
+        instance_id = request.state.instance["id"]
+        current_config = await run_in_threadpool(service.get_full_config, refresh=True)
+
+        if instance_id not in _saved_config_snapshots:
+            _saved_config_snapshots[instance_id] = current_config
+            return {
+                "has_changes": False,
+                "added": {},
+                "removed": {},
+                "modified": {},
+                "summary": {"added": 0, "removed": 0, "modified": 0},
+            }
+
+        added, removed, modified = deep_diff(current_config, _saved_config_snapshots[instance_id])
+        has_changes = bool(added or removed or modified)
+
+        return {
+            "has_changes": has_changes,
+            "added": added,
+            "removed": removed,
+            "modified": modified,
+            "summary": {
+                "added": len(added),
+                "removed": len(removed),
+                "modified": len(modified),
+            },
+        }
+    except Exception:
+        logger.exception("Failed to get config diff for SSE")
+        return {
+            "has_changes": False,
+            "added": {},
+            "removed": {},
+            "modified": {},
+            "summary": {"added": 0, "removed": 0, "modified": 0},
+        }
+
+
+def _get_commit_confirm_state(instance_id: str) -> Dict[str, Any]:
+    """Get commit-confirm state from the in-memory tracker."""
+    session = commit_confirm_state.get_active(instance_id)
+    if session is None:
+        return {"active": False}
+    return session.to_dict()
+
+
+async def _get_power_status_state(request: Request) -> Dict[str, Any]:
+    """Get power status from the database."""
+    try:
+        instance_id = request.state.instance["id"]
+        db_pool = request.app.state.db_pool
+
+        if not db_pool:
+            return {"scheduled": False}
+
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                """
+                DELETE FROM scheduled_power_actions
+                WHERE "instanceId" = $1
+                  AND "scheduledTime" < NOW()
+                """,
+                instance_id,
+            )
+
+            result = await conn.fetchrow(
+                """
+                SELECT "actionType", "scheduledTime", "scheduledBy", "scheduledByName",
+                       cancelled, "cancelledBy", "cancelledByName"
+                FROM scheduled_power_actions
+                WHERE "instanceId" = $1
+                  AND "scheduledTime" > NOW()
+                ORDER BY "createdAt" DESC
+                LIMIT 1
+                """,
+                instance_id,
+            )
+
+            if not result:
+                return {"scheduled": False}
+
+            scheduled_time = result["scheduledTime"]
+            if scheduled_time and (not hasattr(scheduled_time, 'tzinfo') or scheduled_time.tzinfo is None):
+                scheduled_time = scheduled_time.replace(tzinfo=ZoneInfo("UTC"))
+
+            return {
+                "scheduled": True,
+                "action_type": result["actionType"],
+                "scheduled_time": scheduled_time.isoformat() if scheduled_time else None,
+                "scheduled_by": result["scheduledBy"],
+                "scheduled_by_name": result["scheduledByName"],
+                "cancelled": result["cancelled"],
+                "cancelled_by": result["cancelledBy"],
+                "cancelled_by_name": result["cancelledByName"],
+            }
+    except Exception:
+        logger.exception("Failed to get power status for SSE")
+        return {"scheduled": False}
+
+
+# ============================================================================
+# Background Poller
+# ============================================================================
+
+async def _poll_banner_state_for_instance(
+    instance_id: str,
+    app_state: Any,
+) -> None:
+    """
+    Poll the current banner state for a single instance and emit events
+    only if the state has changed since the last poll.
+    """
+    from routers.config.config import _saved_config_snapshots, deep_diff
+
+    # --- Config diff ---
+    try:
+        service = _session_device_registry.get(instance_id)
+        current_config = await run_in_threadpool(service.get_full_config, refresh=True)
+
+        if instance_id not in _saved_config_snapshots:
+            _saved_config_snapshots[instance_id] = current_config
+            config_diff_data = {
+                "has_changes": False,
+                "added": {},
+                "removed": {},
+                "modified": {},
+                "summary": {"added": 0, "removed": 0, "modified": 0},
+            }
+        else:
+            added, removed, modified = deep_diff(current_config, _saved_config_snapshots[instance_id])
+            has_changes = bool(added or removed or modified)
+            config_diff_data = {
+                "has_changes": has_changes,
+                "added": added,
+                "removed": removed,
+                "modified": modified,
+                "summary": {
+                    "added": len(added),
+                    "removed": len(removed),
+                    "modified": len(modified),
+                },
+            }
+
+        if event_manager.update_last_state(instance_id, EVENT_CONFIG_DIFF, config_diff_data):
+            event_manager.emit(instance_id, EVENT_CONFIG_DIFF, config_diff_data)
+    except Exception:
+        logger.debug("Poller: failed to get config diff for instance %s", instance_id)
+
+    # --- Commit confirm ---
+    try:
+        cc_data = _get_commit_confirm_state(instance_id)
+        if event_manager.update_last_state(instance_id, EVENT_COMMIT_CONFIRM, cc_data):
+            event_manager.emit(instance_id, EVENT_COMMIT_CONFIRM, cc_data)
+    except Exception:
+        logger.debug("Poller: failed to get commit-confirm for instance %s", instance_id)
+
+    # --- Power status ---
+    try:
+        db_pool = app_state.db_pool
+        if db_pool:
+            async with db_pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    DELETE FROM scheduled_power_actions
+                    WHERE "instanceId" = $1
+                      AND "scheduledTime" < NOW()
+                    """,
+                    instance_id,
+                )
+
+                result = await conn.fetchrow(
+                    """
+                    SELECT "actionType", "scheduledTime", "scheduledBy", "scheduledByName",
+                           cancelled, "cancelledBy", "cancelledByName"
+                    FROM scheduled_power_actions
+                    WHERE "instanceId" = $1
+                      AND "scheduledTime" > NOW()
+                    ORDER BY "createdAt" DESC
+                    LIMIT 1
+                    """,
+                    instance_id,
+                )
+
+                if not result:
+                    power_data = {"scheduled": False}
+                else:
+                    scheduled_time = result["scheduledTime"]
+                    if scheduled_time and (not hasattr(scheduled_time, 'tzinfo') or scheduled_time.tzinfo is None):
+                        scheduled_time = scheduled_time.replace(tzinfo=ZoneInfo("UTC"))
+                    power_data = {
+                        "scheduled": True,
+                        "action_type": result["actionType"],
+                        "scheduled_time": scheduled_time.isoformat() if scheduled_time else None,
+                        "scheduled_by": result["scheduledBy"],
+                        "scheduled_by_name": result["scheduledByName"],
+                        "cancelled": result["cancelled"],
+                        "cancelled_by": result["cancelledBy"],
+                        "cancelled_by_name": result["cancelledByName"],
+                    }
+
+                if event_manager.update_last_state(instance_id, EVENT_POWER_STATUS, power_data):
+                    event_manager.emit(instance_id, EVENT_POWER_STATUS, power_data)
+    except Exception:
+        logger.debug("Poller: failed to get power status for instance %s", instance_id)
+
+
+async def start_banner_poller(app_state: Any) -> None:
+    """
+    Background task that periodically checks banner state for all instances
+    with active SSE subscribers and emits events when state changes.
+    """
+    logger.info("Banner SSE poller started (interval: %ds)", POLL_INTERVAL)
+
+    while True:
+        try:
+            await asyncio.sleep(POLL_INTERVAL)
+
+            instance_ids = event_manager.get_subscribed_instance_ids()
+            if not instance_ids:
+                continue
+
+            # Poll each instance concurrently
+            tasks = [
+                _poll_banner_state_for_instance(iid, app_state)
+                for iid in instance_ids
+            ]
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        except asyncio.CancelledError:
+            logger.info("Banner SSE poller stopped")
+            break
+        except Exception:
+            logger.exception("Banner poller error")
+
+
+def start_poller(app_state: Any) -> asyncio.Task:
+    """Start the background poller and return the task."""
+    global _poller_task
+    _poller_task = asyncio.create_task(start_banner_poller(app_state))
+    return _poller_task
+
+
+def stop_poller() -> None:
+    """Cancel the background poller task."""
+    global _poller_task
+    if _poller_task and not _poller_task.done():
+        _poller_task.cancel()

--- a/backend/routers/power.py
+++ b/backend/routers/power.py
@@ -20,6 +20,7 @@ import uuid
 from session_vyos_service import get_session_vyos_service
 from fastapi_permissions import require_read_permission, require_write_permission
 from rbac_permissions import FeatureGroup
+from events.event_manager import event_manager, EVENT_POWER_STATUS
 import logging
 logger = logging.getLogger(__name__)
 
@@ -288,6 +289,9 @@ async def reboot_system(request: Request, body: PowerActionRequest):
     if scheduled_time:
         scheduled_time_utc = scheduled_time.replace(tzinfo=ZoneInfo("UTC"))
 
+    # Notify SSE subscribers of power status change
+    event_manager.emit(instance_id, EVENT_POWER_STATUS, None)
+
     return PowerActionResponse(
         success=True, message=message, scheduled_time=scheduled_time_utc
     )
@@ -462,6 +466,9 @@ async def poweroff_system(request: Request, body: PowerActionRequest):
     scheduled_time_utc = None
     if scheduled_time:
         scheduled_time_utc = scheduled_time.replace(tzinfo=ZoneInfo("UTC"))
+
+    # Notify SSE subscribers of power status change
+    event_manager.emit(instance_id, EVENT_POWER_STATUS, None)
 
     return PowerActionResponse(
         success=True, message=message, scheduled_time=scheduled_time_utc

--- a/backend/vyos_service.py
+++ b/backend/vyos_service.py
@@ -13,6 +13,7 @@ import requests as _requests
 from pyvyos import VyDevice
 from pyvyos.core.rest_client import ApiResponse
 import commit_confirm_state
+from events.event_manager import event_manager, EVENT_CONFIG_DIFF, EVENT_COMMIT_CONFIRM
 from vyos_builders import (
     EthernetBatchBuilder,
     DummyBatchBuilder,
@@ -148,7 +149,10 @@ class VyOSService:
             raise ValueError("Cannot execute empty batch")
 
         operations = batch.get_operations()
-        return self.device.configure_multiple_op(op_path=operations)
+        response = self.device.configure_multiple_op(op_path=operations)
+        if response.status == 200 and self.config.instance_id:
+            event_manager.emit(self.config.instance_id, EVENT_CONFIG_DIFF, None)
+        return response
 
     def execute_batch_with_confirm(
         self,
@@ -225,6 +229,8 @@ class VyOSService:
             body = resp.json()
             if body.get("success"):
                 commit_confirm_state.set_active(instance_id, confirm_time_minutes, action)
+                event_manager.emit(instance_id, EVENT_CONFIG_DIFF, None)
+                event_manager.emit(instance_id, EVENT_COMMIT_CONFIRM, None)
                 return ApiResponse(status=200, request={}, result=body.get("data") or {}, error=False)
             else:
                 error_msg = body.get("error", "Unknown error from VyOS API")
@@ -267,6 +273,8 @@ class VyOSService:
             body = resp.json()
             if body.get("success"):
                 commit_confirm_state.clear(instance_id)
+                event_manager.emit(instance_id, EVENT_COMMIT_CONFIRM, None)
+                event_manager.emit(instance_id, EVENT_CONFIG_DIFF, None)
                 return ApiResponse(status=200, request={}, result=body.get("data") or {}, error=False)
             else:
                 error_msg = body.get("error", "Unknown error from VyOS API")

--- a/frontend/src/components/config/UnsavedChangesBanner.tsx
+++ b/frontend/src/components/config/UnsavedChangesBanner.tsx
@@ -9,9 +9,14 @@ import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/useToast";
 import { ApiError } from "@/lib/types/api";
 
-export function UnsavedChangesBanner() {
+interface UnsavedChangesBannerProps {
+  configDiff: ConfigDiff | null;
+  commitConfirm: CommitConfirmStatus | null;
+}
+
+export function UnsavedChangesBanner({ configDiff, commitConfirm }: UnsavedChangesBannerProps) {
   const [diff, setDiff] = useState<ConfigDiff | null>(null);
-  const [commitConfirm, setCommitConfirm] = useState<CommitConfirmStatus | null>(null);
+  const [cc, setCc] = useState<CommitConfirmStatus | null>(null);
   const [confirming, setConfirming] = useState(false);
   const [saving, setSaving] = useState(false);
   const [showDiffModal, setShowDiffModal] = useState(false);
@@ -21,9 +26,18 @@ export function UnsavedChangesBanner() {
   const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const { toast } = useToast();
 
+  // Sync SSE-driven props into local state
+  useEffect(() => {
+    if (configDiff !== null) setDiff(configDiff);
+  }, [configDiff]);
+
+  useEffect(() => {
+    if (commitConfirm !== null) setCc(commitConfirm);
+  }, [commitConfirm]);
+
   // Manage the per-second tick for the countdown
   useEffect(() => {
-    if (commitConfirm?.active) {
+    if (cc?.active) {
       tickRef.current = setInterval(() => setTick((t) => t + 1), 1000);
     } else {
       if (tickRef.current) {
@@ -34,30 +48,7 @@ export function UnsavedChangesBanner() {
     return () => {
       if (tickRef.current) clearInterval(tickRef.current);
     };
-  }, [commitConfirm?.active]);
-
-  // Poll commit-confirm status every 5 s, config diff every 10 s
-  useEffect(() => {
-    const checkStatus = async () => {
-      try {
-        const [diffResult, ccStatus] = await Promise.all([
-          configService.getDiff(),
-          configService.getCommitConfirmStatus(),
-        ]);
-        setDiff(diffResult);
-        setCommitConfirm(ccStatus);
-        setError(null);
-      } catch (err) {
-        const msg = (err as ApiError).message || "Failed to check configuration status";
-        console.error("Banner status check failed:", msg);
-        setError(msg);
-      }
-    };
-
-    checkStatus();
-    const interval = setInterval(checkStatus, 5000);
-    return () => clearInterval(interval);
-  }, []);
+  }, [cc?.active]);
 
   const handleConfirm = async () => {
     setConfirming(true);
@@ -71,7 +62,8 @@ export function UnsavedChangesBanner() {
         return;
       }
       toast.success("Changes Confirmed", "Your changes are live. Save configuration when ready.");
-      setCommitConfirm({ active: false });
+      setCc({ active: false });
+      // SSE will push updated diff shortly; also fetch eagerly
       const newDiff = await configService.getDiff();
       setDiff(newDiff);
     } catch (err) {
@@ -95,6 +87,7 @@ export function UnsavedChangesBanner() {
         return;
       }
       toast.success("Configuration Saved", "Your changes have been written to disk successfully.");
+      // SSE will push updated diff shortly; also fetch eagerly
       const newDiff = await configService.getDiff();
       setDiff(newDiff);
       setError(null);
@@ -109,8 +102,8 @@ export function UnsavedChangesBanner() {
 
   // Calculate live seconds remaining from expires_at (more accurate than polled value)
   const secondsRemaining = (() => {
-    if (!commitConfirm?.active || !commitConfirm.expires_at) return 0;
-    const diff = new Date(commitConfirm.expires_at).getTime() - Date.now();
+    if (!cc?.active || !cc.expires_at) return 0;
+    const diff = new Date(cc.expires_at).getTime() - Date.now();
     return Math.max(0, Math.floor(diff / 1000));
   })();
 
@@ -121,7 +114,7 @@ export function UnsavedChangesBanner() {
   };
 
   // ── Commit-confirm active: show countdown banner (highest priority) ──
-  if (commitConfirm?.active) {
+  if (cc?.active) {
     const isUrgent = secondsRemaining <= 60;
     return (
       <>
@@ -143,11 +136,11 @@ export function UnsavedChangesBanner() {
                   Commit-Confirm Active — confirm before changes revert
                 </p>
                 <p className="text-xs text-white/80">
-                  Auto-{commitConfirm.action ?? "reload"} in{" "}
+                  Auto-{cc.action ?? "reload"} in{" "}
                   <span className={cn("font-mono font-bold", isUrgent && "text-white")}>
                     {formatCountdown(secondsRemaining)}
                   </span>
-                  {" "}· {commitConfirm.confirm_time_minutes} min window
+                  {" "}· {cc.confirm_time_minutes} min window
                 </p>
               </div>
             </div>

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -10,6 +10,7 @@ import { useSessionStore } from "@/store/session-store";
 import { Loader2 } from "lucide-react";
 import { UnifiedView } from "../ui/unified-view";
 import { useUnifiedView } from "@/contexts/UnifiedViewContext";
+import { useBannerEvents } from "@/hooks/useBannerEvents";
 
 
 export function AppLayout({ children }: { children: React.ReactNode }) {
@@ -17,6 +18,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const { activeSession, loadSession } = useSessionStore();
   const [isChecking, setIsChecking] = useState(true);
   const { unifiedViewData, closeUnifiedView } = useUnifiedView();
+  const bannerEvents = useBannerEvents();
 
   useEffect(() => {
     const checkSession = async () => {
@@ -66,8 +68,8 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
       <div className="flex-1 flex flex-col overflow-hidden">
         {/* Main Content */}
         <main className="flex-1 flex flex-col overflow-hidden relative">
-          <PowerActionBanner />
-          <UnsavedChangesBanner />
+          <PowerActionBanner powerStatus={bannerEvents.data.powerStatus} />
+          <UnsavedChangesBanner configDiff={bannerEvents.data.configDiff} commitConfirm={bannerEvents.data.commitConfirm} />
           <div className="flex-1 min-h-0 overflow-y-auto">
             {children}
           </div>

--- a/frontend/src/components/system/PowerActionBanner.tsx
+++ b/frontend/src/components/system/PowerActionBanner.tsx
@@ -5,38 +5,31 @@ import { Button } from "@/components/ui/button";
 import { AlertTriangle, Power, PowerOff, X } from "lucide-react";
 import { powerService, PowerStatusResponse } from "@/lib/api/power";
 
-export function PowerActionBanner() {
+interface PowerActionBannerProps {
+  powerStatus: PowerStatusResponse | null;
+}
+
+export function PowerActionBanner({ powerStatus }: PowerActionBannerProps) {
   const [status, setStatus] = useState<PowerStatusResponse | null>(null);
   const [countdown, setCountdown] = useState<string>("");
   const [cancelling, setCancelling] = useState(false);
   const [showCancelledMessage, setShowCancelledMessage] = useState(false);
 
-  // Poll status every 5 seconds
+  // Sync SSE-driven props into local state
   useEffect(() => {
-    const checkStatus = async () => {
-      try {
-        const result = await powerService.getStatus();
-        setStatus(result);
+    if (powerStatus === null) return;
 
-        // If action was just cancelled, show message briefly
-        if (result.cancelled && !showCancelledMessage) {
-          setShowCancelledMessage(true);
-          setTimeout(() => {
-            setShowCancelledMessage(false);
-            setStatus(null);
-          }, 5000); // Show for 5 seconds
-        }
-      } catch (err) {
-        // Ignore errors (user might not have active session)
+    setStatus(powerStatus);
+
+    // If action was just cancelled, show message briefly
+    if (powerStatus.cancelled && !showCancelledMessage) {
+      setShowCancelledMessage(true);
+      setTimeout(() => {
+        setShowCancelledMessage(false);
         setStatus(null);
-      }
-    };
-
-    checkStatus();
-    const interval = setInterval(checkStatus, 5000); // Poll every 5 seconds
-
-    return () => clearInterval(interval);
-  }, [showCancelledMessage]);
+      }, 5000);
+    }
+  }, [powerStatus, showCancelledMessage]);
 
   // Update countdown every second
   useEffect(() => {
@@ -69,7 +62,7 @@ export function PowerActionBanner() {
     };
 
     updateCountdown();
-    const interval = setInterval(updateCountdown, 1000); // Update every second
+    const interval = setInterval(updateCountdown, 1000);
 
     return () => clearInterval(interval);
   }, [status]);
@@ -85,7 +78,7 @@ export function PowerActionBanner() {
         await powerService.poweroff({ action: "cancel" });
       }
 
-      // Immediately check status to show cancelled message
+      // SSE will push updated status shortly; also fetch eagerly
       const result = await powerService.getStatus();
       setStatus(result);
       setShowCancelledMessage(true);

--- a/frontend/src/hooks/useBannerEvents.ts
+++ b/frontend/src/hooks/useBannerEvents.ts
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import type { ConfigDiff, CommitConfirmStatus } from "@/lib/api/config";
+import type { PowerStatusResponse } from "@/lib/api/power";
+import { configService } from "@/lib/api/config";
+import { powerService } from "@/lib/api/power";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type BannerSSEStatus = "disconnected" | "connecting" | "connected" | "error";
+
+export interface BannerState {
+  configDiff: ConfigDiff | null;
+  commitConfirm: CommitConfirmStatus | null;
+  powerStatus: PowerStatusResponse | null;
+}
+
+export interface BannerSSEState {
+  status: BannerSSEStatus;
+  data: BannerState;
+}
+
+interface SSEEvent {
+  type: string;
+  data: {
+    config_diff?: ConfigDiff | null;
+    commit_confirm?: CommitConfirmStatus | null;
+    power_status?: PowerStatusResponse | null;
+  } | null;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+const RECONNECT_DELAY_MS = 3000;
+
+export function useBannerEvents(): BannerSSEState {
+  const [status, setStatus] = useState<BannerSSEStatus>("disconnected");
+  const [data, setData] = useState<BannerState>({
+    configDiff: null,
+    commitConfirm: null,
+    powerStatus: null,
+  });
+  const esRef = useRef<EventSource | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Fetch individual pieces of state on demand (when mutation signals arrive
+  // with null data, meaning "something changed, go re-fetch")
+  const refreshConfigDiff = useCallback(async () => {
+    try {
+      const diff = await configService.getDiff();
+      setData((prev) => ({ ...prev, configDiff: diff }));
+    } catch {
+      // Ignore — next SSE push or poll will catch up
+    }
+  }, []);
+
+  const refreshCommitConfirm = useCallback(async () => {
+    try {
+      const cc = await configService.getCommitConfirmStatus();
+      setData((prev) => ({ ...prev, commitConfirm: cc }));
+    } catch {
+      // Ignore
+    }
+  }, []);
+
+  const refreshPowerStatus = useCallback(async () => {
+    try {
+      const ps = await powerService.getStatus();
+      setData((prev) => ({ ...prev, powerStatus: ps }));
+    } catch {
+      // Ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+
+    const connect = () => {
+      if (disposed) return;
+
+      setStatus("connecting");
+
+      const es = new EventSource("/api/vyos/events/banners");
+      esRef.current = es;
+
+      es.onopen = () => {
+        if (!disposed) {
+          setStatus("connected");
+        }
+      };
+
+      es.onmessage = (event: MessageEvent) => {
+        if (disposed) return;
+
+        try {
+          const parsed = JSON.parse(event.data) as SSEEvent;
+
+          switch (parsed.type) {
+            case "banner_state": {
+              // Full state push (initial connect or poller detected change)
+              const d = parsed.data;
+              if (d) {
+                setData({
+                  configDiff: d.config_diff ?? null,
+                  commitConfirm: d.commit_confirm ?? null,
+                  powerStatus: d.power_status ?? null,
+                });
+              }
+              break;
+            }
+            case "config_diff": {
+              // Mutation signal — data may be null (re-fetch) or contain actual state
+              if (parsed.data === null) {
+                refreshConfigDiff();
+              } else {
+                const d = parsed.data;
+                if (d.config_diff) {
+                  setData((prev) => ({ ...prev, configDiff: d.config_diff ?? null }));
+                }
+              }
+              break;
+            }
+            case "commit_confirm": {
+              if (parsed.data === null) {
+                refreshCommitConfirm();
+              } else {
+                const d = parsed.data;
+                if (d.commit_confirm) {
+                  setData((prev) => ({ ...prev, commitConfirm: d.commit_confirm ?? null }));
+                }
+              }
+              break;
+            }
+            case "power_status": {
+              if (parsed.data === null) {
+                refreshPowerStatus();
+              } else {
+                const d = parsed.data;
+                if (d.power_status) {
+                  setData((prev) => ({ ...prev, powerStatus: d.power_status ?? null }));
+                }
+              }
+              break;
+            }
+          }
+        } catch {
+          // Ignore malformed payloads
+        }
+      };
+
+      es.onerror = () => {
+        if (disposed) return;
+
+        setStatus("error");
+        es.close();
+        esRef.current = null;
+
+        // Reconnect after delay
+        reconnectTimerRef.current = setTimeout(connect, RECONNECT_DELAY_MS);
+      };
+    };
+
+    connect();
+
+    return () => {
+      disposed = true;
+      if (esRef.current) {
+        esRef.current.close();
+        esRef.current = null;
+      }
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      setStatus("disconnected");
+    };
+  }, [refreshConfigDiff, refreshCommitConfirm, refreshPowerStatus]);
+
+  return { status, data };
+}


### PR DESCRIPTION
  Frontend banner components previously polled 3 endpoints every 5 seconds
  (config/diff, commit-confirm/status, power/status) regardless of state,
  generating 36 requests/min of mostly redundant traffic.

  This replaces that with a single SSE connection (GET /vyos/events/banners)
  that pushes updates only when state actually changes:

  Backend:
  - Add event manager with per-instance pub/sub and change detection
  - Add SSE endpoint with background poller (10s, only active subscribers)
  - Emit events from mutation endpoints (batch, save, confirm, power actions)

  Frontend:
  - Add useBannerEvents hook with auto-reconnect
  - Banner components now receive state via props from AppLayout
  - Remove all setInterval polling from both banner components