### PR TITLE
Fix group tooltips missing in bridge and NAT rule tables

### DIFF
--- a/frontend/src/app/firewall/bridge/page.tsx
+++ b/frontend/src/app/firewall/bridge/page.tsx
@@ -63,6 +63,7 @@ import { DeleteBridgeRuleModal } from "@/components/firewall/DeleteBridgeRuleMod
 import { CreateCustomBridgeChainModal } from "@/components/firewall/CreateCustomBridgeChainModal";
 import { DeleteCustomBridgeChainModal } from "@/components/firewall/DeleteCustomBridgeChainModal";
 import { BridgeRuleRow } from "@/components/firewall/BridgeRuleRow";
+import { firewallGroupsService, type FirewallGroup } from "@/lib/api/firewall-groups";
 import { BridgeReorderBanner } from "@/components/firewall/BridgeReorderBanner";
 import { ColumnToggleButton } from "@/components/firewall/ColumnToggleButton";
 import { useColumnVisibility, type ColumnDef } from "@/hooks/useColumnVisibility";
@@ -88,6 +89,7 @@ const BRIDGE_COLUMNS: ColumnDef[] = [
 export default function BridgeFirewallPage() {
   const [config, setConfig] = useState<BridgeConfigResponse | null>(null);
   const [capabilities, setCapabilities] = useState<BridgeCapabilities | null>(null);
+  const [groups, setGroups] = useState<FirewallGroup[]>([]);
   const [selectedChain, setSelectedChain] = useState<string>("forward");
   const [isCustomChain, setIsCustomChain] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -132,12 +134,21 @@ export default function BridgeFirewallPage() {
     try {
       setLoading(true);
       setError(null);
-      const [configData, capabilitiesData] = await Promise.all([
+      const [configData, capabilitiesData, groupsConfig] = await Promise.all([
         bridgeFirewallService.getConfig(refresh),
         bridgeFirewallService.getCapabilities(),
+        firewallGroupsService.getConfig(),
       ]);
       setConfig(configData);
       setCapabilities(capabilitiesData);
+      setGroups([
+        ...groupsConfig.address_groups,
+        ...groupsConfig.network_groups,
+        ...groupsConfig.port_groups,
+        ...groupsConfig.interface_groups,
+        ...groupsConfig.mac_groups,
+        ...groupsConfig.domain_groups,
+      ]);
       // Reset reorder state when data is loaded
       setHasChanges(false);
       setReorderedRules([]);
@@ -771,6 +782,7 @@ export default function BridgeFirewallPage() {
                             onEdit={(r) => setEditingRule({ chain: selectedChain, rule: r, openedAt: Date.now() })}
                             onDelete={(r) => setDeletingRule({ chain: selectedChain, rule: r })}
                             visibleOrderedColumns={visibleOrderedColumns}
+                            groups={groups}
                           />
                         ))}
                       </SortableContext>

--- a/frontend/src/app/network/nat/page.tsx
+++ b/frontend/src/app/network/nat/page.tsx
@@ -114,6 +114,8 @@ export default function NATPage() {
         ...gc.address_groups,
         ...gc.network_groups,
         ...gc.port_groups,
+        ...gc.interface_groups,
+        ...gc.mac_groups,
         ...gc.domain_groups,
       ]);
     }).catch(console.error);

--- a/frontend/src/components/firewall/BridgeRuleRow.tsx
+++ b/frontend/src/components/firewall/BridgeRuleRow.tsx
@@ -13,7 +13,9 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { BridgeRule } from "@/lib/api/firewall-bridge";
+import type { FirewallGroup } from "@/lib/api/types/firewall-groups";
 import type { ColumnDef } from "@/hooks/useColumnVisibility";
+import { cn } from "@/lib/utils";
 
 const DEFAULT_BRIDGE_COLUMNS: ColumnDef[] = [
   { id: "source",      label: "Source" },
@@ -28,9 +30,52 @@ interface BridgeRuleRowProps {
   onEdit: (rule: BridgeRule) => void;
   onDelete: (rule: BridgeRule) => void;
   visibleOrderedColumns?: ColumnDef[];
+  groups?: FirewallGroup[];
 }
 
-export function BridgeRuleRow({ rule, isV15, onEdit, onDelete, visibleOrderedColumns = DEFAULT_BRIDGE_COLUMNS }: BridgeRuleRowProps) {
+export function BridgeRuleRow({ rule, isV15, onEdit, onDelete, visibleOrderedColumns = DEFAULT_BRIDGE_COLUMNS, groups = [] }: BridgeRuleRowProps) {
+  const getGroupMembers = (groupName: string): string[] => {
+    const cleanName = groupName.startsWith("!") ? groupName.substring(1) : groupName;
+    return groups.find((g) => g.name === cleanName)?.members || [];
+  };
+
+  const renderGroupBadge = (name: string, isPort?: boolean) => {
+    const inv = name.startsWith("!");
+    const display = inv ? name.substring(1) : name;
+    const members = getGroupMembers(name);
+    return (
+      <TooltipProvider key={name}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge
+              variant="outline"
+              className={cn(
+                "text-xs cursor-help",
+                inv && "bg-orange-500/10 text-orange-500 border-orange-500/20",
+                !inv && isPort && "bg-blue-500/10 text-blue-500 border-blue-500/20"
+              )}
+            >
+              {inv && "!"}{display}
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent>
+            <div className="max-w-xs">
+              <p className="font-semibold text-xs mb-2">{inv ? `NOT ${display}` : display}</p>
+              {members.length > 0 ? (
+                <div className="flex flex-wrap gap-1 max-h-40 overflow-y-auto">
+                  {members.map((m, i) => (
+                    <code key={i} className="text-xs font-mono px-1.5 py-0.5 rounded bg-muted/60 whitespace-nowrap">{m}</code>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">No members</p>
+              )}
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  };
   const {
     attributes,
     listeners,
@@ -88,6 +133,10 @@ export function BridgeRuleRow({ rule, isV15, onEdit, onDelete, visibleOrderedCol
       );
     }
 
+    if (rule.source_group_address) items.push(renderGroupBadge(rule.source_group_address));
+    if (rule.source_group_network) items.push(renderGroupBadge(rule.source_group_network));
+    if (rule.source_group_mac) items.push(renderGroupBadge(rule.source_group_mac));
+
     if (rule.source_port) {
       items.push(
         <div key="port" className="text-xs text-muted-foreground">
@@ -95,6 +144,8 @@ export function BridgeRuleRow({ rule, isV15, onEdit, onDelete, visibleOrderedCol
         </div>
       );
     }
+
+    if (rule.source_group_port) items.push(renderGroupBadge(rule.source_group_port, true));
 
     if (rule.vlan_id) {
       items.push(
@@ -134,6 +185,10 @@ export function BridgeRuleRow({ rule, isV15, onEdit, onDelete, visibleOrderedCol
       );
     }
 
+    if (rule.destination_group_address) items.push(renderGroupBadge(rule.destination_group_address));
+    if (rule.destination_group_network) items.push(renderGroupBadge(rule.destination_group_network));
+    if (rule.destination_group_mac) items.push(renderGroupBadge(rule.destination_group_mac));
+
     if (rule.destination_port) {
       items.push(
         <div key="port" className="text-xs text-muted-foreground">
@@ -141,6 +196,8 @@ export function BridgeRuleRow({ rule, isV15, onEdit, onDelete, visibleOrderedCol
         </div>
       );
     }
+
+    if (rule.destination_group_port) items.push(renderGroupBadge(rule.destination_group_port, true));
 
     if (items.length === 0) {
       return <span className="text-muted-foreground text-sm">Any</span>;
@@ -163,15 +220,24 @@ export function BridgeRuleRow({ rule, isV15, onEdit, onDelete, visibleOrderedCol
 
   // Format interfaces
   const formatInterfaces = () => {
-    if (!rule.inbound_interface && !rule.outbound_interface) {
+    const hasAny = rule.inbound_interface || rule.inbound_interface_group || rule.outbound_interface || rule.outbound_interface_group;
+    if (!hasAny) {
       return <span className="text-muted-foreground text-sm">Any</span>;
     }
 
+    const inbound = rule.inbound_interface_group
+      ? renderGroupBadge(rule.inbound_interface_group)
+      : <span className="font-mono">{rule.inbound_interface || "*"}</span>;
+
+    const outbound = rule.outbound_interface_group
+      ? renderGroupBadge(rule.outbound_interface_group)
+      : <span className="font-mono">{rule.outbound_interface || "*"}</span>;
+
     return (
       <div className="flex items-center gap-1 text-xs">
-        <span className="font-mono">{rule.inbound_interface || "*"}</span>
+        {inbound}
         <ArrowRight className="h-3 w-3 text-muted-foreground" />
-        <span className="font-mono">{rule.outbound_interface || "*"}</span>
+        {outbound}
       </div>
     );
   };

--- a/frontend/src/components/network/NATRuleRow.tsx
+++ b/frontend/src/components/network/NATRuleRow.tsx
@@ -232,9 +232,18 @@ function SourceNATContent({ rule, groups }: { rule: SourceNATRule; groups: Firew
         )}
       </TableCell>
       <TableCell>
-        <Badge variant="outline" className="font-mono text-xs">
-          {rule.outbound_interface?.name || rule.outbound_interface?.group || "any"}
-        </Badge>
+        {rule.outbound_interface?.group ? (
+          (() => {
+            const g = rule.outbound_interface.group;
+            const inv = g.startsWith("!");
+            const display = inv ? g.substring(1) : g;
+            return <GroupTooltipBadge name={display} inv={inv} members={getGroupMembers(g)} />;
+          })()
+        ) : (
+          <Badge variant="outline" className="font-mono text-xs">
+            {rule.outbound_interface?.name || "any"}
+          </Badge>
+        )}
       </TableCell>
       <TableCell>
         <span className="text-sm text-muted-foreground">
@@ -297,9 +306,18 @@ function DestinationNATContent({ rule, groups }: { rule: DestinationNATRule; gro
         </code>
       </TableCell>
       <TableCell>
-        <Badge variant="outline" className="font-mono text-xs">
-          {rule.inbound_interface?.name || rule.inbound_interface?.group || "any"}
-        </Badge>
+        {rule.inbound_interface?.group ? (
+          (() => {
+            const g = rule.inbound_interface.group;
+            const inv = g.startsWith("!");
+            const display = inv ? g.substring(1) : g;
+            return <GroupTooltipBadge name={display} inv={inv} members={getGroupMembers(g)} />;
+          })()
+        ) : (
+          <Badge variant="outline" className="font-mono text-xs">
+            {rule.inbound_interface?.name || "any"}
+          </Badge>
+        )}
       </TableCell>
       <TableCell>
         <span className="text-sm text-muted-foreground">


### PR DESCRIPTION
- BridgeRuleRow: fetch firewall groups in bridge page and pass them down; render source, destination, and interface group fields as tooltip badges showing group members instead of plain text
- NATRuleRow: render outbound/inbound interface groups as tooltip badges using the existing GroupTooltipBadge helper instead of a plain Badge
- NAT page: include interface_groups and mac_groups in the groups fetch so all group types are available for tooltip lookup

Closes #310