### PR TITLE
Fix destination NAT port randomisation option (#332)

### DIFF
--- a/backend/routers/nat/nat.py
+++ b/backend/routers/nat/nat.py
@@ -393,8 +393,7 @@ async def get_nat_config(http_request: Request, refresh: bool = False):
                     options = None
                     if "options" in trans_data:
                         options = NATRuleTranslationOptions(
-                            address_mapping=trans_data["options"].get("address-mapping"),
-                            port_mapping=trans_data["options"].get("port-mapping")
+                            address_mapping=trans_data["options"].get("address-mapping")
                         )
                     redirect = None
                     if "redirect" in trans_data:
@@ -844,8 +843,6 @@ async def reorder_nat_rules(http_request: Request, request: ReorderNATRequest):
                     batch.set_destination_rule_translation_port(new_num, rule_data["translation_port"])
                 if rule_data.get("translation_options_address_mapping"):
                     batch.set_destination_rule_translation_options_address_mapping(new_num, rule_data["translation_options_address_mapping"])
-                if rule_data.get("translation_options_port_mapping"):
-                    batch.set_destination_rule_translation_options_port_mapping(new_num, rule_data["translation_options_port_mapping"])
                 if rule_data.get("translation_redirect_port"):
                     batch.set_destination_rule_translation_redirect_port(new_num, rule_data["translation_redirect_port"])
                 # Source groups

--- a/backend/vyos_builders/nat/nat.py
+++ b/backend/vyos_builders/nat/nat.py
@@ -756,24 +756,6 @@ class NATBatchBuilder:
         )
         return self.add_delete(path)
 
-    def set_destination_rule_translation_options_port_mapping(
-        self, rule_number: int, value: str
-    ) -> "NATBatchBuilder":
-        """Set destination rule translation options port-mapping."""
-        path = self.mappers[self.mapper_key].get_destination_rule_translation_options_port_mapping(
-            rule_number, value
-        )
-        return self.add_set(path)
-
-    def delete_destination_rule_translation_options_port_mapping(
-        self, rule_number: int
-    ) -> "NATBatchBuilder":
-        """Delete destination rule translation options port-mapping."""
-        path = self.mappers[self.mapper_key].get_destination_rule_translation_options_port_mapping_path(
-            rule_number
-        )
-        return self.add_delete(path)
-
     def set_destination_rule_translation_redirect_port(
         self, rule_number: int, port: str
     ) -> "NATBatchBuilder":
@@ -1178,8 +1160,6 @@ class NATBatchBuilder:
                     "delete_destination_rule_translation_port",
                     "set_destination_rule_translation_options_address_mapping",
                     "delete_destination_rule_translation_options_address_mapping",
-                    "set_destination_rule_translation_options_port_mapping",
-                    "delete_destination_rule_translation_options_port_mapping",
                     "set_destination_rule_translation_redirect_port",
                     "delete_destination_rule_translation_redirect_port",
                 ],

--- a/backend/vyos_mappers/nat/nat.py
+++ b/backend/vyos_mappers/nat/nat.py
@@ -349,14 +349,6 @@ class NATMapper(BaseFeatureMapper):
         """Get command path for destination rule translation options address-mapping (for deletion)."""
         return ["nat", "destination", "rule", str(rule_number), "translation", "options", "address-mapping"]
 
-    def get_destination_rule_translation_options_port_mapping(self, rule_number: int, value: str) -> List[str]:
-        """Get command path for destination rule translation options port-mapping."""
-        return ["nat", "destination", "rule", str(rule_number), "translation", "options", "port-mapping", value]
-
-    def get_destination_rule_translation_options_port_mapping_path(self, rule_number: int) -> List[str]:
-        """Get command path for destination rule translation options port-mapping (for deletion)."""
-        return ["nat", "destination", "rule", str(rule_number), "translation", "options", "port-mapping"]
-
     def get_destination_rule_translation_redirect_port(self, rule_number: int, port: str) -> List[str]:
         """Get command path for destination rule translation redirect port."""
         return ["nat", "destination", "rule", str(rule_number), "translation", "redirect", "port", port]

--- a/frontend/src/components/network/CreateDestinationNATModal.tsx
+++ b/frontend/src/components/network/CreateDestinationNATModal.tsx
@@ -74,7 +74,6 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
   // Translation
   const [translationAddress, setTranslationAddress] = useState("");
   const [translationPort, setTranslationPort] = useState("");
-  const [translationPortMapping, setTranslationPortMapping] = useState(false);
   const [translationAddressMapping, setTranslationAddressMapping] = useState(false);
 
   // Load Balance
@@ -239,7 +238,6 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
     setPacketType("");
     setTranslationAddress("");
     setTranslationPort("");
-    setTranslationPortMapping(false);
     setTranslationAddressMapping(false);
     setLoadBalanceHash("");
     setLoadBalanceBackend("");
@@ -330,7 +328,6 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
       if (translationPort.trim()) {
         config.translation_port = translationPort.trim();
       }
-      if (translationPortMapping) config.translation_port_mapping = true;
       if (translationAddressMapping) config.translation_address_mapping = true;
 
       // Load balance
@@ -504,22 +501,6 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
 
               {/* Translation Options */}
               <div className="space-y-2">
-                <div className="flex items-start space-x-2">
-                  <Checkbox
-                    id="translation-port-mapping"
-                    checked={translationPortMapping}
-                    onCheckedChange={(checked) => setTranslationPortMapping(checked === true)}
-                    className="mt-1"
-                  />
-                  <div className="space-y-1">
-                    <Label htmlFor="translation-port-mapping" className="text-sm font-medium cursor-pointer">
-                      Randomize source port (port-mapping random)
-                    </Label>
-                    <p className="text-xs text-muted-foreground">
-                      Randomizes the outbound source port for privacy and security
-                    </p>
-                  </div>
-                </div>
                 <div className="flex items-start space-x-2">
                   <Checkbox
                     id="translation-address-mapping"

--- a/frontend/src/components/network/EditDestinationNATModal.tsx
+++ b/frontend/src/components/network/EditDestinationNATModal.tsx
@@ -77,7 +77,6 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
   // Translation
   const [translationAddress, setTranslationAddress] = useState("");
   const [translationPort, setTranslationPort] = useState("");
-  const [translationPortMapping, setTranslationPortMapping] = useState(false);
   const [translationAddressMapping, setTranslationAddressMapping] = useState(false);
 
   // Load balance
@@ -107,7 +106,6 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
   const [originalInboundInterfaceType, setOriginalInboundInterfaceType] = useState<"name" | "group" | null>(null);
   const [originalSourcePortGroup, setOriginalSourcePortGroup] = useState(false);
   const [originalDestPortGroup, setOriginalDestPortGroup] = useState(false);
-  const [originalTranslationPortMapping, setOriginalTranslationPortMapping] = useState(false);
   const [originalTranslationAddressMapping, setOriginalTranslationAddressMapping] = useState(false);
 
   // Reset all form fields to defaults
@@ -133,7 +131,6 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
     setPacketType("");
     setTranslationAddress("");
     setTranslationPort("");
-    setTranslationPortMapping(false);
     setTranslationAddressMapping(false);
     setLoadBalancingEnabled(false);
     setLoadBalanceHash("");
@@ -160,7 +157,6 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
     setDestPortGroupName("");
     setOriginalSourcePortGroup(false);
     setOriginalDestPortGroup(false);
-    setOriginalTranslationPortMapping(false);
     setOriginalTranslationAddressMapping(false);
     setError(null);
   };
@@ -314,9 +310,6 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
     // Translation
     setTranslationAddress(rule.translation?.address || "");
     setTranslationPort(rule.translation?.port || "");
-    const pm = rule.translation?.options?.port_mapping === "random";
-    setTranslationPortMapping(pm);
-    setOriginalTranslationPortMapping(pm);
     const am = rule.translation?.options?.address_mapping === "persistent";
     setTranslationAddressMapping(am);
     setOriginalTranslationAddressMapping(am);
@@ -586,12 +579,6 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
         config.translation_port = translationPort.trim();
       }
 
-      if (!translationPortMapping && originalTranslationPortMapping) {
-        config.delete_translation_port_mapping = true;
-      } else if (translationPortMapping) {
-        config.translation_port_mapping = true;
-      }
-
       if (!translationAddressMapping && originalTranslationAddressMapping) {
         config.delete_translation_address_mapping = true;
       } else if (translationAddressMapping) {
@@ -765,22 +752,6 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
 
               {/* Translation Options */}
               <div className="space-y-2">
-                <div className="flex items-start space-x-2">
-                  <Checkbox
-                    id="translation-port-mapping"
-                    checked={translationPortMapping}
-                    onCheckedChange={(checked) => setTranslationPortMapping(checked === true)}
-                    className="mt-1"
-                  />
-                  <div className="space-y-1">
-                    <Label htmlFor="translation-port-mapping" className="text-sm font-medium cursor-pointer">
-                      Randomize source port (port-mapping random)
-                    </Label>
-                    <p className="text-xs text-muted-foreground">
-                      Randomizes the outbound source port for privacy and security
-                    </p>
-                  </div>
-                </div>
                 <div className="flex items-start space-x-2">
                   <Checkbox
                     id="translation-address-mapping"

--- a/frontend/src/lib/api/nat.ts
+++ b/frontend/src/lib/api/nat.ts
@@ -416,7 +416,6 @@ class NATService {
       packet_type?: string;
       translation_address?: string;
       translation_port?: string;
-      translation_port_mapping?: boolean;
       translation_address_mapping?: boolean;
       load_balance_hash?: string;
       load_balance_backend?: string;
@@ -516,9 +515,6 @@ class NATService {
     }
     if (config.translation_port) {
       operations.push({ op: "set_destination_rule_translation_port", value: config.translation_port });
-    }
-    if (config.translation_port_mapping) {
-      operations.push({ op: "set_destination_rule_translation_options_port_mapping", value: "random" });
     }
     if (config.translation_address_mapping) {
       operations.push({ op: "set_destination_rule_translation_options_address_mapping", value: "persistent" });
@@ -900,7 +896,6 @@ class NATService {
       packet_type?: string;
       translation_address?: string;
       translation_port?: string;
-      translation_port_mapping?: boolean;
       translation_address_mapping?: boolean;
       load_balance_hash?: string;
       load_balance_backend?: string;
@@ -921,7 +916,6 @@ class NATService {
       delete_destination_fqdn?: boolean;
       delete_inbound_interface_name?: boolean;
       delete_inbound_interface_group?: boolean;
-      delete_translation_port_mapping?: boolean;
       delete_translation_address_mapping?: boolean;
     }
   ): Promise<VyOSResponse> {
@@ -1060,12 +1054,6 @@ class NATService {
     }
     if (config.translation_port) {
       operations.push({ op: "set_destination_rule_translation_port", value: config.translation_port });
-    }
-
-    if (config.delete_translation_port_mapping) {
-      operations.push({ op: "delete_destination_rule_translation_options_port_mapping" });
-    } else if (config.translation_port_mapping) {
-      operations.push({ op: "set_destination_rule_translation_options_port_mapping", value: "random" });
     }
 
     if (config.delete_translation_address_mapping) {
@@ -1290,7 +1278,6 @@ class NATService {
     if (rule.translation?.address) data.translation_address = rule.translation.address;
     if (rule.translation?.port) data.translation_port = rule.translation.port;
     if (rule.translation?.options?.address_mapping) data.translation_options_address_mapping = rule.translation.options.address_mapping;
-    if (rule.translation?.options?.port_mapping) data.translation_options_port_mapping = rule.translation.options.port_mapping;
     if (rule.translation?.redirect?.port) data.translation_redirect_port = rule.translation.redirect.port;
     if (rule.load_balance?.hash) data.load_balance_hash = rule.load_balance.hash;
     if (rule.load_balance?.backends?.length) data.load_balance_backends = rule.load_balance.backends;


### PR DESCRIPTION
port-mapping is only valid for masquerade (SNAT) rules. Remove it from all DNAT code paths: UI checkboxes, API service, batch builder, mapper, router config parsing, and rule duplication handler.

Closes #332