### PR TITLE
Fix user creation issue with frontend configuration mismatch

### DIFF
--- a/backend/routers/user_management.py
+++ b/backend/routers/user_management.py
@@ -4,6 +4,7 @@ User Management Router
 API endpoints for managing users, roles, and permissions.
 ADMIN only.
 """
+import os
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field, EmailStr
@@ -22,6 +23,7 @@ from fastapi_permissions import require_super_admin
 
 router = APIRouter(prefix="/user-management", tags=["user-management"])
 
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://frontend:3000")
 
 # ============================================================================
 # Pydantic Models
@@ -321,7 +323,7 @@ async def create_user(request: Request, body: CreateUserRequest):
         raise HTTPException(status_code=400, detail="site_role must be ADMIN or VIEWER")
 
     # Call Better Auth's internal user creation endpoint
-    frontend_url = "http://frontend:3000"
+    frontend_url = FRONTEND_URL.rstrip("/")  # Ensure no trailing slash
     create_user_url = f"{frontend_url}/api/internal/create-user"
 
     async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:


### PR DESCRIPTION
This pull request introduces a minor improvement to the `user_management` router by making the frontend URL configurable via an environment variable. This change enhances flexibility for different deployment environments.

Configuration improvement:

* The frontend URL used for internal API calls is now set via the `FRONTEND_URL` environment variable, defaulting to `"http://frontend:3000"` if not provided, and trailing slashes are removed to ensure consistent URL formatting. (`backend/routers/user_management.py`) [[1]](diffhunk://#diff-ec3d34fa119556027338c886f9b814e51d293efb3cf90e4a572abf58fbd5e471R7) [[2]](diffhunk://#diff-ec3d34fa119556027338c886f9b814e51d293efb3cf90e4a572abf58fbd5e471R26) [[3]](diffhunk://#diff-ec3d34fa119556027338c886f9b814e51d293efb3cf90e4a572abf58fbd5e471L324-R326)