### PR TITLE
Feat add missing NAT options: port randomization, address mapping, FQDN matching, load balance weight

### DIFF
--- a/frontend/src/components/network/CreateDestinationNATModal.tsx
+++ b/frontend/src/components/network/CreateDestinationNATModal.tsx
@@ -42,7 +42,7 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
   const [description, setDescription] = useState("");
 
   // Source
-  const [sourceType, setSourceType] = useState<"address" | "group">("address");
+  const [sourceType, setSourceType] = useState<"address" | "group" | "fqdn">("address");
   const [sourceAddress, setSourceAddress] = useState("");
   const [sourceInvert, setSourceInvert] = useState(false);
   const [sourceGroupType, setSourceGroupType] = useState("");
@@ -50,7 +50,7 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
   const [sourcePort, setSourcePort] = useState("");
 
   // Destination
-  const [destinationType, setDestinationType] = useState<"address" | "group">("address");
+  const [destinationType, setDestinationType] = useState<"address" | "group" | "fqdn">("address");
   const [destinationAddress, setDestinationAddress] = useState("");
   const [destinationInvert, setDestinationInvert] = useState(false);
   const [destinationGroupType, setDestinationGroupType] = useState("");
@@ -74,11 +74,18 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
   // Translation
   const [translationAddress, setTranslationAddress] = useState("");
   const [translationPort, setTranslationPort] = useState("");
+  const [translationPortMapping, setTranslationPortMapping] = useState(false);
+  const [translationAddressMapping, setTranslationAddressMapping] = useState(false);
 
   // Load Balance
   const [loadBalancingEnabled, setLoadBalancingEnabled] = useState(false);
   const [loadBalanceHash, setLoadBalanceHash] = useState("");
   const [loadBalanceBackend, setLoadBalanceBackend] = useState("");
+  const [loadBalanceBackendWeight, setLoadBalanceBackendWeight] = useState("");
+
+  // FQDN
+  const [sourceFqdn, setSourceFqdn] = useState("");
+  const [destinationFqdn, setDestinationFqdn] = useState("");
 
   // Flags
   const [disable, setDisable] = useState(false);
@@ -232,8 +239,13 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
     setPacketType("");
     setTranslationAddress("");
     setTranslationPort("");
+    setTranslationPortMapping(false);
+    setTranslationAddressMapping(false);
     setLoadBalanceHash("");
     setLoadBalanceBackend("");
+    setLoadBalanceBackendWeight("");
+    setSourceFqdn("");
+    setDestinationFqdn("");
     setDisable(false);
     setExclude(false);
     setLog(false);
@@ -264,6 +276,8 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
         config.source_group_type = sourceGroupType;
         config.source_group_name = sourceGroupName;
         config.source_group_invert = sourceInvert;
+      } else if (sourceType === "fqdn" && sourceFqdn.trim()) {
+        config.source_fqdn = sourceFqdn.trim();
       }
       if (sourcePortType === "input" && sourcePort.trim()) {
         config.source_port = sourcePort.trim();
@@ -279,6 +293,8 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
         config.destination_group_type = destinationGroupType;
         config.destination_group_name = destinationGroupName;
         config.destination_group_invert = destinationInvert;
+      } else if (destinationType === "fqdn" && destinationFqdn.trim()) {
+        config.destination_fqdn = destinationFqdn.trim();
       }
       if (destPortType === "input" && destinationPort.trim()) {
         config.destination_port = destinationPort.trim();
@@ -314,6 +330,8 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
       if (translationPort.trim()) {
         config.translation_port = translationPort.trim();
       }
+      if (translationPortMapping) config.translation_port_mapping = true;
+      if (translationAddressMapping) config.translation_address_mapping = true;
 
       // Load balance
       if (loadBalancingEnabled) {
@@ -322,6 +340,9 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
         }
         if (loadBalanceBackend.trim()) {
           config.load_balance_backend = loadBalanceBackend.trim();
+        }
+        if (loadBalanceBackendWeight.trim()) {
+          config.load_balance_backend_weight = loadBalanceBackendWeight.trim();
         }
       }
 
@@ -370,14 +391,9 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
           )}
 
           {/* Rule Number (Auto-calculated) */}
-          <div className="space-y-2 bg-muted/30 border border-muted rounded-lg p-4">
-            <Label htmlFor="rule-number">Rule Number (Auto-assigned)</Label>
-            <div className="text-2xl font-mono font-bold text-primary">
-              {ruleNumber}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              This rule will be automatically assigned number {ruleNumber}
-            </p>
+          <div className="flex items-center gap-2 bg-muted/30 border border-muted rounded-md px-3 py-2">
+            <span className="text-xs text-muted-foreground">Rule number (auto-assigned):</span>
+            <span className="font-mono font-semibold text-sm text-primary">{ruleNumber}</span>
           </div>
 
           {/* Description */}
@@ -486,6 +502,42 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
                 </div>
               </div>
 
+              {/* Translation Options */}
+              <div className="space-y-2">
+                <div className="flex items-start space-x-2">
+                  <Checkbox
+                    id="translation-port-mapping"
+                    checked={translationPortMapping}
+                    onCheckedChange={(checked) => setTranslationPortMapping(checked === true)}
+                    className="mt-1"
+                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="translation-port-mapping" className="text-sm font-medium cursor-pointer">
+                      Randomize source port (port-mapping random)
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Randomizes the outbound source port for privacy and security
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start space-x-2">
+                  <Checkbox
+                    id="translation-address-mapping"
+                    checked={translationAddressMapping}
+                    onCheckedChange={(checked) => setTranslationAddressMapping(checked === true)}
+                    className="mt-1"
+                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="translation-address-mapping" className="text-sm font-medium cursor-pointer">
+                      Persistent address mapping
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      The same internal IP always maps to the same external IP
+                    </p>
+                  </div>
+                </div>
+              </div>
+
               {/* Protocol */}
               <div className="space-y-2">
                 <Label htmlFor="protocol">Protocol</Label>
@@ -575,7 +627,7 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
             <TabsContent value="source" className="space-y-4">
               <div className="space-y-2">
                 <Label>Source Type</Label>
-                <RadioGroup value={sourceType} onValueChange={(v) => setSourceType(v as "address" | "group")}>
+                <RadioGroup value={sourceType} onValueChange={(v) => setSourceType(v as "address" | "group" | "fqdn")}>
                   <div className="flex items-center space-x-2">
                     <RadioGroupItem value="address" id="source-address" />
                     <Label htmlFor="source-address">Address/Network</Label>
@@ -584,8 +636,25 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
                     <RadioGroupItem value="group" id="source-group" />
                     <Label htmlFor="source-group">Firewall Group</Label>
                   </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="fqdn" id="source-fqdn" />
+                    <Label htmlFor="source-fqdn">FQDN</Label>
+                  </div>
                 </RadioGroup>
               </div>
+
+              {sourceType === "fqdn" && (
+                <div className="space-y-2">
+                  <Label htmlFor="source-fqdn-input">Source FQDN</Label>
+                  <Input
+                    id="source-fqdn-input"
+                    value={sourceFqdn}
+                    onChange={(e) => setSourceFqdn(e.target.value)}
+                    placeholder="e.g., example.com"
+                    className="font-mono"
+                  />
+                </div>
+              )}
 
               {sourceType === "address" ? (
                 <div className="space-y-2">
@@ -598,7 +667,7 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
                     className="font-mono"
                   />
                 </div>
-              ) : (
+              ) : sourceType === "fqdn" ? null : (
                 <>
                   <div className="space-y-2">
                     <Label htmlFor="source-group-type">Source Group Type</Label>
@@ -690,7 +759,7 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
             <TabsContent value="destination" className="space-y-4">
               <div className="space-y-2">
                 <Label>Destination Type</Label>
-                <RadioGroup value={destinationType} onValueChange={(v) => setDestinationType(v as "address" | "group")}>
+                <RadioGroup value={destinationType} onValueChange={(v) => setDestinationType(v as "address" | "group" | "fqdn")}>
                   <div className="flex items-center space-x-2">
                     <RadioGroupItem value="address" id="dest-address" />
                     <Label htmlFor="dest-address">Address/Network</Label>
@@ -699,8 +768,25 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
                     <RadioGroupItem value="group" id="dest-group" />
                     <Label htmlFor="dest-group">Firewall Group</Label>
                   </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="fqdn" id="dest-fqdn" />
+                    <Label htmlFor="dest-fqdn">FQDN</Label>
+                  </div>
                 </RadioGroup>
               </div>
+
+              {destinationType === "fqdn" && (
+                <div className="space-y-2">
+                  <Label htmlFor="destination-fqdn-input">Destination FQDN</Label>
+                  <Input
+                    id="destination-fqdn-input"
+                    value={destinationFqdn}
+                    onChange={(e) => setDestinationFqdn(e.target.value)}
+                    placeholder="e.g., example.com"
+                    className="font-mono"
+                  />
+                </div>
+              )}
 
               {destinationType === "address" ? (
                 <div className="space-y-2">
@@ -713,7 +799,7 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
                     className="font-mono"
                   />
                 </div>
-              ) : (
+              ) : destinationType === "fqdn" ? null : (
                 <>
                   <div className="space-y-2">
                     <Label htmlFor="destination-group-type">Destination Group Type</Label>
@@ -875,6 +961,19 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
                       />
                       <p className="text-xs text-muted-foreground">
                         Internal IP address of the backend server to receive translated traffic
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="load-balance-weight">Backend Weight</Label>
+                      <Input
+                        id="load-balance-weight"
+                        value={loadBalanceBackendWeight}
+                        onChange={(e) => setLoadBalanceBackendWeight(e.target.value)}
+                        placeholder="e.g., 10 (optional, relative weight)"
+                        className="font-mono"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Relative weight for this backend in load balancing
                       </p>
                     </div>
                   </div>

--- a/frontend/src/components/network/CreateSourceNATModal.tsx
+++ b/frontend/src/components/network/CreateSourceNATModal.tsx
@@ -42,7 +42,7 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
   const [description, setDescription] = useState("");
 
   // Source
-  const [sourceType, setSourceType] = useState<"address" | "group">("address");
+  const [sourceType, setSourceType] = useState<"address" | "group" | "fqdn">("address");
   const [sourceAddress, setSourceAddress] = useState("");
   const [sourceInvert, setSourceInvert] = useState(false);
   const [sourceGroupType, setSourceGroupType] = useState("");
@@ -52,7 +52,7 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
   const [sourcePortGroupName, setSourcePortGroupName] = useState("");
 
   // Destination
-  const [destinationType, setDestinationType] = useState<"address" | "group">("address");
+  const [destinationType, setDestinationType] = useState<"address" | "group" | "fqdn">("address");
   const [destinationAddress, setDestinationAddress] = useState("");
   const [destinationInvert, setDestinationInvert] = useState(false);
   const [destinationGroupType, setDestinationGroupType] = useState("");
@@ -74,11 +74,19 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
   // Translation
   const [translationType, setTranslationType] = useState<"ip" | "cidr" | "range" | "masquerade">("masquerade");
   const [translationAddress, setTranslationAddress] = useState("");
+  const [translationPort, setTranslationPort] = useState("");
+  const [translationPortMapping, setTranslationPortMapping] = useState(false);
+  const [translationAddressMapping, setTranslationAddressMapping] = useState(false);
 
   // Load Balance
   const [loadBalancingEnabled, setLoadBalancingEnabled] = useState(false);
   const [loadBalanceHash, setLoadBalanceHash] = useState("");
   const [loadBalanceBackend, setLoadBalanceBackend] = useState("");
+  const [loadBalanceBackendWeight, setLoadBalanceBackendWeight] = useState("");
+
+  // FQDN
+  const [sourceFqdn, setSourceFqdn] = useState("");
+  const [destinationFqdn, setDestinationFqdn] = useState("");
 
   // Flags
   const [disable, setDisable] = useState(false);
@@ -232,8 +240,14 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
     setPacketType("");
     setTranslationType("masquerade");
     setTranslationAddress("");
+    setTranslationPort("");
+    setTranslationPortMapping(false);
+    setTranslationAddressMapping(false);
     setLoadBalanceHash("");
     setLoadBalanceBackend("");
+    setLoadBalanceBackendWeight("");
+    setSourceFqdn("");
+    setDestinationFqdn("");
     setDisable(false);
     setExclude(false);
     setLog(false);
@@ -264,6 +278,8 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
         config.source_group_type = sourceGroupType;
         config.source_group_name = sourceGroupName;
         config.source_group_invert = sourceInvert;
+      } else if (sourceType === "fqdn" && sourceFqdn.trim()) {
+        config.source_fqdn = sourceFqdn.trim();
       }
       if (sourcePortType === "input" && sourcePort.trim()) {
         config.source_port = sourcePort.trim();
@@ -279,6 +295,8 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
         config.destination_group_type = destinationGroupType;
         config.destination_group_name = destinationGroupName;
         config.destination_group_invert = destinationInvert;
+      } else if (destinationType === "fqdn" && destinationFqdn.trim()) {
+        config.destination_fqdn = destinationFqdn.trim();
       }
       if (destPortType === "input" && destinationPort.trim()) {
         config.destination_port = destinationPort.trim();
@@ -314,6 +332,11 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
       } else if (translationAddress.trim()) {
         config.translation_address = translationAddress.trim();
       }
+      if (translationPort.trim()) {
+        config.translation_port = translationPort.trim();
+      }
+      if (translationPortMapping) config.translation_port_mapping = true;
+      if (translationAddressMapping) config.translation_address_mapping = true;
 
       // Load balance
       if (loadBalancingEnabled) {
@@ -322,6 +345,9 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
         }
         if (loadBalanceBackend.trim()) {
           config.load_balance_backend = loadBalanceBackend.trim();
+        }
+        if (loadBalanceBackendWeight.trim()) {
+          config.load_balance_backend_weight = loadBalanceBackendWeight.trim();
         }
       }
 
@@ -370,14 +396,9 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
           )}
 
           {/* Rule Number (Auto-calculated) */}
-          <div className="space-y-2 bg-muted/30 border border-muted rounded-lg p-4">
-            <Label htmlFor="rule-number">Rule Number (Auto-assigned)</Label>
-            <div className="text-2xl font-mono font-bold text-primary">
-              {ruleNumber}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              This rule will be automatically assigned number {ruleNumber}
-            </p>
+          <div className="flex items-center gap-2 bg-muted/30 border border-muted rounded-md px-3 py-2">
+            <span className="text-xs text-muted-foreground">Rule number (auto-assigned):</span>
+            <span className="font-mono font-semibold text-sm text-primary">{ruleNumber}</span>
           </div>
 
           {/* Description */}
@@ -507,6 +528,55 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
                 </div>
               )}
 
+              {translationType !== "masquerade" && (
+                <div className="space-y-2">
+                  <Label htmlFor="translation-port">Translation Port</Label>
+                  <Input
+                    id="translation-port"
+                    value={translationPort}
+                    onChange={(e) => setTranslationPort(e.target.value)}
+                    placeholder="e.g., 8080 or 1024-65535"
+                    className="font-mono"
+                  />
+                </div>
+              )}
+
+              {/* Translation Options */}
+              <div className="space-y-2">
+                <div className="flex items-start space-x-2">
+                  <Checkbox
+                    id="translation-port-mapping"
+                    checked={translationPortMapping}
+                    onCheckedChange={(checked) => setTranslationPortMapping(checked === true)}
+                    className="mt-1"
+                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="translation-port-mapping" className="text-sm font-medium cursor-pointer">
+                      Randomize source port (port-mapping random)
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Randomizes the outbound source port for privacy and security
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start space-x-2">
+                  <Checkbox
+                    id="translation-address-mapping"
+                    checked={translationAddressMapping}
+                    onCheckedChange={(checked) => setTranslationAddressMapping(checked === true)}
+                    className="mt-1"
+                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="translation-address-mapping" className="text-sm font-medium cursor-pointer">
+                      Persistent address mapping
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      The same internal IP always maps to the same external IP
+                    </p>
+                  </div>
+                </div>
+              </div>
+
               {/* Protocol */}
               <div className="space-y-2">
                 <Label htmlFor="protocol">Protocol</Label>
@@ -596,7 +666,7 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
             <TabsContent value="source" className="space-y-4">
               <div className="space-y-2">
                 <Label>Source Type</Label>
-                <RadioGroup value={sourceType} onValueChange={(v) => setSourceType(v as "address" | "group")}>
+                <RadioGroup value={sourceType} onValueChange={(v) => setSourceType(v as "address" | "group" | "fqdn")}>
                   <div className="flex items-center space-x-2">
                     <RadioGroupItem value="address" id="source-address" />
                     <Label htmlFor="source-address">Address/Network</Label>
@@ -605,8 +675,25 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
                     <RadioGroupItem value="group" id="source-group" />
                     <Label htmlFor="source-group">Firewall Group</Label>
                   </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="fqdn" id="source-fqdn" />
+                    <Label htmlFor="source-fqdn">FQDN</Label>
+                  </div>
                 </RadioGroup>
               </div>
+
+              {sourceType === "fqdn" && (
+                <div className="space-y-2">
+                  <Label htmlFor="source-fqdn-input">Source FQDN</Label>
+                  <Input
+                    id="source-fqdn-input"
+                    value={sourceFqdn}
+                    onChange={(e) => setSourceFqdn(e.target.value)}
+                    placeholder="e.g., example.com"
+                    className="font-mono"
+                  />
+                </div>
+              )}
 
               {sourceType === "address" ? (
                 <div className="space-y-2">
@@ -619,7 +706,7 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
                     className="font-mono"
                   />
                 </div>
-              ) : (
+              ) : sourceType === "fqdn" ? null : (
                 <>
                   <div className="space-y-2">
                     <Label htmlFor="source-group-type">Source Group Type</Label>
@@ -711,7 +798,7 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
             <TabsContent value="destination" className="space-y-4">
               <div className="space-y-2">
                 <Label>Destination Type</Label>
-                <RadioGroup value={destinationType} onValueChange={(v) => setDestinationType(v as "address" | "group")}>
+                <RadioGroup value={destinationType} onValueChange={(v) => setDestinationType(v as "address" | "group" | "fqdn")}>
                   <div className="flex items-center space-x-2">
                     <RadioGroupItem value="address" id="dest-address" />
                     <Label htmlFor="dest-address">Address/Network</Label>
@@ -720,8 +807,25 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
                     <RadioGroupItem value="group" id="dest-group" />
                     <Label htmlFor="dest-group">Firewall Group</Label>
                   </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="fqdn" id="dest-fqdn" />
+                    <Label htmlFor="dest-fqdn">FQDN</Label>
+                  </div>
                 </RadioGroup>
               </div>
+
+              {destinationType === "fqdn" && (
+                <div className="space-y-2">
+                  <Label htmlFor="destination-fqdn-input">Destination FQDN</Label>
+                  <Input
+                    id="destination-fqdn-input"
+                    value={destinationFqdn}
+                    onChange={(e) => setDestinationFqdn(e.target.value)}
+                    placeholder="e.g., example.com"
+                    className="font-mono"
+                  />
+                </div>
+              )}
 
               {destinationType === "address" ? (
                 <div className="space-y-2">
@@ -734,7 +838,7 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
                     className="font-mono"
                   />
                 </div>
-              ) : (
+              ) : destinationType === "fqdn" ? null : (
                 <>
                   <div className="space-y-2">
                     <Label htmlFor="destination-group-type">Destination Group Type</Label>
@@ -896,6 +1000,19 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
                       />
                       <p className="text-xs text-muted-foreground">
                         Internal IP address of the backend server to receive translated traffic
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="load-balance-weight">Backend Weight</Label>
+                      <Input
+                        id="load-balance-weight"
+                        value={loadBalanceBackendWeight}
+                        onChange={(e) => setLoadBalanceBackendWeight(e.target.value)}
+                        placeholder="e.g., 10 (optional, relative weight)"
+                        className="font-mono"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Relative weight for this backend in load balancing
                       </p>
                     </div>
                   </div>

--- a/frontend/src/components/network/EditDestinationNATModal.tsx
+++ b/frontend/src/components/network/EditDestinationNATModal.tsx
@@ -41,7 +41,7 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
   const [description, setDescription] = useState("");
 
   // Source fields
-  const [sourceType, setSourceType] = useState<"address" | "group">("address");
+  const [sourceType, setSourceType] = useState<"address" | "group" | "fqdn">("address");
   const [sourceAddress, setSourceAddress] = useState("");
   const [sourceInvert, setSourceInvert] = useState(false);
   const [sourcePort, setSourcePort] = useState("");
@@ -53,7 +53,7 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
   const [sourcePortGroupName, setSourcePortGroupName] = useState("");
 
   // Destination fields
-  const [destinationType, setDestinationType] = useState<"address" | "group">("address");
+  const [destinationType, setDestinationType] = useState<"address" | "group" | "fqdn">("address");
   const [destinationAddress, setDestinationAddress] = useState("");
   const [destinationInvert, setDestinationInvert] = useState(false);
   const [destinationPort, setDestinationPort] = useState("");
@@ -77,11 +77,18 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
   // Translation
   const [translationAddress, setTranslationAddress] = useState("");
   const [translationPort, setTranslationPort] = useState("");
+  const [translationPortMapping, setTranslationPortMapping] = useState(false);
+  const [translationAddressMapping, setTranslationAddressMapping] = useState(false);
 
   // Load balance
   const [loadBalancingEnabled, setLoadBalancingEnabled] = useState(false);
   const [loadBalanceHash, setLoadBalanceHash] = useState("");
   const [loadBalanceBackend, setLoadBalanceBackend] = useState("");
+  const [loadBalanceBackendWeight, setLoadBalanceBackendWeight] = useState("");
+
+  // FQDN
+  const [sourceFqdn, setSourceFqdn] = useState("");
+  const [destinationFqdn, setDestinationFqdn] = useState("");
 
   // Flags
   const [disable, setDisable] = useState(false);
@@ -92,12 +99,16 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
   const [originalSourceAddress, setOriginalSourceAddress] = useState("");
   const [originalSourcePort, setOriginalSourcePort] = useState("");
   const [originalSourceGroup, setOriginalSourceGroup] = useState(false);
+  const [originalSourceFqdn, setOriginalSourceFqdn] = useState("");
   const [originalDestinationAddress, setOriginalDestinationAddress] = useState("");
   const [originalDestinationPort, setOriginalDestinationPort] = useState("");
   const [originalDestinationGroup, setOriginalDestinationGroup] = useState(false);
+  const [originalDestinationFqdn, setOriginalDestinationFqdn] = useState("");
   const [originalInboundInterfaceType, setOriginalInboundInterfaceType] = useState<"name" | "group" | null>(null);
   const [originalSourcePortGroup, setOriginalSourcePortGroup] = useState(false);
   const [originalDestPortGroup, setOriginalDestPortGroup] = useState(false);
+  const [originalTranslationPortMapping, setOriginalTranslationPortMapping] = useState(false);
+  const [originalTranslationAddressMapping, setOriginalTranslationAddressMapping] = useState(false);
 
   // Reset all form fields to defaults
   const resetForm = () => {
@@ -122,9 +133,14 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
     setPacketType("");
     setTranslationAddress("");
     setTranslationPort("");
+    setTranslationPortMapping(false);
+    setTranslationAddressMapping(false);
     setLoadBalancingEnabled(false);
     setLoadBalanceHash("");
     setLoadBalanceBackend("");
+    setLoadBalanceBackendWeight("");
+    setSourceFqdn("");
+    setDestinationFqdn("");
     setDisable(false);
     setExclude(false);
     setLog(false);
@@ -132,9 +148,11 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
     setOriginalSourceAddress("");
     setOriginalSourcePort("");
     setOriginalSourceGroup(false);
+    setOriginalSourceFqdn("");
     setOriginalDestinationAddress("");
     setOriginalDestinationPort("");
     setOriginalDestinationGroup(false);
+    setOriginalDestinationFqdn("");
     setOriginalInboundInterfaceType(null);
     setSourcePortType("input");
     setSourcePortGroupName("");
@@ -142,6 +160,8 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
     setDestPortGroupName("");
     setOriginalSourcePortGroup(false);
     setOriginalDestPortGroup(false);
+    setOriginalTranslationPortMapping(false);
+    setOriginalTranslationAddressMapping(false);
     setError(null);
   };
 
@@ -199,6 +219,11 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
         setSourceGroupName(srcGrpInverted ? name.substring(1) : name);
         setOriginalSourceGroup(true);
       }
+    } else if (rule.source?.fqdn) {
+      setSourceType("fqdn");
+      setSourceFqdn(rule.source.fqdn);
+      setOriginalSourceFqdn(rule.source.fqdn);
+      setSourceInvert(false);
     } else {
       setSourceInvert(false);
       setOriginalSourceAddress("");
@@ -237,6 +262,11 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
         setDestinationGroupName(dstGrpInverted ? name.substring(1) : name);
         setOriginalDestinationGroup(true);
       }
+    } else if (rule.destination?.fqdn) {
+      setDestinationType("fqdn");
+      setDestinationFqdn(rule.destination.fqdn);
+      setOriginalDestinationFqdn(rule.destination.fqdn);
+      setDestinationInvert(false);
     } else {
       setDestinationInvert(false);
       setOriginalDestinationAddress("");
@@ -284,12 +314,19 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
     // Translation
     setTranslationAddress(rule.translation?.address || "");
     setTranslationPort(rule.translation?.port || "");
+    const pm = rule.translation?.options?.port_mapping === "random";
+    setTranslationPortMapping(pm);
+    setOriginalTranslationPortMapping(pm);
+    const am = rule.translation?.options?.address_mapping === "persistent";
+    setTranslationAddressMapping(am);
+    setOriginalTranslationAddressMapping(am);
 
     // Load balance
     const hasLoadBalancing = !!(rule.load_balance?.hash || rule.load_balance?.backends?.[0]);
     setLoadBalancingEnabled(hasLoadBalancing);
     setLoadBalanceHash(rule.load_balance?.hash || "");
     setLoadBalanceBackend(rule.load_balance?.backends?.[0]?.name || "");
+    setLoadBalanceBackendWeight(rule.load_balance?.backends?.[0]?.weight || "");
 
     // Flags
     setDisable(rule.disable);
@@ -404,6 +441,9 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
         if (originalSourceGroup) {
           config.delete_source_group = true;
         }
+        if (originalSourceFqdn) {
+          config.delete_source_fqdn = true;
+        }
       } else if (sourceType === "group") {
         if (sourceGroupType && sourceGroupName) {
           config.source_group_type = sourceGroupType;
@@ -417,6 +457,17 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
         if (originalSourceAddress) {
           config.delete_source_address = true;
         }
+        if (originalSourceFqdn) {
+          config.delete_source_fqdn = true;
+        }
+      } else if (sourceType === "fqdn") {
+        if (sourceFqdn.trim()) {
+          config.source_fqdn = sourceFqdn.trim();
+        } else if (originalSourceFqdn) {
+          config.delete_source_fqdn = true;
+        }
+        if (originalSourceAddress) config.delete_source_address = true;
+        if (originalSourceGroup) config.delete_source_group = true;
       }
 
       if (sourcePortType === "input") {
@@ -450,6 +501,9 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
         if (originalDestinationGroup) {
           config.delete_destination_group = true;
         }
+        if (originalDestinationFqdn) {
+          config.delete_destination_fqdn = true;
+        }
       } else if (destinationType === "group") {
         if (destinationGroupType && destinationGroupName) {
           config.destination_group_type = destinationGroupType;
@@ -463,6 +517,17 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
         if (originalDestinationAddress) {
           config.delete_destination_address = true;
         }
+        if (originalDestinationFqdn) {
+          config.delete_destination_fqdn = true;
+        }
+      } else if (destinationType === "fqdn") {
+        if (destinationFqdn.trim()) {
+          config.destination_fqdn = destinationFqdn.trim();
+        } else if (originalDestinationFqdn) {
+          config.delete_destination_fqdn = true;
+        }
+        if (originalDestinationAddress) config.delete_destination_address = true;
+        if (originalDestinationGroup) config.delete_destination_group = true;
       }
 
       if (destPortType === "input") {
@@ -521,6 +586,18 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
         config.translation_port = translationPort.trim();
       }
 
+      if (!translationPortMapping && originalTranslationPortMapping) {
+        config.delete_translation_port_mapping = true;
+      } else if (translationPortMapping) {
+        config.translation_port_mapping = true;
+      }
+
+      if (!translationAddressMapping && originalTranslationAddressMapping) {
+        config.delete_translation_address_mapping = true;
+      } else if (translationAddressMapping) {
+        config.translation_address_mapping = true;
+      }
+
       // Load balance
       if (loadBalancingEnabled) {
         if (loadBalanceHash) {
@@ -528,6 +605,9 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
         }
         if (loadBalanceBackend.trim()) {
           config.load_balance_backend = loadBalanceBackend.trim();
+        }
+        if (loadBalanceBackendWeight.trim()) {
+          config.load_balance_backend_weight = loadBalanceBackendWeight.trim();
         }
       }
 
@@ -683,6 +763,42 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
                 </div>
               </div>
 
+              {/* Translation Options */}
+              <div className="space-y-2">
+                <div className="flex items-start space-x-2">
+                  <Checkbox
+                    id="translation-port-mapping"
+                    checked={translationPortMapping}
+                    onCheckedChange={(checked) => setTranslationPortMapping(checked === true)}
+                    className="mt-1"
+                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="translation-port-mapping" className="text-sm font-medium cursor-pointer">
+                      Randomize source port (port-mapping random)
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Randomizes the outbound source port for privacy and security
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start space-x-2">
+                  <Checkbox
+                    id="translation-address-mapping"
+                    checked={translationAddressMapping}
+                    onCheckedChange={(checked) => setTranslationAddressMapping(checked === true)}
+                    className="mt-1"
+                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="translation-address-mapping" className="text-sm font-medium cursor-pointer">
+                      Persistent address mapping
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      The same internal IP always maps to the same external IP
+                    </p>
+                  </div>
+                </div>
+              </div>
+
               {/* Protocol */}
               <div className="space-y-2">
                 <Label htmlFor="protocol">Protocol</Label>
@@ -772,7 +888,7 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
             <TabsContent value="source" className="space-y-4">
               <div className="space-y-2">
                 <Label>Source Type</Label>
-                <RadioGroup value={sourceType} onValueChange={(v) => setSourceType(v as "address" | "group")}>
+                <RadioGroup value={sourceType} onValueChange={(v) => setSourceType(v as "address" | "group" | "fqdn")}>
                   <div className="flex items-center space-x-2">
                     <RadioGroupItem value="address" id="source-address" />
                     <Label htmlFor="source-address">Address/Network</Label>
@@ -780,6 +896,10 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
                   <div className="flex items-center space-x-2">
                     <RadioGroupItem value="group" id="source-group" />
                     <Label htmlFor="source-group">Firewall Group</Label>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="fqdn" id="source-fqdn" />
+                    <Label htmlFor="source-fqdn">FQDN</Label>
                   </div>
                 </RadioGroup>
               </div>
@@ -792,6 +912,17 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
                     value={sourceAddress}
                     onChange={(e) => setSourceAddress(e.target.value)}
                     placeholder="e.g., 192.168.1.0/24 or 10.0.0.1"
+                    className="font-mono"
+                  />
+                </div>
+              ) : sourceType === "fqdn" ? (
+                <div className="space-y-2">
+                  <Label htmlFor="source-fqdn-input">Source FQDN</Label>
+                  <Input
+                    id="source-fqdn-input"
+                    value={sourceFqdn}
+                    onChange={(e) => setSourceFqdn(e.target.value)}
+                    placeholder="e.g., example.com"
                     className="font-mono"
                   />
                 </div>
@@ -887,7 +1018,7 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
             <TabsContent value="destination" className="space-y-4">
               <div className="space-y-2">
                 <Label>Destination Type</Label>
-                <RadioGroup value={destinationType} onValueChange={(v) => setDestinationType(v as "address" | "group")}>
+                <RadioGroup value={destinationType} onValueChange={(v) => setDestinationType(v as "address" | "group" | "fqdn")}>
                   <div className="flex items-center space-x-2">
                     <RadioGroupItem value="address" id="dest-address" />
                     <Label htmlFor="dest-address">Address/Network</Label>
@@ -895,6 +1026,10 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
                   <div className="flex items-center space-x-2">
                     <RadioGroupItem value="group" id="dest-group" />
                     <Label htmlFor="dest-group">Firewall Group</Label>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="fqdn" id="dest-fqdn" />
+                    <Label htmlFor="dest-fqdn">FQDN</Label>
                   </div>
                 </RadioGroup>
               </div>
@@ -907,6 +1042,17 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
                     value={destinationAddress}
                     onChange={(e) => setDestinationAddress(e.target.value)}
                     placeholder="e.g., 203.0.113.10"
+                    className="font-mono"
+                  />
+                </div>
+              ) : destinationType === "fqdn" ? (
+                <div className="space-y-2">
+                  <Label htmlFor="destination-fqdn-input">Destination FQDN</Label>
+                  <Input
+                    id="destination-fqdn-input"
+                    value={destinationFqdn}
+                    onChange={(e) => setDestinationFqdn(e.target.value)}
+                    placeholder="e.g., example.com"
                     className="font-mono"
                   />
                 </div>
@@ -1072,6 +1218,19 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
                       />
                       <p className="text-xs text-muted-foreground">
                         Internal IP address of the backend server to receive translated traffic
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="load-balance-weight">Backend Weight (optional)</Label>
+                      <Input
+                        id="load-balance-weight"
+                        value={loadBalanceBackendWeight}
+                        onChange={(e) => setLoadBalanceBackendWeight(e.target.value)}
+                        placeholder="e.g., 10 (relative weight)"
+                        className="font-mono"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Relative weight for this backend in load balancing
                       </p>
                     </div>
                   </div>

--- a/frontend/src/components/network/EditSourceNATModal.tsx
+++ b/frontend/src/components/network/EditSourceNATModal.tsx
@@ -41,7 +41,7 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
   const [description, setDescription] = useState("");
 
   // Source fields
-  const [sourceType, setSourceType] = useState<"address" | "group">("address");
+  const [sourceType, setSourceType] = useState<"address" | "group" | "fqdn">("address");
   const [sourceAddress, setSourceAddress] = useState("");
   const [sourceInvert, setSourceInvert] = useState(false);
   const [sourcePort, setSourcePort] = useState("");
@@ -53,7 +53,7 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
   const [sourcePortGroupName, setSourcePortGroupName] = useState("");
 
   // Destination fields
-  const [destinationType, setDestinationType] = useState<"address" | "group">("address");
+  const [destinationType, setDestinationType] = useState<"address" | "group" | "fqdn">("address");
   const [destinationAddress, setDestinationAddress] = useState("");
   const [destinationInvert, setDestinationInvert] = useState(false);
   const [destinationPort, setDestinationPort] = useState("");
@@ -77,11 +77,19 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
   // Translation
   const [translationType, setTranslationType] = useState<"ip" | "cidr" | "range" | "masquerade">("masquerade");
   const [translationAddress, setTranslationAddress] = useState("");
+  const [translationPort, setTranslationPort] = useState("");
+  const [translationPortMapping, setTranslationPortMapping] = useState(false);
+  const [translationAddressMapping, setTranslationAddressMapping] = useState(false);
 
   // Load balance
   const [loadBalancingEnabled, setLoadBalancingEnabled] = useState(false);
   const [loadBalanceHash, setLoadBalanceHash] = useState("");
   const [loadBalanceBackend, setLoadBalanceBackend] = useState("");
+  const [loadBalanceBackendWeight, setLoadBalanceBackendWeight] = useState("");
+
+  // FQDN
+  const [sourceFqdn, setSourceFqdn] = useState("");
+  const [destinationFqdn, setDestinationFqdn] = useState("");
 
   // Flags
   const [disable, setDisable] = useState(false);
@@ -92,12 +100,17 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
   const [originalSourceAddress, setOriginalSourceAddress] = useState("");
   const [originalSourcePort, setOriginalSourcePort] = useState("");
   const [originalSourceGroup, setOriginalSourceGroup] = useState(false);
+  const [originalSourceFqdn, setOriginalSourceFqdn] = useState("");
   const [originalDestinationAddress, setOriginalDestinationAddress] = useState("");
   const [originalDestinationPort, setOriginalDestinationPort] = useState("");
   const [originalDestinationGroup, setOriginalDestinationGroup] = useState(false);
+  const [originalDestinationFqdn, setOriginalDestinationFqdn] = useState("");
   const [originalOutboundInterfaceType, setOriginalOutboundInterfaceType] = useState<"name" | "group" | null>(null);
   const [originalSourcePortGroup, setOriginalSourcePortGroup] = useState("");
   const [originalDestPortGroup, setOriginalDestPortGroup] = useState("");
+  const [originalTranslationPort, setOriginalTranslationPort] = useState("");
+  const [originalTranslationPortMapping, setOriginalTranslationPortMapping] = useState(false);
+  const [originalTranslationAddressMapping, setOriginalTranslationAddressMapping] = useState(false);
 
   // Reset all form fields to defaults
   const resetForm = () => {
@@ -126,9 +139,15 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
     setPacketType("");
     setTranslationType("masquerade");
     setTranslationAddress("");
+    setTranslationPort("");
+    setTranslationPortMapping(false);
+    setTranslationAddressMapping(false);
     setLoadBalancingEnabled(false);
     setLoadBalanceHash("");
     setLoadBalanceBackend("");
+    setLoadBalanceBackendWeight("");
+    setSourceFqdn("");
+    setDestinationFqdn("");
     setDisable(false);
     setExclude(false);
     setLog(false);
@@ -136,12 +155,17 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
     setOriginalSourceAddress("");
     setOriginalSourcePort("");
     setOriginalSourceGroup(false);
+    setOriginalSourceFqdn("");
     setOriginalDestinationAddress("");
     setOriginalDestinationPort("");
     setOriginalDestinationGroup(false);
+    setOriginalDestinationFqdn("");
     setOriginalOutboundInterfaceType(null);
     setOriginalSourcePortGroup("");
     setOriginalDestPortGroup("");
+    setOriginalTranslationPort("");
+    setOriginalTranslationPortMapping(false);
+    setOriginalTranslationAddressMapping(false);
     setError(null);
   };
 
@@ -199,6 +223,11 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
         setSourceGroupName(srcGrpInverted ? name.substring(1) : name);
         setOriginalSourceGroup(true);
       }
+    } else if (rule.source?.fqdn) {
+      setSourceType("fqdn");
+      setSourceFqdn(rule.source.fqdn);
+      setOriginalSourceFqdn(rule.source.fqdn);
+      setSourceInvert(false);
     } else {
       setSourceInvert(false);
       setOriginalSourceAddress("");
@@ -237,6 +266,11 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
         setDestinationGroupName(dstGrpInverted ? name.substring(1) : name);
         setOriginalDestinationGroup(true);
       }
+    } else if (rule.destination?.fqdn) {
+      setDestinationType("fqdn");
+      setDestinationFqdn(rule.destination.fqdn);
+      setOriginalDestinationFqdn(rule.destination.fqdn);
+      setDestinationInvert(false);
     } else {
       setDestinationInvert(false);
       setOriginalDestinationAddress("");
@@ -297,11 +331,23 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
       setTranslationAddress(transAddr);
     }
 
+    // Translation port and options
+    const tPort = rule.translation?.port || "";
+    setTranslationPort(tPort);
+    setOriginalTranslationPort(tPort);
+    const pm = rule.translation?.options?.port_mapping === "random";
+    setTranslationPortMapping(pm);
+    setOriginalTranslationPortMapping(pm);
+    const am = rule.translation?.options?.address_mapping === "persistent";
+    setTranslationAddressMapping(am);
+    setOriginalTranslationAddressMapping(am);
+
     // Load balance
     const hasLoadBalancing = !!(rule.load_balance?.hash || rule.load_balance?.backends?.[0]);
     setLoadBalancingEnabled(hasLoadBalancing);
     setLoadBalanceHash(rule.load_balance?.hash || "");
     setLoadBalanceBackend(rule.load_balance?.backends?.[0]?.name || "");
+    setLoadBalanceBackendWeight(rule.load_balance?.backends?.[0]?.weight || "");
 
     // Flags
     setDisable(rule.disable);
@@ -416,6 +462,9 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
         if (originalSourceGroup) {
           config.delete_source_group = true;
         }
+        if (originalSourceFqdn) {
+          config.delete_source_fqdn = true;
+        }
       } else if (sourceType === "group") {
         if (sourceGroupType && sourceGroupName) {
           config.source_group_type = sourceGroupType;
@@ -429,6 +478,17 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
         if (originalSourceAddress) {
           config.delete_source_address = true;
         }
+        if (originalSourceFqdn) {
+          config.delete_source_fqdn = true;
+        }
+      } else if (sourceType === "fqdn") {
+        if (sourceFqdn.trim()) {
+          config.source_fqdn = sourceFqdn.trim();
+        } else if (originalSourceFqdn) {
+          config.delete_source_fqdn = true;
+        }
+        if (originalSourceAddress) config.delete_source_address = true;
+        if (originalSourceGroup) config.delete_source_group = true;
       }
 
       if (sourcePortType === "input") {
@@ -465,6 +525,9 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
         if (originalDestinationGroup) {
           config.delete_destination_group = true;
         }
+        if (originalDestinationFqdn) {
+          config.delete_destination_fqdn = true;
+        }
       } else if (destinationType === "group") {
         if (destinationGroupType && destinationGroupName) {
           config.destination_group_type = destinationGroupType;
@@ -478,6 +541,17 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
         if (originalDestinationAddress) {
           config.delete_destination_address = true;
         }
+        if (originalDestinationFqdn) {
+          config.delete_destination_fqdn = true;
+        }
+      } else if (destinationType === "fqdn") {
+        if (destinationFqdn.trim()) {
+          config.destination_fqdn = destinationFqdn.trim();
+        } else if (originalDestinationFqdn) {
+          config.delete_destination_fqdn = true;
+        }
+        if (originalDestinationAddress) config.delete_destination_address = true;
+        if (originalDestinationGroup) config.delete_destination_group = true;
       }
 
       if (destPortType === "input") {
@@ -539,6 +613,24 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
         config.translation_address = translationAddress.trim();
       }
 
+      if (!translationPort.trim() && originalTranslationPort) {
+        config.delete_translation_port = true;
+      } else if (translationPort.trim()) {
+        config.translation_port = translationPort.trim();
+      }
+
+      if (!translationPortMapping && originalTranslationPortMapping) {
+        config.delete_translation_port_mapping = true;
+      } else if (translationPortMapping) {
+        config.translation_port_mapping = true;
+      }
+
+      if (!translationAddressMapping && originalTranslationAddressMapping) {
+        config.delete_translation_address_mapping = true;
+      } else if (translationAddressMapping) {
+        config.translation_address_mapping = true;
+      }
+
       // Load balance
       if (loadBalancingEnabled) {
         if (loadBalanceHash) {
@@ -546,6 +638,9 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
         }
         if (loadBalanceBackend.trim()) {
           config.load_balance_backend = loadBalanceBackend.trim();
+        }
+        if (loadBalanceBackendWeight.trim()) {
+          config.load_balance_backend_weight = loadBalanceBackendWeight.trim();
         }
       }
 
@@ -722,6 +817,55 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
                 </div>
               )}
 
+              {translationType !== "masquerade" && (
+                <div className="space-y-2">
+                  <Label htmlFor="translation-port">Translation Port</Label>
+                  <Input
+                    id="translation-port"
+                    value={translationPort}
+                    onChange={(e) => setTranslationPort(e.target.value)}
+                    placeholder="e.g., 8080 or 1024-65535"
+                    className="font-mono"
+                  />
+                </div>
+              )}
+
+              {/* Translation Options */}
+              <div className="space-y-2">
+                <div className="flex items-start space-x-2">
+                  <Checkbox
+                    id="translation-port-mapping"
+                    checked={translationPortMapping}
+                    onCheckedChange={(checked) => setTranslationPortMapping(checked === true)}
+                    className="mt-1"
+                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="translation-port-mapping" className="text-sm font-medium cursor-pointer">
+                      Randomize source port (port-mapping random)
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Randomizes the outbound source port for privacy and security
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-start space-x-2">
+                  <Checkbox
+                    id="translation-address-mapping"
+                    checked={translationAddressMapping}
+                    onCheckedChange={(checked) => setTranslationAddressMapping(checked === true)}
+                    className="mt-1"
+                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="translation-address-mapping" className="text-sm font-medium cursor-pointer">
+                      Persistent address mapping
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      The same internal IP always maps to the same external IP
+                    </p>
+                  </div>
+                </div>
+              </div>
+
               {/* Protocol */}
               <div className="space-y-2">
                 <Label htmlFor="protocol">Protocol</Label>
@@ -811,7 +955,7 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
             <TabsContent value="source" className="space-y-4">
               <div className="space-y-2">
                 <Label>Source Type</Label>
-                <RadioGroup value={sourceType} onValueChange={(v) => setSourceType(v as "address" | "group")}>
+                <RadioGroup value={sourceType} onValueChange={(v) => setSourceType(v as "address" | "group" | "fqdn")}>
                   <div className="flex items-center space-x-2">
                     <RadioGroupItem value="address" id="source-address" />
                     <Label htmlFor="source-address">Address/Network</Label>
@@ -820,8 +964,25 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
                     <RadioGroupItem value="group" id="source-group" />
                     <Label htmlFor="source-group">Firewall Group</Label>
                   </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="fqdn" id="source-fqdn" />
+                    <Label htmlFor="source-fqdn">FQDN</Label>
+                  </div>
                 </RadioGroup>
               </div>
+
+              {sourceType === "fqdn" && (
+                <div className="space-y-2">
+                  <Label htmlFor="source-fqdn-input">Source FQDN</Label>
+                  <Input
+                    id="source-fqdn-input"
+                    value={sourceFqdn}
+                    onChange={(e) => setSourceFqdn(e.target.value)}
+                    placeholder="e.g., example.com"
+                    className="font-mono"
+                  />
+                </div>
+              )}
 
               {sourceType === "address" ? (
                 <div className="space-y-2">
@@ -834,7 +995,7 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
                     className="font-mono"
                   />
                 </div>
-              ) : (
+              ) : sourceType === "fqdn" ? null : (
                 <>
                   <div className="space-y-2">
                     <Label htmlFor="source-group-type">Source Group Type</Label>
@@ -926,7 +1087,7 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
             <TabsContent value="destination" className="space-y-4">
               <div className="space-y-2">
                 <Label>Destination Type</Label>
-                <RadioGroup value={destinationType} onValueChange={(v) => setDestinationType(v as "address" | "group")}>
+                <RadioGroup value={destinationType} onValueChange={(v) => setDestinationType(v as "address" | "group" | "fqdn")}>
                   <div className="flex items-center space-x-2">
                     <RadioGroupItem value="address" id="dest-address" />
                     <Label htmlFor="dest-address">Address/Network</Label>
@@ -935,8 +1096,25 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
                     <RadioGroupItem value="group" id="dest-group" />
                     <Label htmlFor="dest-group">Firewall Group</Label>
                   </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="fqdn" id="dest-fqdn" />
+                    <Label htmlFor="dest-fqdn">FQDN</Label>
+                  </div>
                 </RadioGroup>
               </div>
+
+              {destinationType === "fqdn" && (
+                <div className="space-y-2">
+                  <Label htmlFor="destination-fqdn-input">Destination FQDN</Label>
+                  <Input
+                    id="destination-fqdn-input"
+                    value={destinationFqdn}
+                    onChange={(e) => setDestinationFqdn(e.target.value)}
+                    placeholder="e.g., example.com"
+                    className="font-mono"
+                  />
+                </div>
+              )}
 
               {destinationType === "address" ? (
                 <div className="space-y-2">
@@ -949,7 +1127,7 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
                     className="font-mono"
                   />
                 </div>
-              ) : (
+              ) : destinationType === "fqdn" ? null : (
                 <>
                   <div className="space-y-2">
                     <Label htmlFor="destination-group-type">Destination Group Type</Label>
@@ -1111,6 +1289,19 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
                       />
                       <p className="text-xs text-muted-foreground">
                         Internal IP address of the backend server to receive translated traffic
+                      </p>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="load-balance-weight">Backend Weight</Label>
+                      <Input
+                        id="load-balance-weight"
+                        value={loadBalanceBackendWeight}
+                        onChange={(e) => setLoadBalanceBackendWeight(e.target.value)}
+                        placeholder="e.g., 10 (optional, relative weight)"
+                        className="font-mono"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Relative weight for this backend in load balancing
                       </p>
                     </div>
                   </div>

--- a/frontend/src/lib/api/nat.ts
+++ b/frontend/src/lib/api/nat.ts
@@ -219,6 +219,7 @@ class NATService {
       source_group_name?: string;
       source_group_invert?: boolean;
       source_port_group_name?: string;
+      source_fqdn?: string;
       destination_address?: string;
       destination_address_invert?: boolean;
       destination_port?: string;
@@ -226,6 +227,7 @@ class NATService {
       destination_group_name?: string;
       destination_group_invert?: boolean;
       destination_port_group_name?: string;
+      destination_fqdn?: string;
       outbound_interface_type?: "name" | "group";
       outbound_interface_value?: string;
       outbound_interface_invert?: boolean;
@@ -233,8 +235,12 @@ class NATService {
       packet_type?: string;
       translation_type?: "ip" | "cidr" | "range" | "masquerade";
       translation_address?: string;
+      translation_port?: string;
+      translation_port_mapping?: boolean;
+      translation_address_mapping?: boolean;
       load_balance_hash?: string;
       load_balance_backend?: string;
+      load_balance_backend_weight?: string;
       disable?: boolean;
       exclude?: boolean;
       log?: boolean;
@@ -322,6 +328,23 @@ class NATService {
     if (config.translation_address) {
       operations.push({ op: "set_source_rule_translation_address", value: config.translation_address });
     }
+    if (config.translation_port) {
+      operations.push({ op: "set_source_rule_translation_port", value: config.translation_port });
+    }
+    if (config.translation_port_mapping) {
+      operations.push({ op: "set_source_rule_translation_options_port_mapping", value: "random" });
+    }
+    if (config.translation_address_mapping) {
+      operations.push({ op: "set_source_rule_translation_options_address_mapping", value: "persistent" });
+    }
+
+    // FQDN matching
+    if (config.source_fqdn) {
+      operations.push({ op: "set_source_rule_source_fqdn", value: config.source_fqdn });
+    }
+    if (config.destination_fqdn) {
+      operations.push({ op: "set_source_rule_destination_fqdn", value: config.destination_fqdn });
+    }
 
     // Load balance
     if (config.load_balance_hash) {
@@ -329,6 +352,12 @@ class NATService {
     }
     if (config.load_balance_backend) {
       operations.push({ op: "set_source_rule_load_balance_backend", value: config.load_balance_backend });
+    }
+    if (config.load_balance_backend && config.load_balance_backend_weight) {
+      operations.push({
+        op: "set_source_rule_load_balance_backend_weight",
+        value: JSON.stringify({ backend: config.load_balance_backend, weight: config.load_balance_backend_weight })
+      });
     }
 
     // Flags
@@ -371,6 +400,7 @@ class NATService {
       source_group_name?: string;
       source_group_invert?: boolean;
       source_port_group_name?: string;
+      source_fqdn?: string;
       destination_address?: string;
       destination_address_invert?: boolean;
       destination_port?: string;
@@ -378,6 +408,7 @@ class NATService {
       destination_group_name?: string;
       destination_group_invert?: boolean;
       destination_port_group_name?: string;
+      destination_fqdn?: string;
       inbound_interface_type?: "name" | "group";
       inbound_interface_value?: string;
       inbound_interface_invert?: boolean;
@@ -385,8 +416,11 @@ class NATService {
       packet_type?: string;
       translation_address?: string;
       translation_port?: string;
+      translation_port_mapping?: boolean;
+      translation_address_mapping?: boolean;
       load_balance_hash?: string;
       load_balance_backend?: string;
+      load_balance_backend_weight?: string;
       disable?: boolean;
       exclude?: boolean;
       log?: boolean;
@@ -423,6 +457,9 @@ class NATService {
         value: JSON.stringify({ group_type: "port-group", group_name: config.source_port_group_name })
       });
     }
+    if (config.source_fqdn) {
+      operations.push({ op: "set_destination_rule_source_fqdn", value: config.source_fqdn });
+    }
 
     // Destination
     if (config.destination_address) {
@@ -444,6 +481,9 @@ class NATService {
         op: "set_destination_rule_destination_group",
         value: JSON.stringify({ group_type: "port-group", group_name: config.destination_port_group_name })
       });
+    }
+    if (config.destination_fqdn) {
+      operations.push({ op: "set_destination_rule_destination_fqdn", value: config.destination_fqdn });
     }
 
     // Inbound interface
@@ -477,6 +517,12 @@ class NATService {
     if (config.translation_port) {
       operations.push({ op: "set_destination_rule_translation_port", value: config.translation_port });
     }
+    if (config.translation_port_mapping) {
+      operations.push({ op: "set_destination_rule_translation_options_port_mapping", value: "random" });
+    }
+    if (config.translation_address_mapping) {
+      operations.push({ op: "set_destination_rule_translation_options_address_mapping", value: "persistent" });
+    }
 
     // Load balance
     if (config.load_balance_hash) {
@@ -484,6 +530,12 @@ class NATService {
     }
     if (config.load_balance_backend) {
       operations.push({ op: "set_destination_rule_load_balance_backend", value: config.load_balance_backend });
+    }
+    if (config.load_balance_backend && config.load_balance_backend_weight) {
+      operations.push({
+        op: "set_destination_rule_load_balance_backend_weight",
+        value: JSON.stringify({ backend: config.load_balance_backend, weight: config.load_balance_backend_weight })
+      });
     }
 
     // Flags
@@ -582,6 +634,7 @@ class NATService {
       source_group_name?: string;
       source_group_invert?: boolean;
       source_port_group_name?: string;
+      source_fqdn?: string;
       destination_address?: string;
       destination_address_invert?: boolean;
       destination_port?: string;
@@ -589,6 +642,7 @@ class NATService {
       destination_group_name?: string;
       destination_group_invert?: boolean;
       destination_port_group_name?: string;
+      destination_fqdn?: string;
       outbound_interface_type?: "name" | "group";
       outbound_interface_value?: string;
       outbound_interface_invert?: boolean;
@@ -597,8 +651,12 @@ class NATService {
       packet_type?: string;
       translation_type?: "ip" | "cidr" | "range" | "masquerade";
       translation_address?: string;
+      translation_port?: string;
+      translation_port_mapping?: boolean;
+      translation_address_mapping?: boolean;
       load_balance_hash?: string;
       load_balance_backend?: string;
+      load_balance_backend_weight?: string;
       disable?: boolean;
       exclude?: boolean;
       log?: boolean;
@@ -607,12 +665,17 @@ class NATService {
       delete_source_port?: boolean;
       delete_source_group?: boolean;
       delete_source_port_group?: boolean;
+      delete_source_fqdn?: boolean;
       delete_destination_address?: boolean;
       delete_destination_port?: boolean;
       delete_destination_group?: boolean;
       delete_destination_port_group?: boolean;
+      delete_destination_fqdn?: boolean;
       delete_outbound_interface_name?: boolean;
       delete_outbound_interface_group?: boolean;
+      delete_translation_port?: boolean;
+      delete_translation_port_mapping?: boolean;
+      delete_translation_address_mapping?: boolean;
     }
   ): Promise<VyOSResponse> {
     // Build operations just like createSourceRule
@@ -663,6 +726,12 @@ class NATService {
       });
     }
 
+    if (config.delete_source_fqdn) {
+      operations.push({ op: "delete_source_rule_source_fqdn" });
+    } else if (config.source_fqdn) {
+      operations.push({ op: "set_source_rule_source_fqdn", value: config.source_fqdn });
+    }
+
     // Destination - handle deletions first, then sets
     if (config.delete_destination_address) {
       operations.push({ op: "delete_source_rule_destination_address" });
@@ -697,6 +766,12 @@ class NATService {
         op: "set_source_rule_destination_group",
         value: JSON.stringify({ group_type: "port-group", group_name: config.destination_port_group_name })
       });
+    }
+
+    if (config.delete_destination_fqdn) {
+      operations.push({ op: "delete_source_rule_destination_fqdn" });
+    } else if (config.destination_fqdn) {
+      operations.push({ op: "set_source_rule_destination_fqdn", value: config.destination_fqdn });
     }
 
     // Outbound interface - handle deletions first when switching types
@@ -737,12 +812,36 @@ class NATService {
       operations.push({ op: "set_source_rule_translation_address", value: config.translation_address });
     }
 
+    if (config.delete_translation_port) {
+      operations.push({ op: "delete_source_rule_translation_port" });
+    } else if (config.translation_port) {
+      operations.push({ op: "set_source_rule_translation_port", value: config.translation_port });
+    }
+
+    if (config.delete_translation_port_mapping) {
+      operations.push({ op: "delete_source_rule_translation_options_port_mapping" });
+    } else if (config.translation_port_mapping) {
+      operations.push({ op: "set_source_rule_translation_options_port_mapping", value: "random" });
+    }
+
+    if (config.delete_translation_address_mapping) {
+      operations.push({ op: "delete_source_rule_translation_options_address_mapping" });
+    } else if (config.translation_address_mapping) {
+      operations.push({ op: "set_source_rule_translation_options_address_mapping", value: "persistent" });
+    }
+
     // Load balance
     if (config.load_balance_hash) {
       operations.push({ op: "set_source_rule_load_balance_hash", value: config.load_balance_hash });
     }
     if (config.load_balance_backend) {
       operations.push({ op: "set_source_rule_load_balance_backend", value: config.load_balance_backend });
+    }
+    if (config.load_balance_backend && config.load_balance_backend_weight) {
+      operations.push({
+        op: "set_source_rule_load_balance_backend_weight",
+        value: JSON.stringify({ backend: config.load_balance_backend, weight: config.load_balance_backend_weight })
+      });
     }
 
     // Flags
@@ -784,6 +883,7 @@ class NATService {
       source_group_name?: string;
       source_group_invert?: boolean;
       source_port_group_name?: string;
+      source_fqdn?: string;
       destination_address?: string;
       destination_address_invert?: boolean;
       destination_port?: string;
@@ -791,6 +891,7 @@ class NATService {
       destination_group_name?: string;
       destination_group_invert?: boolean;
       destination_port_group_name?: string;
+      destination_fqdn?: string;
       inbound_interface_type?: "name" | "group";
       inbound_interface_value?: string;
       inbound_interface_invert?: boolean;
@@ -799,8 +900,11 @@ class NATService {
       packet_type?: string;
       translation_address?: string;
       translation_port?: string;
+      translation_port_mapping?: boolean;
+      translation_address_mapping?: boolean;
       load_balance_hash?: string;
       load_balance_backend?: string;
+      load_balance_backend_weight?: string;
       disable?: boolean;
       exclude?: boolean;
       log?: boolean;
@@ -809,12 +913,16 @@ class NATService {
       delete_source_port?: boolean;
       delete_source_group?: boolean;
       delete_source_port_group?: boolean;
+      delete_source_fqdn?: boolean;
       delete_destination_address?: boolean;
       delete_destination_port?: boolean;
       delete_destination_group?: boolean;
       delete_destination_port_group?: boolean;
+      delete_destination_fqdn?: boolean;
       delete_inbound_interface_name?: boolean;
       delete_inbound_interface_group?: boolean;
+      delete_translation_port_mapping?: boolean;
+      delete_translation_address_mapping?: boolean;
     }
   ): Promise<VyOSResponse> {
     // Build operations just like createDestinationRule
@@ -865,6 +973,12 @@ class NATService {
       });
     }
 
+    if (config.delete_source_fqdn) {
+      operations.push({ op: "delete_destination_rule_source_fqdn" });
+    } else if (config.source_fqdn) {
+      operations.push({ op: "set_destination_rule_source_fqdn", value: config.source_fqdn });
+    }
+
     // Destination - handle deletions first, then sets
     if (config.delete_destination_address) {
       operations.push({ op: "delete_destination_rule_destination_address" });
@@ -899,6 +1013,12 @@ class NATService {
         op: "set_destination_rule_destination_group",
         value: JSON.stringify({ group_type: "port-group", group_name: config.destination_port_group_name })
       });
+    }
+
+    if (config.delete_destination_fqdn) {
+      operations.push({ op: "delete_destination_rule_destination_fqdn" });
+    } else if (config.destination_fqdn) {
+      operations.push({ op: "set_destination_rule_destination_fqdn", value: config.destination_fqdn });
     }
 
     // Inbound interface - handle deletions first when switching types
@@ -942,12 +1062,30 @@ class NATService {
       operations.push({ op: "set_destination_rule_translation_port", value: config.translation_port });
     }
 
+    if (config.delete_translation_port_mapping) {
+      operations.push({ op: "delete_destination_rule_translation_options_port_mapping" });
+    } else if (config.translation_port_mapping) {
+      operations.push({ op: "set_destination_rule_translation_options_port_mapping", value: "random" });
+    }
+
+    if (config.delete_translation_address_mapping) {
+      operations.push({ op: "delete_destination_rule_translation_options_address_mapping" });
+    } else if (config.translation_address_mapping) {
+      operations.push({ op: "set_destination_rule_translation_options_address_mapping", value: "persistent" });
+    }
+
     // Load balance
     if (config.load_balance_hash) {
       operations.push({ op: "set_destination_rule_load_balance_hash", value: config.load_balance_hash });
     }
     if (config.load_balance_backend) {
       operations.push({ op: "set_destination_rule_load_balance_backend", value: config.load_balance_backend });
+    }
+    if (config.load_balance_backend && config.load_balance_backend_weight) {
+      operations.push({
+        op: "set_destination_rule_load_balance_backend_weight",
+        value: JSON.stringify({ backend: config.load_balance_backend, weight: config.load_balance_backend_weight })
+      });
     }
 
     // Flags


### PR DESCRIPTION
- Add translation options port-mapping random and address-mapping persistent to source and destination NAT rules
- Add FQDN as a third source/destination match type in all four NAT modals
- Add translation port input to source NAT rules
- Add load balance backend weight input to source and destination NAT rules
- Compact rule number auto-assign display in create modals

Closes #317